### PR TITLE
Fix Trivy scanner reporting noise

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,11 +12,10 @@ on:
         type: choice
         options: [staging, production]
 
-# Required for GHCR, Code Scanning, and Azure OIDC
+# Required for GHCR and Azure OIDC
 permissions:
   contents: read
   packages: write
-  security-events: write
   id-token: write
 
 # Prevent overlapping deploys per branch/env
@@ -39,7 +38,7 @@ jobs:
       image-digest: ${{ steps.build.outputs.digest }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up QEMU
     # Needed for linux/arm64 cross-builds
@@ -109,7 +108,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Azure Login (OIDC)
       uses: azure/login@v2
@@ -250,7 +249,8 @@ jobs:
         format: sarif
         output: trivy-image-results.sarif
 
-    - name: Upload SARIF to Code Scanning
-      uses: github/codeql-action/upload-sarif@v3
+    - name: Upload image scan SARIF as artifact
+      uses: actions/upload-artifact@v7
       with:
-        sarif_file: trivy-image-results.sarif
+        name: trivy-image-results
+        path: trivy-image-results.sarif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pull-requests: write
   checks: write
+  security-events: write
 
 env:
   PYTHON_VERSION: '3.12'
@@ -63,15 +64,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Cache pip dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -115,7 +116,7 @@ jobs:
         DATABASE_URL=postgres://grc:grc@localhost:5432/grc_test
         CELERY_BROKER_URL=redis://localhost:6379/0
         CELERY_RESULT_BACKEND=redis://localhost:6379/1
-        AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;
+        AZURE_STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true
         SECRET_KEY=test-secret-key-for-ci
         DEBUG=0
         EOF
@@ -228,10 +229,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -266,7 +267,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
@@ -279,9 +280,10 @@ jobs:
       # only upload when the GITHUB_TOKEN can write (not forked PRs)
     - name: Upload Trivy scan results to Code Scanning
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: trivy-results.sarif
+        category: trivy-filesystem
     # always keep an artifact so you can see results even on forks
     - name: Upload SARIF as artifact (fallback)
       if: always()
@@ -306,7 +308,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -60,10 +60,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -96,7 +96,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0  # Fetch all history for all branches
 
@@ -114,7 +114,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Run Hadolint Dockerfile linter
       uses: hadolint/hadolint-action@v3.1.0
@@ -126,9 +126,10 @@ jobs:
 
     - name: Upload Hadolint results
       if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: hadolint-results.sarif
+        category: hadolint-dockerfile
 
     - name: Upload Hadolint SARIF as artifact (fallback)
       if: always()
@@ -143,10 +144,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -185,15 +186,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: python, javascript
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
 
   infrastructure-security:
     name: Infrastructure Security Scan
@@ -201,7 +202,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Run Checkov
       id: checkov
@@ -216,9 +217,10 @@ jobs:
 
     - name: Upload Checkov results
       if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: checkov-results.sarif
+        category: checkov-infrastructure
 
     - name: Upload Checkov SARIF as artifact (fallback)
       if: always()


### PR DESCRIPTION
Closes #113.

What changed:

- Adds explicit SARIF categories for PR-visible Trivy filesystem, Hadolint, and Checkov uploads so Code Scanning compares stable analysis keys across workflow changes.
- Stops publishing the push-only CD image scan SARIF to Code Scanning; the image scan is still retained as an Actions artifact. This avoids a main-only Trivy configuration poisoning PR comparisons.
- Grants `security-events: write` to the CI workflow that uploads Trivy SARIF.
- Replaces the embedded Azurite fixture connection string in CI with the existing emulator shortcut, `UseDevelopmentStorage=true`, matching `.env.dev.example` and test settings.
- Updates GitHub-maintained actions that were producing Node-runtime deprecation noise: checkout, setup-python, setup-node, cache, and CodeQL upload/init/analyze.

Verification:

- No remaining embedded `AccountKey=` / full Azurite fixture string in workflows.
- No remaining `actions/checkout@v4`, `actions/setup-python@v4`, `actions/setup-node@v4`, `actions/cache@v3`, or `github/codeql-action/*@v3` refs.
- Workflow YAML parses locally.
- `git diff --check` passes.

Note: this PR itself may still show the old Code Scanning "configuration not found" warning until it lands, because GitHub compares against the current main branch analyses. The fix removes that drift for subsequent PRs after main has the normalized workflow state.
