### PR TITLE
Fix production hygiene and PDF export rendering

### DIFF
--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -22,6 +22,7 @@ SHARED_APPS = [
     "rest_framework",
     "django_filters",
     "drf_spectacular",
+    "corsheaders",
     "core", # Needed here for Tenant and Domain models
 ]
 
@@ -63,6 +64,7 @@ MIDDLEWARE = [
     "django_tenants.middleware.main.TenantMainMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/app/app/settings/production.py
+++ b/app/app/settings/production.py
@@ -4,12 +4,23 @@ Production settings for Azure App Service deployment.
 
 from .base import *
 
+
+def _csv_env(name):
+    return [
+        value.strip()
+        for value in os.environ.get(name, '').split(',')
+        if value.strip()
+    ]
+
 # Security settings
 DEBUG = False
 ALLOWED_HOSTS = [
     '.azurewebsites.net',
     os.environ.get('CUSTOM_DOMAIN', ''),
 ] + [host.strip() for host in os.environ.get('ADDITIONAL_HOSTS', '').split(',') if host.strip()]
+
+CORS_ALLOWED_ORIGINS = _csv_env('CORS_ALLOWED_ORIGINS')
+CSRF_TRUSTED_ORIGINS = _csv_env('CSRF_TRUSTED_ORIGINS') or CORS_ALLOWED_ORIGINS
 
 # Database configuration for Azure
 DATABASES = {
@@ -126,7 +137,3 @@ if STRIPE_LIVE_MODE:
 
 # Run migrations on startup if specified
 RUN_MIGRATIONS = os.environ.get('RUN_MIGRATIONS', 'False').lower() == 'true'
-
-print(f"Production settings loaded - Debug: {DEBUG}, Allowed hosts: {ALLOWED_HOSTS}")
-if RUN_MIGRATIONS:
-    print("🔄 Migrations will run on startup")

--- a/app/core/test_production_settings.py
+++ b/app/core/test_production_settings.py
@@ -1,0 +1,21 @@
+"""Production settings regression tests."""
+
+from pathlib import Path
+
+
+def test_production_settings_do_not_print_allowed_hosts():
+    production_settings = Path("app/settings/production.py").read_text()
+
+    assert "print(f\"Production settings loaded" not in production_settings
+    assert "Allowed hosts" not in production_settings
+
+
+def test_production_settings_use_explicit_origin_allowlists():
+    production_settings = Path("app/settings/production.py").read_text()
+
+    assert "CORS_ALLOWED_ORIGINS = _csv_env('CORS_ALLOWED_ORIGINS')" in production_settings
+    assert (
+        "CSRF_TRUSTED_ORIGINS = _csv_env('CSRF_TRUSTED_ORIGINS') or CORS_ALLOWED_ORIGINS"
+        in production_settings
+    )
+    assert "CORS_ALLOW_ALL_ORIGINS" not in production_settings

--- a/app/exports/services.py
+++ b/app/exports/services.py
@@ -76,12 +76,14 @@ class AssessmentReportGenerator:
         if self.report.framework:
             # Framework-specific summary
             assessments = ControlAssessment.objects.filter(
-                control__clause__framework=self.report.framework
-            ).select_related('control', 'assigned_to', 'control__clause')
+                control__clauses__framework=self.report.framework
+            ).select_related(
+                'control', 'assigned_to'
+            ).prefetch_related('control__clauses').distinct()
             
             # Assessment statistics
             total_assessments = assessments.count()
-            completed_assessments = assessments.filter(status='completed').count()
+            completed_assessments = assessments.filter(status='complete').count()
             in_progress_assessments = assessments.filter(status='in_progress').count()
             not_started_assessments = assessments.filter(status='not_started').count()
             overdue_assessments = assessments.filter(
@@ -126,14 +128,14 @@ class AssessmentReportGenerator:
         
         if self.report.framework:
             assessments = ControlAssessment.objects.filter(
-                control__clause__framework=self.report.framework
+                control__clauses__framework=self.report.framework
             ).select_related(
-                'control', 'assigned_to', 'control__clause'
-            ).prefetch_related('evidence_links__evidence')
+                'control', 'assigned_to'
+            ).prefetch_related('control__clauses', 'evidence_links__evidence').distinct()
         else:
             assessments = self.report.assessments.all().select_related(
-                'control', 'assigned_to', 'control__clause'
-            ).prefetch_related('evidence_links__evidence')
+                'control', 'assigned_to'
+            ).prefetch_related('control__clauses', 'evidence_links__evidence')
         
         context['assessments'] = assessments
         return render_to_string('exports/reports/detailed_assessment.html', context)
@@ -148,10 +150,10 @@ class AssessmentReportGenerator:
         # Get evidence across assessments
         if self.report.framework:
             evidence_links = AssessmentEvidence.objects.filter(
-                assessment__control__clause__framework=self.report.framework
+                assessment__control__clauses__framework=self.report.framework
             ).select_related(
                 'assessment', 'evidence', 'assessment__control'
-            ).prefetch_related('evidence__document')
+            ).prefetch_related('evidence__document').distinct()
         else:
             assessment_ids = self.report.assessments.values_list('id', flat=True)
             evidence_links = AssessmentEvidence.objects.filter(
@@ -190,8 +192,10 @@ class AssessmentReportGenerator:
         
         # Get all assessments for the framework
         assessments = ControlAssessment.objects.filter(
-            control__clause__framework=self.report.framework
-        ).select_related('control', 'assigned_to', 'control__clause')
+            control__clauses__framework=self.report.framework
+        ).select_related(
+            'control', 'assigned_to'
+        ).prefetch_related('control__clauses').distinct()
         
         # Categorize gaps
         not_started = assessments.filter(status='not_started')
@@ -200,11 +204,11 @@ class AssessmentReportGenerator:
             due_date__lt=timezone.now().date()
         )
         missing_evidence = assessments.filter(
-            status='completed',
+            status='complete',
             evidence_links__isnull=True
         )
         no_primary_evidence = assessments.filter(
-            status='completed'
+            status='complete'
         ).exclude(
             evidence_links__is_primary_evidence=True
         )
@@ -316,6 +320,7 @@ class AssessmentReportGenerator:
             color: white;
         }
         
+        .status-complete,
         .status-completed { background-color: #28a745; }
         .status-in-progress { background-color: #ffc107; color: #333; }
         .status-not-started { background-color: #6c757d; }
@@ -340,7 +345,12 @@ class AssessmentReportGenerator:
         html = HTML(string=html_content)
         
         pdf_buffer = io.BytesIO()
-        html.write_pdf(pdf_buffer, stylesheets=[css], font_config=self.font_config)
+        html.write_pdf(
+            pdf_buffer,
+            stylesheets=[css],
+            font_config=self.font_config,
+            presentational_hints=False,
+        )
         pdf_buffer.seek(0)
         
         return pdf_buffer.getvalue()

--- a/app/exports/templates/exports/reports/assessment_summary.html
+++ b/app/exports/templates/exports/reports/assessment_summary.html
@@ -124,7 +124,7 @@
                 {% for assessment in assessments %}
                 <tr>
                     <td>{{ assessment.control.control_id }}</td>
-                    <td>{{ assessment.control.title|truncatechars:60 }}</td>
+                    <td>{{ assessment.control.name|truncatechars:60 }}</td>
                     <td>
                         <span class="status-badge status-{{ assessment.status }}">
                             {{ assessment.get_status_display }}
@@ -134,7 +134,7 @@
                     <td>
                         {% if assessment.due_date %}
                             {{ assessment.due_date|date:"M d, Y" }}
-                            {% if assessment.status != 'completed' and assessment.due_date < today %}
+                            {% if assessment.status != 'complete' and assessment.due_date < today %}
                                 <span class="status-badge status-overdue">OVERDUE</span>
                             {% endif %}
                         {% else %}
@@ -164,10 +164,10 @@
             </thead>
             <tbody>
                 {% for assessment in assessments %}
-                    {% if assessment.status != 'completed' and assessment.due_date < today %}
+                    {% if assessment.status != 'complete' and assessment.due_date < today %}
                     <tr>
                         <td>{{ assessment.control.control_id }}</td>
-                        <td>{{ assessment.control.title|truncatechars:80 }}</td>
+                        <td>{{ assessment.control.name|truncatechars:80 }}</td>
                         <td>{{ assessment.assigned_to.get_full_name|default:assessment.assigned_to.username|default:"Unassigned" }}</td>
                         <td>{{ assessment.due_date|date:"M d, Y" }}</td>
                         <td>{{ assessment.due_date|timesince|truncatewords:1 }}</td>

--- a/app/exports/templates/exports/reports/compliance_gap.html
+++ b/app/exports/templates/exports/reports/compliance_gap.html
@@ -74,8 +74,14 @@
                 {% for assessment in not_started %}
                 <tr>
                     <td style="font-weight: bold;">{{ assessment.control.control_id }}</td>
-                    <td>{{ assessment.control.title }}</td>
-                    <td>{{ assessment.control.clause.clause_id }}</td>
+                    <td>{{ assessment.control.name }}</td>
+                    <td>
+                        {% for clause in assessment.control.clauses.all %}
+                            {{ clause.clause_id }}{% if not forloop.last %}, {% endif %}
+                        {% empty %}
+                            -
+                        {% endfor %}
+                    </td>
                     <td>{{ assessment.assigned_to.get_full_name|default:assessment.assigned_to.username|default:"Unassigned" }}</td>
                     <td>
                         {% if assessment.due_date %}
@@ -88,13 +94,17 @@
                         {% endif %}
                     </td>
                     <td>
-                        {% if assessment.control.clause.criticality == 'critical' %}
-                            <span class="status-badge status-overdue">CRITICAL</span>
-                        {% elif assessment.control.clause.criticality == 'high' %}
-                            <span class="status-badge" style="background-color: #fd7e14;">HIGH</span>
-                        {% else %}
-                            <span class="status-badge status-in-progress">MEDIUM</span>
-                        {% endif %}
+                        {% for clause in assessment.control.clauses.all %}
+                            {% if clause.criticality == 'critical' %}
+                                <span class="status-badge status-overdue">CRITICAL</span>
+                            {% elif clause.criticality == 'high' %}
+                                <span class="status-badge" style="background-color: #fd7e14;">HIGH</span>
+                            {% else %}
+                                <span class="status-badge status-in-progress">{{ clause.get_criticality_display|upper }}</span>
+                            {% endif %}
+                        {% empty %}
+                            <span class="status-badge status-in-progress">UNKNOWN</span>
+                        {% endfor %}
                     </td>
                 </tr>
                 {% endfor %}
@@ -122,7 +132,7 @@
                 {% for assessment in in_progress_overdue %}
                 <tr>
                     <td style="font-weight: bold;">{{ assessment.control.control_id }}</td>
-                    <td>{{ assessment.control.title }}</td>
+                    <td>{{ assessment.control.name }}</td>
                     <td>{{ assessment.assigned_to.get_full_name|default:assessment.assigned_to.username|default:"Unassigned" }}</td>
                     <td>{{ assessment.due_date|date:"M d, Y" }}</td>
                     <td style="color: #dc3545; font-weight: bold;">{{ assessment.due_date|timesince|truncatewords:1 }}</td>
@@ -152,15 +162,19 @@
                 {% for assessment in missing_evidence %}
                 <tr>
                     <td style="font-weight: bold;">{{ assessment.control.control_id }}</td>
-                    <td>{{ assessment.control.title }}</td>
+                    <td>{{ assessment.control.name }}</td>
                     <td>{{ assessment.completed_date|date:"M d, Y"|default:"Unknown" }}</td>
                     <td>{{ assessment.assigned_to.get_full_name|default:assessment.assigned_to.username|default:"Unassigned" }}</td>
                     <td>
-                        {% if assessment.control.clause.is_testable %}
-                            <span class="status-badge status-overdue">HIGH RISK</span>
-                        {% else %}
-                            <span class="status-badge status-in-progress">MEDIUM RISK</span>
-                        {% endif %}
+                        {% for clause in assessment.control.clauses.all %}
+                            {% if clause.is_testable %}
+                                <span class="status-badge status-overdue">HIGH RISK</span>
+                            {% else %}
+                                <span class="status-badge status-in-progress">MEDIUM RISK</span>
+                            {% endif %}
+                        {% empty %}
+                            <span class="status-badge status-in-progress">UNKNOWN RISK</span>
+                        {% endfor %}
                     </td>
                 </tr>
                 {% endfor %}
@@ -187,7 +201,7 @@
                 {% for assessment in no_primary_evidence %}
                 <tr>
                     <td style="font-weight: bold;">{{ assessment.control.control_id }}</td>
-                    <td>{{ assessment.control.title }}</td>
+                    <td>{{ assessment.control.name }}</td>
                     <td>{{ assessment.evidence_links.count }}</td>
                     <td>{{ assessment.completed_date|date:"M d, Y"|default:"Unknown" }}</td>
                     <td style="font-style: italic; color: #0066cc;">Designate primary evidence</td>

--- a/app/exports/templates/exports/reports/detailed_assessment.html
+++ b/app/exports/templates/exports/reports/detailed_assessment.html
@@ -19,7 +19,7 @@
 
     {% for assessment in assessments %}
     <div class="section {% if not forloop.first %}page-break{% endif %}">
-        <h2>{{ assessment.control.control_id }}: {{ assessment.control.title }}</h2>
+        <h2>{{ assessment.control.control_id }}: {{ assessment.control.name }}</h2>
         
         <div class="assessment-details">
             <table style="width: 100%; margin-bottom: 1em;">
@@ -40,7 +40,7 @@
                     <td>
                         {% if assessment.due_date %}
                             {{ assessment.due_date|date:"F d, Y" }}
-                            {% if assessment.status != 'completed' and assessment.due_date < today %}
+                            {% if assessment.status != 'complete' and assessment.due_date < today %}
                                 <span class="status-badge status-overdue">OVERDUE</span>
                             {% endif %}
                         {% else %}
@@ -74,20 +74,11 @@
         </div>
         {% endif %}
 
-        {% if report.include_implementation_notes and assessment.implementation_notes %}
+        {% if report.include_implementation_notes and assessment.implementation_approach %}
         <div style="margin: 1em 0;">
-            <h3 style="color: #0066cc; font-size: 12pt;">Implementation Notes</h3>
+            <h3 style="color: #0066cc; font-size: 12pt;">Implementation Approach</h3>
             <div style="background-color: #f8f9fa; padding: 1em; border-left: 4px solid #0066cc;">
-                {{ assessment.implementation_notes|linebreaks }}
-            </div>
-        </div>
-        {% endif %}
-
-        {% if assessment.testing_notes %}
-        <div style="margin: 1em 0;">
-            <h3 style="color: #0066cc; font-size: 12pt;">Testing Notes</h3>
-            <div style="background-color: #f8f9fa; padding: 1em; border-left: 4px solid #28a745;">
-                {{ assessment.testing_notes|linebreaks }}
+                {{ assessment.implementation_approach|linebreaks }}
             </div>
         </div>
         {% endif %}

--- a/app/exports/templates/exports/reports/evidence_portfolio.html
+++ b/app/exports/templates/exports/reports/evidence_portfolio.html
@@ -101,7 +101,7 @@
                 <ul style="margin: 0.5em 0;">
                     {% for assessment in evidence_info.assessments %}
                     <li>
-                        <strong>{{ assessment.control.control_id }}:</strong> {{ assessment.control.title|truncatechars:60 }}
+                        <strong>{{ assessment.control.control_id }}:</strong> {{ assessment.control.name|truncatechars:60 }}
                         <span class="status-badge status-{{ assessment.status }}" style="margin-left: 0.5em; font-size: 8pt;">
                             {{ assessment.get_status_display }}
                         </span>

--- a/app/exports/tests.py
+++ b/app/exports/tests.py
@@ -27,7 +27,8 @@ class AssessmentReportModelTest(TestCase):
         self.framework = Framework.objects.create(
             name='Test Framework',
             short_name='TEST',
-            version='1.0'
+            version='1.0',
+            effective_date=timezone.now().date()
         )
     
     def test_assessment_report_creation(self):
@@ -73,7 +74,8 @@ class AssessmentReportAPITest(APITestCase):
         self.framework = Framework.objects.create(
             name='ISO 27001',
             short_name='ISO27001',
-            version='2022'
+            version='2022',
+            effective_date=timezone.now().date()
         )
         
         self.clause = Clause.objects.create(
@@ -84,17 +86,19 @@ class AssessmentReportAPITest(APITestCase):
         )
         
         self.control = Control.objects.create(
-            clause=self.clause,
             control_id='A.5.1.1',
-            title='Test Control',
-            description='Test control description'
+            name='Test Control',
+            description='Test control description',
+            control_type='preventive'
         )
+        self.control.clauses.add(self.clause)
         
         self.assessment = ControlAssessment.objects.create(
             control=self.control,
             assigned_to=self.user,
-            status='completed',
-            implementation_status='implemented'
+            status='complete',
+            implementation_status='implemented',
+            implementation_approach='Test implementation'
         )
         
         self.client.force_authenticate(user=self.user)
@@ -283,7 +287,8 @@ class AssessmentReportGeneratorTest(TestCase):
         self.framework = Framework.objects.create(
             name='Test Framework',
             short_name='TEST',
-            version='1.0'
+            version='1.0',
+            effective_date=timezone.now().date()
         )
         
         self.clause = Clause.objects.create(
@@ -294,18 +299,19 @@ class AssessmentReportGeneratorTest(TestCase):
         )
         
         self.control = Control.objects.create(
-            clause=self.clause,
             control_id='T.1.1',
-            title='Test Control',
-            description='Test control description'
+            name='Test Control',
+            description='Test control description',
+            control_type='preventive'
         )
+        self.control.clauses.add(self.clause)
         
         self.assessment = ControlAssessment.objects.create(
             control=self.control,
             assigned_to=self.user,
-            status='completed',
+            status='complete',
             implementation_status='implemented',
-            implementation_notes='Test implementation'
+            implementation_approach='Test implementation'
         )
         
         # Create evidence
@@ -339,7 +345,10 @@ class AssessmentReportGeneratorTest(TestCase):
         )
         
         with patch('exports.services.AssessmentReportGenerator._save_pdf_document') as mock_save:
-            mock_document = Document(title='Test Report')
+            mock_document = Document.objects.create(
+                title='Test Report',
+                uploaded_by=self.user
+            )
             mock_save.return_value = mock_document
             
             generator = AssessmentReportGenerator(report)
@@ -349,6 +358,9 @@ class AssessmentReportGeneratorTest(TestCase):
             report.refresh_from_db()
             self.assertEqual(report.status, 'completed')
             self.assertIsNotNone(report.generation_completed_at)
+            mock_html_instance.write_pdf.assert_called_once()
+            _, write_pdf_kwargs = mock_html_instance.write_pdf.call_args
+            self.assertFalse(write_pdf_kwargs['presentational_hints'])
     
     def test_generate_detailed_assessment(self):
         """Test generating detailed assessment report HTML."""
@@ -364,7 +376,7 @@ class AssessmentReportGeneratorTest(TestCase):
         
         self.assertIn('Detailed Assessment Report', html_content)
         self.assertIn(self.control.control_id, html_content)
-        self.assertIn(self.control.title, html_content)
+        self.assertIn(self.control.name, html_content)
         self.assertIn('Test implementation', html_content)
     
     def test_generate_evidence_portfolio(self):
@@ -416,7 +428,7 @@ class AssessmentReportGeneratorTest(TestCase):
         generator = AssessmentReportGenerator(report)
         
         with self.assertRaises(ValueError):
-            generator._generate_assessment_summary()
+            generator.generate_report()
     
     def test_filename_generation(self):
         """Test PDF filename generation."""

--- a/app/exports/views.py
+++ b/app/exports/views.py
@@ -295,28 +295,33 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
         search = request.query_params.get('search', '')
         
         assessments = ControlAssessment.objects.select_related(
-            'control', 'control__clause'
-        )
+            'control'
+        ).prefetch_related('control__clauses__framework')
         
         if framework_id:
-            assessments = assessments.filter(control__clause__framework_id=framework_id)
+            assessments = assessments.filter(control__clauses__framework_id=framework_id)
         
         if search:
             assessments = assessments.filter(
                 Q(control__control_id__icontains=search) |
-                Q(control__title__icontains=search)
+                Q(control__name__icontains=search)
             )
         
         # Limit results to prevent large responses
-        assessments = assessments[:100]
+        assessments = assessments.distinct()[:100]
         
         assessment_data = [
             {
                 'id': assessment.id,
                 'control_id': assessment.control.control_id,
-                'control_title': assessment.control.title,
+                'control_title': assessment.control.name,
                 'status': assessment.status,
-                'framework_name': assessment.control.clause.framework.short_name
+                'framework_name': ', '.join(
+                    sorted({
+                        clause.framework.short_name
+                        for clause in assessment.control.clauses.all()
+                    })
+                )
             }
             for assessment in assessments
         ]


### PR DESCRIPTION
## Summary
- Remove production import-time logging of debug/allowed-host configuration.
- Add explicit env-backed CORS/CSRF origin allowlists and wire django-cors-headers into settings.
- Mitigate WeasyPrint CVE-2026-49452 exposure by rendering PDFs with presentational_hints=False.
- Bring PDF export generation back in line with the current catalog schema: Control.clauses many-to-many, Control.name, ControlAssessment.status=complete, and implementation_approach.
- Update assessment options to use the current control/clause model shape.

## Validation
- ruff check app/settings/base.py app/settings/production.py exports/services.py exports/views.py exports/tests.py core/test_production_settings.py
- git diff --check
- POSTGRES_DB=grc_test POSTGRES_USER=grc POSTGRES_PASSWORD=grc POSTGRES_HOST=localhost POSTGRES_PORT=5432 SECRET_KEY=test-secret-key DJANGO_SETTINGS_MODULE=app.settings.test CELERY_BROKER_URL=redis://localhost:6379/0 CELERY_RESULT_BACKEND=redis://localhost:6379/1 python -m pytest exports/tests.py::AssessmentReportGeneratorTest core/test_production_settings.py -q

## Notes
Dependabot alert #109 has no patched WeasyPrint version listed, so this mitigates our application usage but may not close the alert until upstream ships a fixed release. Follow-up #129 tracks evaluating a migration away from WeasyPrint. Follow-up #130 tracks the separate exports API test 404 drift encountered while verifying the broader exports suite.

Closes #89