### PR TITLE
feat: add API rate limiting

### DIFF
--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -122,6 +122,22 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
+    "DEFAULT_THROTTLE_CLASSES": [
+        "rest_framework.throttling.AnonRateThrottle",
+        "rest_framework.throttling.UserRateThrottle",
+        "rest_framework.throttling.ScopedRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "anon": os.environ.get("DRF_THROTTLE_ANON_RATE", "100/hour"),
+        "user": os.environ.get("DRF_THROTTLE_USER_RATE", "1000/hour"),
+        "auth": os.environ.get("DRF_THROTTLE_AUTH_RATE", "10/minute"),
+        "two_factor": os.environ.get("DRF_THROTTLE_TWO_FACTOR_RATE", "10/minute"),
+        "exports": os.environ.get("DRF_THROTTLE_EXPORTS_RATE", "30/hour"),
+        "evidence_upload": os.environ.get(
+            "DRF_THROTTLE_EVIDENCE_UPLOAD_RATE",
+            "60/hour",
+        ),
+    },
 }
 
 SPECTACULAR_SETTINGS = {

--- a/app/app/settings/test.py
+++ b/app/app/settings/test.py
@@ -109,6 +109,14 @@ TESTING_SKIP_EMAIL_SENDING = True
 # Django Rest Framework test settings
 REST_FRAMEWORK.update({
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '10000/hour',
+        'user': '10000/hour',
+        'auth': '10000/minute',
+        'two_factor': '10000/minute',
+        'exports': '10000/hour',
+        'evidence_upload': '10000/hour',
+    },
 })
 
 # Spectacular settings for API docs testing

--- a/app/authn/views.py
+++ b/app/authn/views.py
@@ -40,6 +40,7 @@ class RegisterView(APIView):
     Register a new user account with email verification and tenant assignment.
     """
     permission_classes = [permissions.AllowAny]
+    throttle_scope = "auth"
     
     @extend_schema(
         summary="Register new user",
@@ -80,6 +81,7 @@ class LoginView(APIView):
     Authenticate user with username/email and password. Supports 2FA flow with multiple methods.
     """
     permission_classes = [permissions.AllowAny]
+    throttle_scope = "auth"
     
     @extend_schema(
         summary="User login",
@@ -283,6 +285,7 @@ class TwoFactorStatusView(APIView):
 
 class EnableTwoFactorView(APIView):
     permission_classes = [permissions.IsAuthenticated]
+    throttle_scope = "two_factor"
     
     def post(self, request):
         """Enable 2FA for current user - supports email, TOTP, and push"""
@@ -359,6 +362,7 @@ class EnableTwoFactorView(APIView):
 
 class DisableTwoFactorView(APIView):
     permission_classes = [permissions.IsAuthenticated]
+    throttle_scope = "two_factor"
     
     def post(self, request):
         """Disable 2FA methods for current user"""
@@ -390,6 +394,7 @@ class VerifyOTPView(APIView):
     Complete login by verifying 2FA code from email, TOTP app, or push notification.
     """
     permission_classes = [permissions.AllowAny]
+    throttle_scope = "two_factor"
     
     @extend_schema(
         summary="Verify 2FA code",
@@ -437,6 +442,7 @@ class VerifyOTPView(APIView):
 
 class SetupTOTPView(APIView):
     permission_classes = [permissions.IsAuthenticated]
+    throttle_scope = "two_factor"
     
     def post(self, request):
         """Generate QR code for TOTP setup using enhanced pyotp service"""
@@ -474,6 +480,7 @@ class SetupTOTPView(APIView):
 
 class ConfirmTOTPView(APIView):
     permission_classes = [permissions.IsAuthenticated]
+    throttle_scope = "two_factor"
     
     def post(self, request):
         """Confirm TOTP setup with verification code using enhanced service"""
@@ -500,6 +507,7 @@ class ConfirmTOTPView(APIView):
 
 class RegisterPushDeviceView(APIView):
     permission_classes = [permissions.IsAuthenticated]
+    throttle_scope = "two_factor"
     
     def post(self, request):
         """Register a new push notification device"""
@@ -529,6 +537,7 @@ class RegisterPushDeviceView(APIView):
 
 class ApprovePushChallengeView(APIView):
     permission_classes = [permissions.AllowAny]
+    throttle_scope = "two_factor"
     
     def post(self, request):
         """Approve or deny a push notification challenge"""

--- a/app/catalogs/views.py
+++ b/app/catalogs/views.py
@@ -433,6 +433,13 @@ class ControlEvidenceViewSet(viewsets.ModelViewSet):
     search_fields = ['title', 'description']
     ordering_fields = ['evidence_date', 'created_at']
     ordering = ['-evidence_date']
+    throttle_scope_by_action = {"create": "evidence_upload"}
+
+    def get_throttles(self):
+        self.throttle_scope = self.throttle_scope_by_action.get(
+            getattr(self, "action", None)
+        )
+        return super().get_throttles()
     
     def get_queryset(self):
         return ControlEvidence.objects.select_related(
@@ -678,6 +685,16 @@ class ControlAssessmentViewSet(viewsets.ModelViewSet):
     search_fields = ['assessment_id', 'control__control_id', 'control__name', 'assessment_notes']
     ordering_fields = ['due_date', 'created_at', 'updated_at', 'completion_percentage']
     ordering = ['due_date', 'control__control_id']
+    throttle_scope_by_action = {
+        "upload_evidence": "evidence_upload",
+        "bulk_upload_evidence": "evidence_upload",
+    }
+
+    def get_throttles(self):
+        self.throttle_scope = self.throttle_scope_by_action.get(
+            getattr(self, "action", None)
+        )
+        return super().get_throttles()
     
     def get_serializer_class(self):
         if self.action == 'list':

--- a/app/core/test_rate_limiting.py
+++ b/app/core/test_rate_limiting.py
@@ -1,0 +1,59 @@
+"""API rate-limit configuration regression tests."""
+
+from rest_framework.settings import api_settings
+from rest_framework.throttling import AnonRateThrottle, ScopedRateThrottle, UserRateThrottle
+
+from authn.views import (
+    ApprovePushChallengeView,
+    ConfirmTOTPView,
+    EnableTwoFactorView,
+    LoginView,
+    RegisterPushDeviceView,
+    RegisterView,
+    SetupTOTPView,
+    VerifyOTPView,
+)
+from catalogs.views import ControlAssessmentViewSet, ControlEvidenceViewSet
+from core.views import DocumentViewSet
+from exports.views import AssessmentReportViewSet
+
+
+def test_default_drf_throttles_are_enabled():
+    throttle_classes = set(api_settings.DEFAULT_THROTTLE_CLASSES)
+
+    assert {AnonRateThrottle, UserRateThrottle, ScopedRateThrottle}.issubset(
+        throttle_classes
+    )
+    assert {"anon", "user", "auth", "two_factor", "exports", "evidence_upload"} <= set(
+        api_settings.DEFAULT_THROTTLE_RATES
+    )
+
+
+def test_auth_and_two_factor_views_have_sensitive_scopes():
+    assert RegisterView.throttle_scope == "auth"
+    assert LoginView.throttle_scope == "auth"
+
+    two_factor_views = [
+        EnableTwoFactorView,
+        VerifyOTPView,
+        SetupTOTPView,
+        ConfirmTOTPView,
+        RegisterPushDeviceView,
+        ApprovePushChallengeView,
+    ]
+    assert all(view.throttle_scope == "two_factor" for view in two_factor_views)
+
+
+def test_export_views_use_export_scope():
+    assert AssessmentReportViewSet.throttle_scope == "exports"
+
+
+def test_upload_actions_use_evidence_upload_scope():
+    assert DocumentViewSet.throttle_scope_by_action == {"create": "evidence_upload"}
+    assert ControlEvidenceViewSet.throttle_scope_by_action == {
+        "create": "evidence_upload"
+    }
+    assert ControlAssessmentViewSet.throttle_scope_by_action == {
+        "upload_evidence": "evidence_upload",
+        "bulk_upload_evidence": "evidence_upload",
+    }

--- a/app/core/views.py
+++ b/app/core/views.py
@@ -91,6 +91,13 @@ class DocumentViewSet(viewsets.ModelViewSet):
     serializer_class = DocumentSerializer
     permission_classes = [permissions.IsAuthenticated]
     parser_classes = [MultiPartParser, FormParser]
+    throttle_scope_by_action = {"create": "evidence_upload"}
+
+    def get_throttles(self):
+        self.throttle_scope = self.throttle_scope_by_action.get(
+            getattr(self, "action", None)
+        )
+        return super().get_throttles()
     
     def get_queryset(self):
         """Return documents for the current tenant only."""

--- a/app/exports/views.py
+++ b/app/exports/views.py
@@ -101,6 +101,7 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ['report_type', 'status', 'framework']
+    throttle_scope = "exports"
     
     def get_queryset(self):
         """Return reports for the current user's tenant."""


### PR DESCRIPTION
## Summary
- enables DRF anon, user, and scoped throttles with env-tunable rates
- adds scoped throttles for auth/login/register, 2FA operations, exports, and evidence/document upload actions
- keeps test settings at high limits to avoid order-dependent fixture failures
- adds regression tests for throttle classes, rate keys, and sensitive scope wiring

Closes #85

## Verification
- ruff check app/app/settings/base.py app/app/settings/test.py app/authn/views.py app/catalogs/views.py app/core/views.py app/exports/views.py app/core/test_rate_limiting.py
- git diff --check
- POSTGRES_DB=grc_test POSTGRES_USER=grc POSTGRES_PASSWORD=grc POSTGRES_HOST=localhost POSTGRES_PORT=5432 SECRET_KEY=test-secret-key DJANGO_SETTINGS_MODULE=app.settings.test CELERY_BROKER_URL=redis://localhost:6379/0 CELERY_RESULT_BACKEND=redis://localhost:6379/1 /private/tmp/aximcyber-trivy-baseline/.venv/bin/python -m pytest core/test_rate_limiting.py -q
- POSTGRES_DB=grc_test POSTGRES_USER=grc POSTGRES_PASSWORD=grc POSTGRES_HOST=localhost POSTGRES_PORT=5432 SECRET_KEY=test-secret-key DJANGO_SETTINGS_MODULE=app.settings.test CELERY_BROKER_URL=redis://localhost:6379/0 CELERY_RESULT_BACKEND=redis://localhost:6379/1 /private/tmp/aximcyber-trivy-baseline/.venv/bin/python -m pytest --ignore=risk/tests --ignore=catalogs/test_reminders.py --cov=. --cov-report=term-missing --cov-fail-under=0 --verbose --migrations