### PR TITLE
Fix CD baseline by gating Azure deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -105,7 +105,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     environment: staging
-    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
+    # Keep push-to-main CD green before Azure OIDC secrets are configured.
+    # Main pushes still build, publish, generate SBOMs, and scan the image;
+    # deployment is an explicit staging action.
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging'
 
     steps:
     - uses: actions/checkout@v5
@@ -213,7 +216,7 @@ jobs:
     name: Rollback (Swap back)
     runs-on: ubuntu-latest
     needs: [deploy-staging-slot]
-    if: failure()
+    if: failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging'
     environment: production
 
     steps:


### PR DESCRIPTION
Closes #95.

#95 has narrowed after #118 and #120:

- Frontend lint/type/build are now green on main.
- Trivy SARIF upload is now green on main.
- The remaining red baseline is CD trying to Azure-deploy on every push to `main` without Azure OIDC secrets configured.

This PR keeps the useful push-time CD work and gates only the external deployment:

- `main` pushes still build and publish the image, generate the SBOM, and run the image scan.
- Azure staging deploy is now explicit via `workflow_dispatch` with `environment=staging`.
- Rollback only runs for that same manual staging deployment path.

Verification:

- `.github/workflows/cd.yml` parses locally.
- `git diff --check` passes.
