### PR TITLE
Make CD workflow manual-only

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,6 @@
 name: CD - Build, Deploy (Slots), and Scan
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
     inputs:
       environment:
@@ -20,7 +18,7 @@ permissions:
 
 # Prevent overlapping deploys per branch/env
 concurrency:
-  group: cd-${{ github.ref }}-${{ github.event.inputs.environment || 'push' }}
+  group: cd-${{ github.ref }}-${{ github.event.inputs.environment || 'manual' }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
Follow-up for #95.

After #121, the Azure deployment was correctly gated, but the CD workflow still ran on every push to `main` and spent a long time building/pushing a multi-arch image. CD is not a branch-protection gate, and deployment is now manual, so this makes the workflow manual-only:

- Removes the `push: main` trigger from `cd.yml`.
- Keeps `workflow_dispatch` for explicit build/deploy/scan runs.
- Leaves CI as the push/PR validation path for backend, frontend, security scan, and Docker test build.

Verification:

- `.github/workflows/cd.yml` parses locally.
- `git diff --check` passes.
