### PR TITLE
fix: commit frontend/src/lib swallowed by .gitignore (refs #95)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,184 @@
+import axios, { AxiosError, AxiosResponse } from "axios";
+import { getAccessToken, setAccessToken, refresh } from "./auth";
+import { getTenantFromHost } from "./tenant";
+
+// Define API error interface for Django backend
+interface APIError {
+  message?: string;
+  detail?: string;
+  non_field_errors?: string[];
+  [key: string]: any;
+}
+
+// Enhanced error class for API errors
+export class APIException extends Error {
+  public status: number;
+  public data: APIError;
+  public isAPIError = true;
+
+  constructor(status: number, data: APIError, originalError?: AxiosError) {
+    const message = data.detail || data.message || data.non_field_errors?.[0] || 'An error occurred';
+    super(message);
+    this.name = 'APIException';
+    this.status = status;
+    this.data = data;
+  }
+}
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE,
+  withCredentials: true, // allow refresh cookie
+});
+
+api.interceptors.request.use((config) => {
+  const token = getAccessToken();
+  const tenant = getTenantFromHost();
+  if (token) config.headers.Authorization = `Bearer ${token}`;
+  if (tenant) config.headers["X-Tenant-Id"] = tenant;
+  return config;
+});
+
+let refreshing = false;
+let queue: Array<() => void> = [];
+
+api.interceptors.response.use(
+  (res: AxiosResponse) => res,
+  async (err: AxiosError) => {
+    const original = err.config;
+    
+    // Handle 401 Unauthorized - attempt token refresh
+    if (err?.response?.status === 401 && original && !(original as any)._retry) {
+      (original as any)._retry = true;
+      if (!refreshing) {
+        refreshing = true;
+        try {
+          const newToken = await refresh(); // calls /auth/refresh, httpOnly cookie provides refresh
+          setAccessToken(newToken);
+          queue.forEach((fn) => fn());
+          queue = [];
+        } catch (refreshError) {
+          // Refresh failed - redirect to login or handle appropriately
+          console.error('Token refresh failed:', refreshError);
+          // Clear any stored tokens
+          setAccessToken('');
+          // In a real app, you might redirect to login here
+          if (typeof window !== 'undefined') {
+            window.location.href = '/login';
+          }
+        } finally {
+          refreshing = false;
+        }
+      }
+      return new Promise((resolve) => {
+        queue.push(() => resolve(api(original)));
+      });
+    }
+    
+    // Enhanced error handling for different status codes
+    if (err.response) {
+      const { status, data } = err.response;
+      
+      // Log errors in development
+      if (process.env.NODE_ENV === 'development') {
+        console.group(`🚨 API Error ${status}`);
+        console.error('URL:', err.config?.url);
+        console.error('Method:', err.config?.method?.toUpperCase());
+        console.error('Status:', status);
+        console.error('Data:', data);
+        console.error('Headers:', err.config?.headers);
+        console.groupEnd();
+      }
+      
+      // Create structured API exception
+      const apiError = new APIException(status, data as APIError, err);
+      
+      // Handle specific status codes
+      switch (status) {
+        case 400:
+          // Bad Request - validation errors
+          console.warn('Validation error:', data);
+          break;
+        case 403:
+          // Forbidden - insufficient permissions
+          console.warn('Access denied:', data);
+          break;
+        case 404:
+          // Not Found
+          console.warn('Resource not found:', err.config?.url);
+          break;
+        case 429:
+          // Rate Limited
+          console.warn('Rate limited - please slow down requests');
+          break;
+        case 500:
+          // Internal Server Error
+          console.error('Server error - please try again later');
+          break;
+        case 502:
+        case 503:
+        case 504:
+          // Service unavailable
+          console.error('Service temporarily unavailable');
+          break;
+        default:
+          console.error('Unexpected error:', status, data);
+      }
+      
+      return Promise.reject(apiError);
+    } else if (err.request) {
+      // Network error
+      console.error('Network error - check your connection');
+      const networkError = new APIException(0, { 
+        message: 'Network error - please check your connection and try again'
+      }, err);
+      return Promise.reject(networkError);
+    } else {
+      // Request setup error
+      console.error('Request setup error:', err.message);
+      const setupError = new APIException(0, { 
+        message: 'Request setup error - please try again'
+      }, err);
+      return Promise.reject(setupError);
+    }
+  }
+);
+
+// Utility functions for error handling
+export const isAPIError = (error: any): error is APIException => {
+  return error && error.isAPIError === true;
+};
+
+export const getErrorMessage = (error: any): string => {
+  if (isAPIError(error)) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return 'An unexpected error occurred';
+};
+
+export const getValidationErrors = (error: any): Record<string, string[]> => {
+  if (isAPIError(error) && error.status === 400) {
+    const errors: Record<string, string[]> = {};
+    Object.keys(error.data).forEach(key => {
+      if (key !== 'detail' && key !== 'message') {
+        const value = error.data[key];
+        if (Array.isArray(value)) {
+          errors[key] = value;
+        } else if (typeof value === 'string') {
+          errors[key] = [value];
+        }
+      }
+    });
+    return errors;
+  }
+  return {};
+};
+
+// Export both default and named exports for flexibility
+export { api };
+export default api;

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,41 @@
+let accessToken: string | null = null;
+
+export function setAccessToken(t: string | null) { accessToken = t; }
+export function getAccessToken() { return accessToken; }
+
+export async function login(email: string, password: string, otp?: string) {
+  const r = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/login/`, {
+    method: "POST",
+    credentials: "include", // set refresh cookie on server
+    headers: { 
+      "Content-Type": "application/json",
+      "Host": "demo.localhost"  // Add tenant header
+    },
+    body: JSON.stringify({ 
+      username: email,  // Django expects username field
+      password, 
+      otp 
+    }),
+  });
+  if (!r.ok) throw new Error("Login failed");
+  const data = await r.json();
+  setAccessToken(data.access); // short-lived JWT
+  return data;
+}
+
+export async function refresh(): Promise<string> {
+  const r = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/refresh/`, {
+    method: "POST",
+    credentials: "include",
+  });
+  if (!r.ok) throw new Error("Refresh failed");
+  const data = await r.json();
+  return data.access;
+}
+
+export async function logout() {
+  await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/logout/`, {
+    method: "POST", credentials: "include"
+  });
+  setAccessToken(null);
+}

--- a/frontend/src/lib/services/analyticsService.ts
+++ b/frontend/src/lib/services/analyticsService.ts
@@ -1,0 +1,378 @@
+import { api } from '../api'
+
+export interface DashboardMetric {
+  title: string
+  value: number | string
+  change?: number
+  changeType?: 'increase' | 'decrease' | 'neutral'
+  format?: 'number' | 'percentage' | 'currency' | 'text'
+}
+
+export interface ChartData {
+  labels: string[]
+  datasets: Array<{
+    label: string
+    data: number[]
+    backgroundColor?: string[]
+    borderColor?: string
+    fill?: boolean
+  }>
+}
+
+export interface ExecutiveDashboard {
+  summary_metrics: {
+    total_risks: DashboardMetric
+    high_priority_risks: DashboardMetric
+    policy_compliance: DashboardMetric
+    training_completion: DashboardMetric
+    vendor_assessments: DashboardMetric
+  }
+  risk_trend_chart: ChartData
+  compliance_by_category: ChartData
+  recent_activities: Array<{
+    id: string
+    type: 'risk' | 'policy' | 'training' | 'vendor'
+    title: string
+    description: string
+    timestamp: string
+    priority?: 'low' | 'medium' | 'high' | 'critical'
+  }>
+}
+
+export interface ComplianceDashboard {
+  compliance_overview: {
+    overall_score: DashboardMetric
+    policies_due_review: DashboardMetric
+    pending_acknowledgments: DashboardMetric
+    overdue_trainings: DashboardMetric
+  }
+  compliance_by_framework: ChartData
+  policy_acknowledgment_rates: ChartData
+  training_completion_trends: ChartData
+}
+
+export interface VendorRiskDashboard {
+  vendor_metrics: {
+    total_vendors: DashboardMetric
+    high_risk_vendors: DashboardMetric
+    pending_assessments: DashboardMetric
+    contract_renewals: DashboardMetric
+  }
+  risk_distribution: ChartData
+  vendor_performance_trends: ChartData
+  upcoming_renewals: Array<{
+    vendor_name: string
+    contract_end_date: string
+    risk_level: string
+    annual_spend: number
+  }>
+}
+
+export interface ReportRequest {
+  report_type: 'executive' | 'compliance' | 'risk' | 'vendor' | 'policy' | 'training' | 'integrated' | 'operational'
+  export_format: 'pdf' | 'excel' | 'csv' | 'json'
+  date_range?: {
+    start_date: string
+    end_date: string
+  }
+  filters?: Record<string, any>
+}
+
+export interface AnalyticsReport {
+  id: string
+  report_type: string
+  export_format: string
+  status: 'pending' | 'processing' | 'completed' | 'failed'
+  requested_by: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+  }
+  created_at: string
+  completed_at?: string
+  download_url?: string
+  error_message?: string
+  file_size?: number
+}
+
+export interface PaginatedResponse<T> {
+  results: T[]
+  count: number
+  next: string | null
+  previous: string | null
+}
+
+export const analyticsService = {
+  // Executive Dashboard
+  async getExecutiveDashboard(dateRange?: { start_date: string, end_date: string }): Promise<ExecutiveDashboard> {
+    try {
+      const params = new URLSearchParams()
+      if (dateRange) {
+        params.append('start_date', dateRange.start_date)
+        params.append('end_date', dateRange.end_date)
+      }
+      
+      const response = await api.get(`/analytics/executive/?${params.toString()}`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching executive dashboard:', error)
+      
+      // Return mock data as fallback
+      return {
+        summary_metrics: {
+          total_risks: { title: 'Total Risks', value: 42, change: -8, changeType: 'decrease' },
+          high_priority_risks: { title: 'High Priority', value: 8, change: 2, changeType: 'increase' },
+          policy_compliance: { title: 'Policy Compliance', value: 92.5, format: 'percentage', change: 3.2, changeType: 'increase' },
+          training_completion: { title: 'Training Completion', value: 87.3, format: 'percentage', change: 1.8, changeType: 'increase' },
+          vendor_assessments: { title: 'Vendor Assessments', value: 23, change: 0, changeType: 'neutral' }
+        },
+        risk_trend_chart: {
+          labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+          datasets: [{
+            label: 'Risk Score',
+            data: [65, 72, 68, 74, 71, 69],
+            borderColor: '#dc2626',
+            fill: false
+          }]
+        },
+        compliance_by_category: {
+          labels: ['Security', 'HR', 'IT', 'Legal', 'Finance'],
+          datasets: [{
+            label: 'Compliance Rate',
+            data: [95, 88, 92, 85, 90],
+            backgroundColor: ['#10b981', '#f59e0b', '#3b82f6', '#8b5cf6', '#ef4444']
+          }]
+        },
+        recent_activities: [
+          {
+            id: '1',
+            type: 'risk',
+            title: 'New Risk Identified',
+            description: 'Data breach risk from third-party vendor',
+            timestamp: '2024-08-25T10:30:00Z',
+            priority: 'high'
+          }
+        ]
+      }
+    }
+  },
+
+  // Compliance Dashboard
+  async getComplianceDashboard(dateRange?: { start_date: string, end_date: string }): Promise<ComplianceDashboard> {
+    try {
+      const params = new URLSearchParams()
+      if (dateRange) {
+        params.append('start_date', dateRange.start_date)
+        params.append('end_date', dateRange.end_date)
+      }
+      
+      const response = await api.get(`/analytics/compliance/?${params.toString()}`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching compliance dashboard:', error)
+      
+      // Return mock data as fallback
+      return {
+        compliance_overview: {
+          overall_score: { title: 'Overall Compliance', value: 92.5, format: 'percentage', change: 2.1, changeType: 'increase' },
+          policies_due_review: { title: 'Policies Due Review', value: 3, change: -2, changeType: 'decrease' },
+          pending_acknowledgments: { title: 'Pending Acknowledgments', value: 45, change: 8, changeType: 'increase' },
+          overdue_trainings: { title: 'Overdue Trainings', value: 12, change: -5, changeType: 'decrease' }
+        },
+        compliance_by_framework: {
+          labels: ['ISO 27001', 'GDPR', 'SOX', 'HIPAA', 'PCI DSS'],
+          datasets: [{
+            label: 'Compliance Score',
+            data: [98, 95, 88, 92, 85],
+            backgroundColor: ['#10b981']
+          }]
+        },
+        policy_acknowledgment_rates: {
+          labels: ['Security', 'HR', 'IT', 'Legal'],
+          datasets: [{
+            label: 'Acknowledgment Rate',
+            data: [95, 88, 92, 85],
+            backgroundColor: ['#3b82f6']
+          }]
+        },
+        training_completion_trends: {
+          labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+          datasets: [{
+            label: 'Completion Rate',
+            data: [82, 85, 88, 87, 89, 87],
+            borderColor: '#10b981',
+            fill: true
+          }]
+        }
+      }
+    }
+  },
+
+  // Vendor Risk Dashboard
+  async getVendorRiskDashboard(dateRange?: { start_date: string, end_date: string }): Promise<VendorRiskDashboard> {
+    try {
+      const params = new URLSearchParams()
+      if (dateRange) {
+        params.append('start_date', dateRange.start_date)
+        params.append('end_date', dateRange.end_date)
+      }
+      
+      const response = await api.get(`/analytics/vendor-risk/?${params.toString()}`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching vendor risk dashboard:', error)
+      
+      // Return mock data as fallback
+      return {
+        vendor_metrics: {
+          total_vendors: { title: 'Total Vendors', value: 89, change: 3, changeType: 'increase' },
+          high_risk_vendors: { title: 'High Risk', value: 6, change: -2, changeType: 'decrease' },
+          pending_assessments: { title: 'Pending Assessments', value: 12, change: 1, changeType: 'increase' },
+          contract_renewals: { title: 'Contracts Due', value: 8, change: 0, changeType: 'neutral' }
+        },
+        risk_distribution: {
+          labels: ['Low', 'Medium', 'High', 'Critical'],
+          datasets: [{
+            label: 'Vendor Count',
+            data: [45, 32, 10, 2],
+            backgroundColor: ['#10b981', '#f59e0b', '#ef4444', '#dc2626']
+          }]
+        },
+        vendor_performance_trends: {
+          labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+          datasets: [{
+            label: 'Average Performance',
+            data: [85, 87, 86, 89, 88, 90],
+            borderColor: '#3b82f6',
+            fill: false
+          }]
+        },
+        upcoming_renewals: [
+          {
+            vendor_name: 'Microsoft Corporation',
+            contract_end_date: '2024-12-31',
+            risk_level: 'low',
+            annual_spend: 120000
+          }
+        ]
+      }
+    }
+  },
+
+  // Request report generation
+  async requestReport(reportRequest: ReportRequest): Promise<AnalyticsReport> {
+    try {
+      const response = await api.post('/analytics/export/', reportRequest)
+      return response.data
+    } catch (error) {
+      console.error('Error requesting report:', error)
+      throw error
+    }
+  },
+
+  // Get user's reports
+  async getMyReports(): Promise<PaginatedResponse<AnalyticsReport>> {
+    try {
+      const response = await api.get('/analytics/reports/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching reports:', error)
+      return {
+        results: [],
+        count: 0,
+        next: null,
+        previous: null
+      }
+    }
+  },
+
+  // Get report status
+  async getReportStatus(reportId: string): Promise<AnalyticsReport> {
+    try {
+      const response = await api.get(`/analytics/reports/${reportId}/status/`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching report status:', error)
+      throw error
+    }
+  },
+
+  // Download report
+  async downloadReport(reportId: string): Promise<Blob> {
+    try {
+      const response = await api.get(`/analytics/reports/${reportId}/download/`, {
+        responseType: 'blob'
+      })
+      return response.data
+    } catch (error) {
+      console.error('Error downloading report:', error)
+      throw error
+    }
+  },
+
+  // Delete report
+  async deleteReport(reportId: string): Promise<void> {
+    try {
+      await api.delete(`/analytics/reports/${reportId}/`)
+    } catch (error) {
+      console.error('Error deleting report:', error)
+      throw error
+    }
+  },
+
+  // Get available report types and formats from Django
+  async getReportChoices(): Promise<{
+    report_types: Array<{value: string, label: string}>,
+    export_formats: Array<{value: string, label: string}>
+  }> {
+    try {
+      const response = await api.get('/analytics/choices/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching analytics choices:', error)
+      return {
+        report_types: [
+          { value: 'executive', label: 'Executive Dashboard' },
+          { value: 'compliance', label: 'Compliance Analytics' },
+          { value: 'risk', label: 'Risk Management' },
+          { value: 'vendor', label: 'Vendor Risk Assessment' },
+          { value: 'policy', label: 'Policy Management' },
+          { value: 'training', label: 'Training Effectiveness' },
+          { value: 'integrated', label: 'Integrated Risk Posture' },
+          { value: 'operational', label: 'Operational Dashboard' }
+        ],
+        export_formats: [
+          { value: 'pdf', label: 'PDF Report' },
+          { value: 'excel', label: 'Excel Spreadsheet' },
+          { value: 'csv', label: 'CSV Data Export' },
+          { value: 'json', label: 'JSON Data Export' }
+        ]
+      }
+    }
+  },
+
+  // Refresh analytics cache
+  async refreshCache(): Promise<{ message: string }> {
+    try {
+      const response = await api.post('/analytics/cache/refresh/')
+      return response.data
+    } catch (error) {
+      console.error('Error refreshing analytics cache:', error)
+      throw error
+    }
+  },
+
+  // Health check
+  async healthCheck(): Promise<{ status: string, timestamp: string }> {
+    try {
+      const response = await api.get('/analytics/health/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching analytics health:', error)
+      return { status: 'error', timestamp: new Date().toISOString() }
+    }
+  }
+}
+
+export default analyticsService

--- a/frontend/src/lib/services/policyService.ts
+++ b/frontend/src/lib/services/policyService.ts
@@ -1,0 +1,429 @@
+import { api } from '../api'
+
+export interface PolicyCategory {
+  id: string
+  name: string
+  description: string
+  color: string
+  created_at: string
+  updated_at: string
+}
+
+export interface PolicyVersion {
+  id: string
+  version_number: string
+  document_url?: string
+  changelog: string
+  file_size?: number
+  file_name?: string
+  is_active: boolean
+  effective_date: string
+  expiry_date?: string
+  created_at: string
+  created_by: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+  }
+}
+
+export interface Policy {
+  id: string
+  policy_code: string
+  title: string
+  category: PolicyCategory
+  policy_type: 'procedure' | 'policy' | 'standard' | 'guideline' | 'framework'
+  status: 'draft' | 'under_review' | 'approved' | 'archived'
+  owner: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+    email: string
+  }
+  approver?: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+    email: string
+  } | null
+  review_frequency_months: number
+  next_review_date?: string
+  requires_acknowledgment: boolean
+  acknowledgment_validity_days: number
+  current_version: PolicyVersion | null
+  latest_version: PolicyVersion | null
+  is_due_for_review: boolean
+  created_at: string
+  updated_at: string
+  created_by: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+  } | null
+}
+
+export interface PolicyAcknowledgment {
+  id: number
+  user: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+    email: string
+  }
+  policy_version: PolicyVersion
+  acknowledged_at: string
+  ip_address: string
+  user_agent: string
+  is_valid: boolean
+  expires_at: string
+}
+
+export interface PolicyDistribution {
+  id: number
+  policy: Policy
+  target_users: number[]
+  target_groups: number[]
+  due_date?: string
+  reminder_frequency_days: number
+  is_mandatory: boolean
+  created_at: string
+  created_by: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+  }
+  is_overdue: boolean
+  completion_percentage: number
+}
+
+export interface PolicyFilters {
+  status?: string[]
+  category?: string[]
+  policy_type?: string[]
+  owner?: string
+  due_for_review?: boolean
+  requires_acknowledgment?: boolean
+  page?: number
+  pageSize?: number
+  search?: string
+}
+
+export interface PaginatedResponse<T> {
+  results: T[]
+  count: number
+  next: string | null
+  previous: string | null
+}
+
+export const policyService = {
+  // Get all policies with optional filtering
+  async getPolicies(filters: PolicyFilters = {}): Promise<PaginatedResponse<Policy>> {
+    try {
+      const params = new URLSearchParams()
+      
+      if (filters.status?.length) {
+        params.append('status', filters.status.join(','))
+      }
+      if (filters.category?.length) {
+        params.append('category', filters.category.join(','))
+      }
+      if (filters.policy_type?.length) {
+        params.append('policy_type', filters.policy_type.join(','))
+      }
+      if (filters.owner) {
+        params.append('owner', filters.owner)
+      }
+      if (filters.due_for_review !== undefined) {
+        params.append('due_for_review', filters.due_for_review.toString())
+      }
+      if (filters.requires_acknowledgment !== undefined) {
+        params.append('requires_acknowledgment', filters.requires_acknowledgment.toString())
+      }
+      if (filters.search) {
+        params.append('search', filters.search)
+      }
+      if (filters.page) {
+        params.append('page', filters.page.toString())
+      }
+      if (filters.pageSize) {
+        params.append('page_size', filters.pageSize.toString())
+      }
+
+      const response = await api.get(`/policies/policies/?${params.toString()}`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching policies:', error)
+      
+      // Return mock data as fallback with Django model structure
+      return {
+        results: [
+          {
+            id: '550e8400-e29b-41d4-a716-446655440000',
+            policy_code: 'POL-SEC-001',
+            title: 'Information Security Policy',
+            category: {
+              id: '550e8400-e29b-41d4-a716-446655440001',
+              name: 'Security',
+              description: 'Information security policies and procedures',
+              color: '#dc2626',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-01T00:00:00Z'
+            },
+            policy_type: 'policy',
+            status: 'approved',
+            owner: {
+              id: 1,
+              username: 'security.manager',
+              first_name: 'Security',
+              last_name: 'Manager',
+              email: 'security@company.com'
+            },
+            approver: {
+              id: 2,
+              username: 'ciso',
+              first_name: 'Chief',
+              last_name: 'Security Officer',
+              email: 'ciso@company.com'
+            },
+            review_frequency_months: 12,
+            next_review_date: '2025-06-01',
+            requires_acknowledgment: true,
+            acknowledgment_validity_days: 365,
+            current_version: {
+              id: '550e8400-e29b-41d4-a716-446655440010',
+              version_number: '2.1',
+              document_url: '/media/policies/security-policy-v2.1.pdf',
+              changelog: 'Updated encryption requirements and access controls',
+              file_size: 2458432,
+              file_name: 'ISP-001_Version_2.1.pdf',
+              is_active: true,
+              effective_date: '2024-06-01',
+              expiry_date: '2025-06-01',
+              created_at: '2024-06-01T00:00:00Z',
+              created_by: {
+                id: 1,
+                username: 'security.manager',
+                first_name: 'Security',
+                last_name: 'Manager'
+              }
+            },
+            latest_version: {
+              id: '550e8400-e29b-41d4-a716-446655440010',
+              version_number: '2.1',
+              document_url: '/media/policies/security-policy-v2.1.pdf',
+              changelog: 'Updated encryption requirements and access controls',
+              file_size: 2458432,
+              file_name: 'ISP-001_Version_2.1.pdf',
+              is_active: true,
+              effective_date: '2024-06-01',
+              expiry_date: '2025-06-01',
+              created_at: '2024-06-01T00:00:00Z',
+              created_by: {
+                id: 1,
+                username: 'security.manager',
+                first_name: 'Security',
+                last_name: 'Manager'
+              }
+            },
+            is_due_for_review: false,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-06-01T10:30:00Z',
+            created_by: {
+              id: 1,
+              username: 'admin',
+              first_name: 'Admin',
+              last_name: 'User'
+            }
+          }
+        ],
+        count: 1,
+        next: null,
+        previous: null
+      }
+    }
+  },
+
+  // Get single policy by ID
+  async getPolicy(id: string): Promise<Policy> {
+    try {
+      const response = await api.get(`/policies/policies/${id}/`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching policy:', error)
+      throw error
+    }
+  },
+
+  // Create new policy
+  async createPolicy(policyData: Partial<Policy>): Promise<Policy> {
+    try {
+      const response = await api.post('/policies/policies/', policyData)
+      return response.data
+    } catch (error) {
+      console.error('Error creating policy:', error)
+      throw error
+    }
+  },
+
+  // Update policy
+  async updatePolicy(id: string, policyData: Partial<Policy>): Promise<Policy> {
+    try {
+      const response = await api.patch(`/policies/policies/${id}/`, policyData)
+      return response.data
+    } catch (error) {
+      console.error('Error updating policy:', error)
+      throw error
+    }
+  },
+
+  // Delete policy
+  async deletePolicy(id: string): Promise<void> {
+    try {
+      await api.delete(`/policies/policies/${id}/`)
+    } catch (error) {
+      console.error('Error deleting policy:', error)
+      throw error
+    }
+  },
+
+  // Get policy categories
+  async getPolicyCategories(): Promise<PolicyCategory[]> {
+    try {
+      const response = await api.get('/policies/categories/')
+      return response.data.results || response.data
+    } catch (error) {
+      console.error('Error fetching policy categories:', error)
+      return [
+        {
+          id: '550e8400-e29b-41d4-a716-446655440001',
+          name: 'Security',
+          description: 'Information security policies and procedures',
+          color: '#dc2626',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z'
+        },
+        {
+          id: '550e8400-e29b-41d4-a716-446655440002',
+          name: 'HR',
+          description: 'Human resources policies and procedures',
+          color: '#059669',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z'
+        },
+        {
+          id: '550e8400-e29b-41d4-a716-446655440003',
+          name: 'IT',
+          description: 'Information technology policies and procedures',
+          color: '#2563eb',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z'
+        }
+      ]
+    }
+  },
+
+  // Get policy acknowledgments
+  async getPolicyAcknowledgments(policyId?: string): Promise<PaginatedResponse<PolicyAcknowledgment>> {
+    try {
+      const params = new URLSearchParams()
+      if (policyId) {
+        params.append('policy', policyId)
+      }
+      
+      const response = await api.get(`/policies/acknowledgments/?${params.toString()}`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching policy acknowledgments:', error)
+      return {
+        results: [],
+        count: 0,
+        next: null,
+        previous: null
+      }
+    }
+  },
+
+  // Create policy acknowledgment
+  async acknowledgePolicy(policyVersionId: string): Promise<PolicyAcknowledgment> {
+    try {
+      const response = await api.post('/policies/acknowledgments/', {
+        policy_version: policyVersionId
+      })
+      return response.data
+    } catch (error) {
+      console.error('Error creating policy acknowledgment:', error)
+      throw error
+    }
+  },
+
+  // Get policy distributions
+  async getPolicyDistributions(): Promise<PaginatedResponse<PolicyDistribution>> {
+    try {
+      const response = await api.get('/policies/distributions/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching policy distributions:', error)
+      return {
+        results: [],
+        count: 0,
+        next: null,
+        previous: null
+      }
+    }
+  },
+
+  // Get policy analytics
+  async getPolicyAnalytics() {
+    try {
+      const response = await api.get('/policies/analytics/dashboard/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching policy analytics:', error)
+      
+      // Return mock analytics as fallback
+      return {
+        totalPolicies: 24,
+        pendingAcknowledgments: 45,
+        overdueReviews: 3,
+        complianceRate: 92.5,
+        acknowledgmentTrend: 5.8
+      }
+    }
+  },
+
+  // Get policy choices (status, types, etc.) from Django
+  async getPolicyChoices(): Promise<{
+    status_choices: Array<{value: string, label: string}>,
+    policy_type_choices: Array<{value: string, label: string}>
+  }> {
+    try {
+      const response = await api.get('/policies/choices/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching policy choices:', error)
+      return {
+        status_choices: [
+          { value: 'draft', label: 'Draft' },
+          { value: 'under_review', label: 'Under Review' },
+          { value: 'approved', label: 'Approved' },
+          { value: 'archived', label: 'Archived' }
+        ],
+        policy_type_choices: [
+          { value: 'procedure', label: 'Procedure' },
+          { value: 'policy', label: 'Policy' },
+          { value: 'standard', label: 'Standard' },
+          { value: 'guideline', label: 'Guideline' },
+          { value: 'framework', label: 'Framework' }
+        ]
+      }
+    }
+  }
+}
+
+export default policyService

--- a/frontend/src/lib/services/riskService.ts
+++ b/frontend/src/lib/services/riskService.ts
@@ -1,0 +1,238 @@
+import { api } from '../api'
+
+export interface RiskCategory {
+  id: number
+  name: string
+  description: string
+  color: string
+}
+
+export interface RiskMatrix {
+  id: number
+  name: string
+  description: string
+  is_default: boolean
+  impact_levels: number
+  likelihood_levels: number
+  matrix_config: Record<string, Record<string, string>>
+}
+
+export interface Risk {
+  id: number
+  risk_id: string
+  title: string
+  description: string
+  category: RiskCategory | null
+  impact: number // 1-5 scale
+  likelihood: number // 1-5 scale
+  risk_level: 'low' | 'medium' | 'high' | 'critical'
+  status: 'identified' | 'assessed' | 'treatment_planned' | 'treatment_in_progress' | 'mitigated' | 'accepted' | 'transferred' | 'closed'
+  treatment_strategy?: 'mitigate' | 'accept' | 'transfer' | 'avoid'
+  treatment_description?: string
+  risk_owner: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+    email: string
+  } | null
+  identified_date: string
+  last_assessed_date?: string
+  next_review_date?: string
+  closed_date?: string
+  potential_impact_description?: string
+  current_controls?: string
+  risk_matrix: RiskMatrix | null
+  created_at: string
+  updated_at: string
+  created_by: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+  } | null
+  // Computed properties from Django model
+  risk_score: number
+  is_overdue_for_review: boolean
+  days_until_review: number | null
+  is_active: boolean
+}
+
+export interface RiskFilters {
+  riskLevel?: string[]
+  status?: string[]
+  category?: string[]
+  owner?: string
+  dateRange?: [string, string]
+  page?: number
+  pageSize?: number
+  search?: string
+}
+
+export interface PaginatedResponse<T> {
+  results: T[]
+  count: number
+  next: string | null
+  previous: string | null
+}
+
+export const riskService = {
+  // Get all risks with optional filtering
+  async getRisks(filters: RiskFilters = {}): Promise<PaginatedResponse<Risk>> {
+    try {
+      const params = new URLSearchParams()
+      
+      if (filters.riskLevel?.length) {
+        params.append('risk_level', filters.riskLevel.join(','))
+      }
+      if (filters.status?.length) {
+        params.append('status', filters.status.join(','))
+      }
+      if (filters.category?.length) {
+        params.append('category', filters.category.join(','))
+      }
+      if (filters.owner) {
+        params.append('owner', filters.owner)
+      }
+      if (filters.search) {
+        params.append('search', filters.search)
+      }
+      if (filters.dateRange) {
+        params.append('date_from', filters.dateRange[0])
+        params.append('date_to', filters.dateRange[1])
+      }
+      if (filters.page) {
+        params.append('page', filters.page.toString())
+      }
+      if (filters.pageSize) {
+        params.append('page_size', filters.pageSize.toString())
+      }
+
+      const response = await api.get(`/risk/risks/?${params.toString()}`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching risks:', error)
+      throw error // Let the calling component handle the error
+    }
+  },
+
+  // Get single risk by ID
+  async getRisk(id: string | number): Promise<Risk> {
+    try {
+      const response = await api.get(`/risk/risks/${id}/`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching risk:', error)
+      throw error
+    }
+  },
+
+  // Create new risk
+  async createRisk(riskData: Partial<Risk>): Promise<Risk> {
+    try {
+      const response = await api.post('/risk/risks/', riskData)
+      return response.data
+    } catch (error) {
+      console.error('Error creating risk:', error)
+      throw error
+    }
+  },
+
+  // Update risk
+  async updateRisk(id: string | number, riskData: Partial<Risk>): Promise<Risk> {
+    try {
+      const response = await api.patch(`/risk/risks/${id}/`, riskData)
+      return response.data
+    } catch (error) {
+      console.error('Error updating risk:', error)
+      throw error
+    }
+  },
+
+  // Delete risk
+  async deleteRisk(id: string | number): Promise<void> {
+    try {
+      await api.delete(`/risk/risks/${id}/`)
+    } catch (error) {
+      console.error('Error deleting risk:', error)
+      throw error
+    }
+  },
+
+  // Get risk analytics
+  async getRiskAnalytics() {
+    try {
+      const response = await api.get('/risk/analytics/dashboard/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching risk analytics:', error)
+      throw error // Let the calling component handle the error
+    }
+  },
+
+  // Get risk categories
+  async getRiskCategories(): Promise<RiskCategory[]> {
+    try {
+      const response = await api.get('/risk/categories/')
+      return response.data.results || response.data
+    } catch (error) {
+      console.error('Error fetching risk categories:', error)
+      return [
+        { id: 1, name: 'Cybersecurity', description: 'Information security related risks', color: '#DC2626' },
+        { id: 2, name: 'Compliance', description: 'Regulatory compliance risks', color: '#F59E0B' },
+        { id: 3, name: 'Operational', description: 'Business operational risks', color: '#3B82F6' }
+      ]
+    }
+  },
+
+  // Get risk matrices
+  async getRiskMatrices(): Promise<RiskMatrix[]> {
+    try {
+      const response = await api.get('/risk/matrices/')
+      return response.data.results || response.data
+    } catch (error) {
+      console.error('Error fetching risk matrices:', error)
+      return []
+    }
+  },
+
+  // Get risk choices (status, levels, etc.) from Django
+  async getRiskChoices(): Promise<{
+    risk_levels: Array<{value: string, label: string}>,
+    status_choices: Array<{value: string, label: string}>,
+    treatment_strategies: Array<{value: string, label: string}>
+  }> {
+    try {
+      const response = await api.get('/risk/choices/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching risk choices:', error)
+      return {
+        risk_levels: [
+          { value: 'low', label: 'Low' },
+          { value: 'medium', label: 'Medium' },
+          { value: 'high', label: 'High' },
+          { value: 'critical', label: 'Critical' }
+        ],
+        status_choices: [
+          { value: 'identified', label: 'Identified' },
+          { value: 'assessed', label: 'Assessed' },
+          { value: 'treatment_planned', label: 'Treatment Planned' },
+          { value: 'treatment_in_progress', label: 'Treatment in Progress' },
+          { value: 'mitigated', label: 'Mitigated' },
+          { value: 'accepted', label: 'Accepted' },
+          { value: 'transferred', label: 'Transferred' },
+          { value: 'closed', label: 'Closed' }
+        ],
+        treatment_strategies: [
+          { value: 'mitigate', label: 'Mitigate' },
+          { value: 'accept', label: 'Accept' },
+          { value: 'transfer', label: 'Transfer' },
+          { value: 'avoid', label: 'Avoid' }
+        ]
+      }
+    }
+  }
+}
+
+export default riskService

--- a/frontend/src/lib/services/trainingService.ts
+++ b/frontend/src/lib/services/trainingService.ts
@@ -1,0 +1,462 @@
+import { api } from '../api'
+
+export interface TrainingCategory {
+  id: string
+  name: string
+  description: string
+  color: string
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface TrainingVideo {
+  id: string
+  title: string
+  description: string
+  category: TrainingCategory
+  video_provider: 'synthesia' | 'youtube' | 'vimeo' | 'custom'
+  video_url: string
+  video_id: string
+  duration_minutes?: number
+  difficulty_level: 'beginner' | 'intermediate' | 'advanced'
+  is_published: boolean
+  published_at?: string
+  created_by: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+  }
+  view_count: number
+  created_at: string
+  updated_at: string
+}
+
+export interface SecurityAwarenessCampaign {
+  id: string
+  name: string
+  description: string
+  start_date: string
+  end_date: string
+  status: 'draft' | 'active' | 'completed' | 'paused'
+  target_audience: {
+    include_all_users: boolean
+    include_new_users: boolean
+    specific_users: number[]
+    exclude_users: number[]
+    department_filters: string[]
+    role_filters: string[]
+  }
+  training_videos: string[]
+  completion_deadline?: string
+  reminder_frequency_days: number
+  max_reminders: number
+  created_by: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+  }
+  created_at: string
+  updated_at: string
+  // Computed fields
+  total_target_users: number
+  completion_rate: number
+  is_active: boolean
+  is_overdue: boolean
+}
+
+export interface CampaignDelivery {
+  id: string
+  campaign: SecurityAwarenessCampaign
+  user: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+    email: string
+  }
+  assigned_at: string
+  first_email_sent?: string
+  last_reminder_sent?: string
+  completed_at?: string
+  completion_percentage: number
+  reminders_sent: number
+  status: 'assigned' | 'in_progress' | 'completed' | 'overdue'
+  is_overdue: boolean
+  days_since_assignment: number
+  videos_watched: number
+  total_videos: number
+}
+
+export interface VideoView {
+  id: string
+  video: TrainingVideo
+  user: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+  }
+  campaign_delivery?: string
+  watched_at: string
+  watch_duration_seconds?: number
+  completion_percentage: number
+  ip_address: string
+  user_agent: string
+}
+
+export interface TrainingDashboard {
+  summary_metrics: {
+    total_videos: number
+    active_campaigns: number
+    total_completions: number
+    average_completion_rate: number
+  }
+  completion_trends: {
+    labels: string[]
+    datasets: Array<{
+      label: string
+      data: number[]
+      backgroundColor?: string
+      borderColor?: string
+    }>
+  }
+  category_performance: {
+    labels: string[]
+    datasets: Array<{
+      label: string
+      data: number[]
+      backgroundColor?: string[]
+    }>
+  }
+  recent_activities: Array<{
+    id: string
+    type: 'video_watched' | 'campaign_started' | 'campaign_completed'
+    user: string
+    video_title?: string
+    campaign_name?: string
+    timestamp: string
+  }>
+}
+
+export interface TrainingFilters {
+  category?: string[]
+  difficulty_level?: string[]
+  is_published?: boolean
+  video_provider?: string[]
+  search?: string
+  page?: number
+  pageSize?: number
+}
+
+export interface CampaignFilters {
+  status?: string[]
+  start_date_from?: string
+  start_date_to?: string
+  created_by?: number
+  search?: string
+  page?: number
+  pageSize?: number
+}
+
+export interface PaginatedResponse<T> {
+  results: T[]
+  count: number
+  next: string | null
+  previous: string | null
+}
+
+export const trainingService = {
+  // Training Videos
+  async getTrainingVideos(filters: TrainingFilters = {}): Promise<PaginatedResponse<TrainingVideo>> {
+    try {
+      const params = new URLSearchParams()
+      
+      if (filters.category?.length) {
+        params.append('category', filters.category.join(','))
+      }
+      if (filters.difficulty_level?.length) {
+        params.append('difficulty_level', filters.difficulty_level.join(','))
+      }
+      if (filters.is_published !== undefined) {
+        params.append('is_published', filters.is_published.toString())
+      }
+      if (filters.video_provider?.length) {
+        params.append('video_provider', filters.video_provider.join(','))
+      }
+      if (filters.search) {
+        params.append('search', filters.search)
+      }
+      if (filters.page) {
+        params.append('page', filters.page.toString())
+      }
+      if (filters.pageSize) {
+        params.append('page_size', filters.pageSize.toString())
+      }
+
+      const response = await api.get(`/training/videos/?${params.toString()}`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching training videos:', error)
+      
+      // Return mock data as fallback
+      return {
+        results: [
+          {
+            id: '550e8400-e29b-41d4-a716-446655440000',
+            title: 'Phishing Awareness Training',
+            description: 'Learn to identify and avoid phishing attacks',
+            category: {
+              id: '550e8400-e29b-41d4-a716-446655440010',
+              name: 'Email Security',
+              description: 'Training focused on email security best practices',
+              color: '#ef4444',
+              is_active: true,
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-01T00:00:00Z'
+            },
+            video_provider: 'synthesia',
+            video_url: 'https://share.synthesia.io/example-video',
+            video_id: 'synthesia-123',
+            duration_minutes: 15,
+            difficulty_level: 'beginner',
+            is_published: true,
+            published_at: '2024-06-01T00:00:00Z',
+            created_by: {
+              id: 1,
+              username: 'training.admin',
+              first_name: 'Training',
+              last_name: 'Admin'
+            },
+            view_count: 1247,
+            created_at: '2024-05-15T00:00:00Z',
+            updated_at: '2024-08-20T10:30:00Z'
+          }
+        ],
+        count: 1,
+        next: null,
+        previous: null
+      }
+    }
+  },
+
+  // Get single training video
+  async getTrainingVideo(id: string): Promise<TrainingVideo> {
+    try {
+      const response = await api.get(`/training/videos/${id}/`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching training video:', error)
+      throw error
+    }
+  },
+
+  // Create training video
+  async createTrainingVideo(videoData: Partial<TrainingVideo>): Promise<TrainingVideo> {
+    try {
+      const response = await api.post('/training/videos/', videoData)
+      return response.data
+    } catch (error) {
+      console.error('Error creating training video:', error)
+      throw error
+    }
+  },
+
+  // Update training video
+  async updateTrainingVideo(id: string, videoData: Partial<TrainingVideo>): Promise<TrainingVideo> {
+    try {
+      const response = await api.patch(`/training/videos/${id}/`, videoData)
+      return response.data
+    } catch (error) {
+      console.error('Error updating training video:', error)
+      throw error
+    }
+  },
+
+  // Delete training video
+  async deleteTrainingVideo(id: string): Promise<void> {
+    try {
+      await api.delete(`/training/videos/${id}/`)
+    } catch (error) {
+      console.error('Error deleting training video:', error)
+      throw error
+    }
+  },
+
+  // Training Categories
+  async getTrainingCategories(): Promise<TrainingCategory[]> {
+    try {
+      const response = await api.get('/training/categories/')
+      return response.data.results || response.data
+    } catch (error) {
+      console.error('Error fetching training categories:', error)
+      return [
+        {
+          id: '550e8400-e29b-41d4-a716-446655440010',
+          name: 'Email Security',
+          description: 'Training focused on email security best practices',
+          color: '#ef4444',
+          is_active: true,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z'
+        },
+        {
+          id: '550e8400-e29b-41d4-a716-446655440011',
+          name: 'Password Security',
+          description: 'Best practices for password creation and management',
+          color: '#10b981',
+          is_active: true,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z'
+        }
+      ]
+    }
+  },
+
+  // Security Awareness Campaigns
+  async getCampaigns(filters: CampaignFilters = {}): Promise<PaginatedResponse<SecurityAwarenessCampaign>> {
+    try {
+      const params = new URLSearchParams()
+      
+      if (filters.status?.length) {
+        params.append('status', filters.status.join(','))
+      }
+      if (filters.start_date_from) {
+        params.append('start_date_from', filters.start_date_from)
+      }
+      if (filters.start_date_to) {
+        params.append('start_date_to', filters.start_date_to)
+      }
+      if (filters.created_by) {
+        params.append('created_by', filters.created_by.toString())
+      }
+      if (filters.search) {
+        params.append('search', filters.search)
+      }
+      if (filters.page) {
+        params.append('page', filters.page.toString())
+      }
+      if (filters.pageSize) {
+        params.append('page_size', filters.pageSize.toString())
+      }
+
+      const response = await api.get(`/training/campaigns/?${params.toString()}`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching campaigns:', error)
+      
+      return {
+        results: [],
+        count: 0,
+        next: null,
+        previous: null
+      }
+    }
+  },
+
+  // Create campaign
+  async createCampaign(campaignData: Partial<SecurityAwarenessCampaign>): Promise<SecurityAwarenessCampaign> {
+    try {
+      const response = await api.post('/training/campaigns/', campaignData)
+      return response.data
+    } catch (error) {
+      console.error('Error creating campaign:', error)
+      throw error
+    }
+  },
+
+  // Record video view
+  async recordVideoView(videoId: string, campaignDeliveryId?: string): Promise<VideoView> {
+    try {
+      const response = await api.post('/training/views/', {
+        video: videoId,
+        campaign_delivery: campaignDeliveryId
+      })
+      return response.data
+    } catch (error) {
+      console.error('Error recording video view:', error)
+      throw error
+    }
+  },
+
+  // Get training dashboard
+  async getTrainingDashboard(): Promise<TrainingDashboard> {
+    try {
+      const response = await api.get('/training/dashboard/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching training dashboard:', error)
+      
+      return {
+        summary_metrics: {
+          total_videos: 24,
+          active_campaigns: 3,
+          total_completions: 1247,
+          average_completion_rate: 87.3
+        },
+        completion_trends: {
+          labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+          datasets: [{
+            label: 'Completion Rate',
+            data: [82, 85, 88, 87, 89, 87],
+            borderColor: '#10b981'
+          }]
+        },
+        category_performance: {
+          labels: ['Email Security', 'Password Security', 'Social Engineering'],
+          datasets: [{
+            label: 'Completion Rate',
+            data: [95, 88, 82],
+            backgroundColor: ['#ef4444', '#10b981', '#f59e0b']
+          }]
+        },
+        recent_activities: [
+          {
+            id: '1',
+            type: 'video_watched',
+            user: 'john.smith',
+            video_title: 'Phishing Awareness Training',
+            timestamp: '2024-08-25T10:30:00Z'
+          }
+        ]
+      }
+    }
+  },
+
+  // Get training choices from Django
+  async getTrainingChoices(): Promise<{
+    video_providers: Array<{value: string, label: string}>,
+    difficulty_levels: Array<{value: string, label: string}>,
+    campaign_statuses: Array<{value: string, label: string}>
+  }> {
+    try {
+      const response = await api.get('/training/choices/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching training choices:', error)
+      return {
+        video_providers: [
+          { value: 'synthesia', label: 'Synthesia.io' },
+          { value: 'youtube', label: 'YouTube' },
+          { value: 'vimeo', label: 'Vimeo' },
+          { value: 'custom', label: 'Custom URL' }
+        ],
+        difficulty_levels: [
+          { value: 'beginner', label: 'Beginner' },
+          { value: 'intermediate', label: 'Intermediate' },
+          { value: 'advanced', label: 'Advanced' }
+        ],
+        campaign_statuses: [
+          { value: 'draft', label: 'Draft' },
+          { value: 'active', label: 'Active' },
+          { value: 'completed', label: 'Completed' },
+          { value: 'paused', label: 'Paused' }
+        ]
+      }
+    }
+  }
+}
+
+export default trainingService

--- a/frontend/src/lib/services/vendorService.ts
+++ b/frontend/src/lib/services/vendorService.ts
@@ -1,0 +1,375 @@
+import { api } from '../api'
+
+export interface VendorCategory {
+  id: number
+  name: string
+  description: string
+  color_code: string
+  risk_weight: 'low' | 'medium' | 'high' | 'critical'
+  compliance_requirements: Record<string, any>
+}
+
+export interface VendorContact {
+  id: number
+  vendor: number
+  contact_type: 'primary' | 'billing' | 'technical' | 'legal' | 'emergency'
+  first_name: string
+  last_name: string
+  title: string
+  email: string
+  phone: string
+  is_primary: boolean
+}
+
+export interface Vendor {
+  id: number
+  vendor_id: string
+  name: string
+  legal_name: string
+  category: VendorCategory | null
+  business_description: string
+  website: string
+  tax_id: string
+  duns_number: string
+  address_line1: string
+  address_line2: string
+  city: string
+  state_province: string
+  postal_code: string
+  country: string
+  status: 'active' | 'inactive' | 'under_review' | 'approved' | 'suspended' | 'terminated'
+  vendor_type: 'supplier' | 'service_provider' | 'consultant' | 'contractor' | 'partner' | 'subcontractor'
+  risk_level: 'low' | 'medium' | 'high' | 'critical'
+  risk_score: number | null
+  annual_spend: number | null
+  credit_rating: string
+  payment_terms: string
+  operating_regions: string[]
+  primary_region: string
+  custom_fields: Record<string, any>
+  certifications: string[]
+  compliance_status: Record<string, any>
+  data_processing_agreement: boolean
+  security_assessment_completed: boolean
+  security_assessment_date: string | null
+  assigned_to: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+    email: string
+  } | null
+  relationship_start_date: string | null
+  created_at: string
+  updated_at: string
+  created_by: {
+    id: number
+    username: string
+    first_name: string
+    last_name: string
+  } | null
+}
+
+export interface VendorFilters {
+  riskLevel?: string
+  status?: string[]
+  category?: string[]
+  spend?: string
+  contractExpiry?: string
+  page?: number
+  pageSize?: number
+  search?: string
+}
+
+export interface PaginatedResponse<T> {
+  results: T[]
+  count: number
+  next: string | null
+  previous: string | null
+}
+
+export const vendorService = {
+  // Get all vendors with optional filtering
+  async getVendors(filters: VendorFilters = {}): Promise<PaginatedResponse<Vendor>> {
+    try {
+      const params = new URLSearchParams()
+      
+      if (filters.riskLevel) {
+        params.append('risk_level', filters.riskLevel)
+      }
+      if (filters.status?.length) {
+        params.append('status', filters.status.join(','))
+      }
+      if (filters.category?.length) {
+        params.append('category', filters.category.join(','))
+      }
+      if (filters.spend) {
+        params.append('spend', filters.spend)
+      }
+      if (filters.contractExpiry) {
+        params.append('contract_expiry', filters.contractExpiry)
+      }
+      if (filters.search) {
+        params.append('search', filters.search)
+      }
+      if (filters.page) {
+        params.append('page', filters.page.toString())
+      }
+      if (filters.pageSize) {
+        params.append('page_size', filters.pageSize.toString())
+      }
+
+      const response = await api.get(`/vendors/vendors/?${params.toString()}`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching vendors:', error)
+      
+      // Return mock data as fallback with Django model structure
+      return {
+        results: [
+          {
+            id: 1,
+            vendor_id: 'VEN-2024-0001',
+            name: 'Microsoft Corporation',
+            legal_name: 'Microsoft Corporation',
+            category: {
+              id: 1,
+              name: 'Cloud Services',
+              description: 'Cloud computing and software services',
+              color_code: '#0078d4',
+              risk_weight: 'low',
+              compliance_requirements: {}
+            },
+            business_description: 'Technology corporation providing cloud services and software',
+            website: 'https://www.microsoft.com',
+            tax_id: '91-1144442',
+            duns_number: '796740573',
+            address_line1: 'One Microsoft Way',
+            address_line2: '',
+            city: 'Redmond',
+            state_province: 'WA',
+            postal_code: '98052',
+            country: 'USA',
+            status: 'active',
+            vendor_type: 'service_provider',
+            risk_level: 'low',
+            risk_score: 15.5,
+            annual_spend: 120000,
+            credit_rating: 'AAA',
+            payment_terms: 'Net 30',
+            operating_regions: ['US', 'EU', 'APAC'],
+            primary_region: 'US',
+            custom_fields: {},
+            certifications: ['ISO 27001', 'SOC 2 Type II'],
+            compliance_status: { gdpr: 'compliant', sox: 'compliant' },
+            data_processing_agreement: true,
+            security_assessment_completed: true,
+            security_assessment_date: '2024-03-15',
+            assigned_to: {
+              id: 1,
+              username: 'procurement.manager',
+              first_name: 'John',
+              last_name: 'Smith',
+              email: 'john.smith@company.com'
+            },
+            relationship_start_date: '2023-06-30',
+            created_at: '2023-06-30T10:00:00Z',
+            updated_at: '2024-08-20T15:30:00Z',
+            created_by: {
+              id: 1,
+              username: 'admin',
+              first_name: 'Admin',
+              last_name: 'User'
+            }
+          },
+          {
+            id: 2,
+            vendor_id: 'VEN-2024-0002',
+            name: 'Amazon Web Services',
+            legal_name: 'Amazon Web Services, Inc.',
+            category: {
+              id: 2,
+              name: 'Infrastructure',
+              description: 'Cloud infrastructure and computing services',
+              color_code: '#ff9900',
+              risk_weight: 'low',
+              compliance_requirements: {}
+            },
+            business_description: 'Cloud computing platform and web services',
+            website: 'https://aws.amazon.com',
+            tax_id: '91-1646860',
+            duns_number: '962274814',
+            address_line1: '410 Terry Ave N',
+            address_line2: '',
+            city: 'Seattle',
+            state_province: 'WA',
+            postal_code: '98109',
+            country: 'USA',
+            status: 'active',
+            vendor_type: 'service_provider',
+            risk_level: 'low',
+            risk_score: 18.2,
+            annual_spend: 85000,
+            credit_rating: 'AAA',
+            payment_terms: 'Net 45',
+            operating_regions: ['US', 'EU', 'APAC'],
+            primary_region: 'US',
+            custom_fields: {},
+            certifications: ['ISO 27001', 'SOC 1 Type II', 'SOC 2 Type II'],
+            compliance_status: { gdpr: 'compliant', sox: 'compliant' },
+            data_processing_agreement: true,
+            security_assessment_completed: true,
+            security_assessment_date: '2024-02-20',
+            assigned_to: {
+              id: 2,
+              username: 'it.manager',
+              first_name: 'Sarah',
+              last_name: 'Johnson',
+              email: 'sarah.johnson@company.com'
+            },
+            relationship_start_date: '2023-01-15',
+            created_at: '2023-01-15T09:00:00Z',
+            updated_at: '2024-08-18T14:20:00Z',
+            created_by: {
+              id: 2,
+              username: 'it.admin',
+              first_name: 'IT',
+              last_name: 'Admin'
+            }
+          }
+        ],
+        count: 2,
+        next: null,
+        previous: null
+      }
+    }
+  },
+
+  // Get single vendor by ID
+  async getVendor(id: string | number): Promise<Vendor> {
+    try {
+      const response = await api.get(`/vendors/vendors/${id}/`)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching vendor:', error)
+      throw error
+    }
+  },
+
+  // Create new vendor
+  async createVendor(vendorData: Partial<Vendor>): Promise<Vendor> {
+    try {
+      const response = await api.post('/vendors/vendors/', vendorData)
+      return response.data
+    } catch (error) {
+      console.error('Error creating vendor:', error)
+      throw error
+    }
+  },
+
+  // Update vendor
+  async updateVendor(id: string | number, vendorData: Partial<Vendor>): Promise<Vendor> {
+    try {
+      const response = await api.patch(`/vendors/vendors/${id}/`, vendorData)
+      return response.data
+    } catch (error) {
+      console.error('Error updating vendor:', error)
+      throw error
+    }
+  },
+
+  // Delete vendor
+  async deleteVendor(id: string | number): Promise<void> {
+    try {
+      await api.delete(`/vendors/vendors/${id}/`)
+    } catch (error) {
+      console.error('Error deleting vendor:', error)
+      throw error
+    }
+  },
+
+  // Get vendor analytics
+  async getVendorAnalytics() {
+    try {
+      const response = await api.get('/vendors/analytics/dashboard/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching vendor analytics:', error)
+      
+      // Return mock analytics as fallback
+      return {
+        totalVendors: 89,
+        contractsExpiring: 8,
+        highRiskVendors: 6,
+        avgPerformance: 88.5,
+        performanceTrend: 3.2
+      }
+    }
+  },
+
+  // Get vendor categories
+  async getVendorCategories(): Promise<VendorCategory[]> {
+    try {
+      const response = await api.get('/vendors/categories/')
+      return response.data.results || response.data
+    } catch (error) {
+      console.error('Error fetching vendor categories:', error)
+      return [
+        { id: 1, name: 'Cloud Services', description: 'Cloud computing and software services', color_code: '#0078d4', risk_weight: 'low', compliance_requirements: {} },
+        { id: 2, name: 'Infrastructure', description: 'Cloud infrastructure and computing services', color_code: '#ff9900', risk_weight: 'low', compliance_requirements: {} },
+        { id: 3, name: 'Software', description: 'Software vendors and applications', color_code: '#00bcf2', risk_weight: 'medium', compliance_requirements: {} }
+      ]
+    }
+  },
+
+  // Get vendor contacts
+  async getVendorContacts(vendorId: number): Promise<VendorContact[]> {
+    try {
+      const response = await api.get(`/vendors/contacts/?vendor=${vendorId}`)
+      return response.data.results || response.data
+    } catch (error) {
+      console.error('Error fetching vendor contacts:', error)
+      return []
+    }
+  },
+
+  // Get vendor choices (status, types, etc.) from Django
+  async getVendorChoices(): Promise<{
+    status_choices: Array<{value: string, label: string}>,
+    vendor_type_choices: Array<{value: string, label: string}>,
+    risk_level_choices: Array<{value: string, label: string}>
+  }> {
+    try {
+      const response = await api.get('/vendors/choices/')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching vendor choices:', error)
+      return {
+        status_choices: [
+          { value: 'active', label: 'Active' },
+          { value: 'inactive', label: 'Inactive' },
+          { value: 'under_review', label: 'Under Review' },
+          { value: 'approved', label: 'Approved' },
+          { value: 'suspended', label: 'Suspended' },
+          { value: 'terminated', label: 'Terminated' }
+        ],
+        vendor_type_choices: [
+          { value: 'supplier', label: 'Supplier' },
+          { value: 'service_provider', label: 'Service Provider' },
+          { value: 'consultant', label: 'Consultant' },
+          { value: 'contractor', label: 'Contractor' },
+          { value: 'partner', label: 'Strategic Partner' },
+          { value: 'subcontractor', label: 'Subcontractor' }
+        ],
+        risk_level_choices: [
+          { value: 'low', label: 'Low' },
+          { value: 'medium', label: 'Medium' },
+          { value: 'high', label: 'High' },
+          { value: 'critical', label: 'Critical' }
+        ]
+      }
+    }
+  }
+}
+
+export default vendorService

--- a/frontend/src/lib/tenant.ts
+++ b/frontend/src/lib/tenant.ts
@@ -1,0 +1,10 @@
+export function getTenantFromHost(host?: string) {
+  const h = (host || (typeof window !== "undefined" ? window.location.host : "")).split(":")[0];
+  const parts = h.split(".");
+  if (parts.length >= 3) return parts[0];
+  if (typeof window !== "undefined") {
+    const t = new URLSearchParams(window.location.search).get("tenant");
+    if (t) return t;
+  }
+  return null;
+}


### PR DESCRIPTION
## What
Commits `frontend/src/lib/` (API client, auth, tenant helper, and the service layer), which was never in the repo.

## Why
The root `.gitignore` carried a Python-packaging rule `lib/` that also matched **`frontend/src/lib/`**. As a result the core frontend source (`@/lib/api`, `@/lib/auth`, `@/lib/services/*`, `@/lib/tenant`) lived only in local working trees and was **not version-controlled**. On a clean checkout, `npm run type-check` and `npm run build` failed with 16 `Cannot find module '@/lib/...'` errors - the real reason frontend CI could never go green (the lint failure just ran first and masked it).

## Change
- Anchor the Python `lib/` / `lib64/` ignore rules to the repo root (`/lib/`, `/lib64/`) so they stop swallowing nested source.
- Add the 8 missing `frontend/src/lib` files.

## Verification
- `npx tsc --noEmit` now passes with **0 errors** (was 16).
- Scanned the added files for secrets before committing: none; config uses `process.env.NEXT_PUBLIC_API_BASE`, tokens are runtime values.

Refs #95. Unblocks the biggest piece of the red frontend CI; remaining #95 items: the 52 ESLint errors (overlaps #70), Trivy SARIF upload perms, and relaxing the `npm audit` gate.
