### PR TITLE
Add tenant isolation regression tests

### DIFF
--- a/app/core/storage.py
+++ b/app/core/storage.py
@@ -9,6 +9,7 @@ This module provides a Django storage backend that:
 """
 
 import os
+from django.db import connection
 from django.core.files.storage import Storage, FileSystemStorage
 from django.conf import settings
 from django.utils.deconstruct import deconstructible
@@ -72,17 +73,12 @@ class TenantAwareBlobStorage(Storage):
         
     def _get_tenant_container_name(self):
         """Get the container name for the current tenant."""
-        try:
-            from django_tenants.utils import get_tenant
-            tenant = get_tenant()
-            if tenant and hasattr(tenant, 'slug'):
-                return f"{self.container_prefix}-{tenant.slug}"
-            else:
-                # Fallback for shared schema or when no tenant context
-                return f"{self.container_prefix}-shared"
-        except Exception:
-            # Fallback for non-tenant contexts (management commands, etc.)
-            return f"{self.container_prefix}-shared"
+        tenant = getattr(connection, "tenant", None)
+        if tenant and getattr(tenant, "slug", None):
+            return f"{self.container_prefix}-{tenant.slug}"
+
+        # Fallback for shared schema or non-tenant contexts.
+        return f"{self.container_prefix}-shared"
     
     def _get_container_client(self, container_name=None):
         """Get a container client for the specified or current tenant."""

--- a/app/core/test_tenant_isolation.py
+++ b/app/core/test_tenant_isolation.py
@@ -1,0 +1,127 @@
+"""Tenant isolation regression tests."""
+
+import pytest
+from uuid import uuid4
+from django.contrib.auth import get_user_model
+from django_tenants.utils import schema_context, tenant_context
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core.models import Domain, Tenant
+from core.storage import TenantAwareBlobStorage
+from risk.models import Risk
+
+User = get_user_model()
+
+
+@pytest.mark.django_db(transaction=True)
+class TestTenantIsolation:
+    """Verify tenant schema boundaries for representative tenant-owned data."""
+
+    def test_risk_list_is_scoped_to_request_tenant(self):
+        tenant_a = self._create_tenant("tenant_a", "tenant-a", "Tenant A")
+        tenant_b = self._create_tenant("tenant_b", "tenant-b", "Tenant B")
+
+        user_a = self._create_user(tenant_a, "alice", "alice@example.com")
+        user_b = self._create_user(tenant_b, "bob", "bob@example.com")
+        self._create_risk(tenant_a, "SHARED-RISK-ID", "Tenant A risk", user_a)
+        self._create_risk(tenant_b, "SHARED-RISK-ID", "Tenant B risk", user_b)
+
+        client = self._authenticated_client(tenant_a, user_a)
+
+        response = client.get("/api/risk/risks/")
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert self._response_count(payload) == 1
+        assert self._response_titles(payload) == ["Tenant A risk"]
+
+    def test_risk_detail_cannot_cross_tenant_boundary_by_pk(self):
+        tenant_a = self._create_tenant("tenant_a", "tenant-a", "Tenant A")
+        tenant_b = self._create_tenant("tenant_b", "tenant-b", "Tenant B")
+
+        user_a = self._create_user(tenant_a, "alice", "alice@example.com")
+        user_b = self._create_user(tenant_b, "bob", "bob@example.com")
+        self._create_risk(tenant_a, "RISK-A-001", "Tenant A risk", user_a)
+
+        with tenant_context(tenant_b):
+            self._create_risk(tenant_b, "RISK-B-001", "Tenant B first risk", user_b)
+            tenant_b_private_risk = self._create_risk(
+                tenant_b,
+                "RISK-B-002",
+                "Tenant B private risk",
+                user_b,
+            )
+
+        client = self._authenticated_client(tenant_a, user_a)
+
+        response = client.get(f"/api/risk/risks/{tenant_b_private_risk.pk}/")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_storage_container_name_uses_current_tenant(self):
+        tenant_a = self._create_tenant("tenant_a", "tenant-a", "Tenant A")
+        tenant_b = self._create_tenant("tenant_b", "tenant-b", "Tenant B")
+        storage = TenantAwareBlobStorage(connection_string="UseDevelopmentStorage=true")
+
+        with tenant_context(tenant_a):
+            container_a = storage._get_tenant_container_name()
+
+        with tenant_context(tenant_b):
+            container_b = storage._get_tenant_container_name()
+
+        assert container_a == f"tenant-{tenant_a.slug}"
+        assert container_b == f"tenant-{tenant_b.slug}"
+        assert container_a != container_b
+
+    def _create_tenant(self, schema_name, slug, name):
+        suffix = uuid4().hex[:8]
+        schema_name = f"{schema_name}_{suffix}"
+        slug = f"{slug}-{suffix}"
+        with schema_context("public"):
+            tenant = Tenant.objects.create(
+                name=name,
+                slug=slug,
+                schema_name=schema_name,
+            )
+            Domain.objects.create(
+                tenant=tenant,
+                domain=f"{slug}.localhost",
+                is_primary=True,
+            )
+        return tenant
+
+    def _create_user(self, tenant, username, email):
+        with tenant_context(tenant):
+            return User.objects.create_user(
+                username=username,
+                email=email,
+                password="testpass123",
+            )
+
+    def _create_risk(self, tenant, risk_id, title, user):
+        with tenant_context(tenant):
+            return Risk.objects.create(
+                risk_id=risk_id,
+                title=title,
+                description=f"{title} description",
+                impact=3,
+                likelihood=3,
+                created_by=user,
+                risk_owner=user,
+            )
+
+    def _authenticated_client(self, tenant, user):
+        client = APIClient()
+        client.defaults["HTTP_HOST"] = f"{tenant.slug}.localhost"
+        client.force_authenticate(user=user)
+        return client
+
+    def _response_count(self, payload):
+        if isinstance(payload, dict) and "count" in payload:
+            return payload["count"]
+        return len(payload)
+
+    def _response_titles(self, payload):
+        results = payload.get("results", payload) if isinstance(payload, dict) else payload
+        return [item["title"] for item in results]

--- a/app/risk/views.py
+++ b/app/risk/views.py
@@ -2,7 +2,7 @@ from rest_framework import viewsets, status, filters, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
-from django.db.models import Count, Q, Case, When, Value, IntegerField
+from django.db.models import Count, Q, Case, When, Value, IntegerField, F
 from django.utils import timezone
 from datetime import datetime, timedelta
 
@@ -170,7 +170,9 @@ class RiskViewSet(viewsets.ModelViewSet):
         """Return risks for the current tenant with optimized queries."""
         queryset = Risk.objects.select_related(
             'category', 'risk_owner', 'risk_matrix', 'created_by'
-        ).prefetch_related('notes')
+        ).prefetch_related('notes').alias(
+            risk_score=F('impact') * F('likelihood')
+        )
         
         # Apply common filters
         if self.request.query_params.get('overdue_review'):


### PR DESCRIPTION
Refs #84.

This is the first tenant-isolation security PR. It adds executable coverage for the core schema boundary and fixes two bugs the tests exposed.

What changed:

- Adds `core/test_tenant_isolation.py` with two real tenant schemas and API assertions that:
  - tenant A risk list only returns tenant A data, even when tenant B has a risk with the same `risk_id`;
  - tenant A cannot retrieve a tenant B risk by primary key;
  - tenant storage container names are derived from the active tenant, not shared globally.
- Fixes `TenantAwareBlobStorage._get_tenant_container_name()` to use `connection.tenant`, which django-tenants sets for the active schema/request. The old helper path silently fell back to `tenant-shared`.
- Fixes the risk list endpoint 500 by adding a queryset alias for `risk_score`; DRF ordering was trying to order by a Python property as if it were a DB field.

Verification:

- `ruff check app/core/test_tenant_isolation.py app/core/storage.py app/risk/views.py`
- `git diff --check`
- Targeted: `pytest core/test_tenant_isolation.py -q --migrations` -> 3 passed
- Maintained backend suite: 82 passed, 8 warnings

Follow-up remains for #84: expand the same pattern across the remaining tenant-owned API surfaces and export paths.
