### PR TITLE
Add GRC BRD, TRD and traceability matrix

### DIFF
--- a/docs/adr/0034-modular-grc-product-architecture.md
+++ b/docs/adr/0034-modular-grc-product-architecture.md
@@ -1,0 +1,99 @@
+# ADR-0034: Modular GRC Product Architecture and Requirements Traceability
+
+## Status
+
+Accepted
+
+## Context
+
+The original business brief defines a broad multi-tenant GRC SaaS product covering frameworks, risk, vendor management, policies, documents, awareness training, calendar reminders, vulnerability scanning, billing, analytics and exports.
+
+The codebase has already implemented substantial module foundations, but delivery now needs a more explicit programme-level architecture and traceability model. Without that, the project risks accumulating isolated modules that do not align with SaaS packaging, one-module trials, content import and audit-ready workflows.
+
+## Decision
+
+We will treat Axim GRC as a modular SaaS platform with shared platform services and independently packageable business modules.
+
+### Platform Services
+
+- Tenant isolation.
+- Authentication and MFA.
+- Subscription billing and module entitlements.
+- Document storage.
+- Audit logging.
+- Notifications/reminders.
+- Imports/exports.
+- Analytics.
+- OpenAPI/API contract.
+
+### Business Modules
+
+- Framework/control assessment.
+- Risk management.
+- Vendor management.
+- Policy, standard and procedure repository.
+- Training and awareness.
+- Asset register.
+- Calendar/deadline management.
+- Vulnerability scanning.
+
+## Key Decisions
+
+### 1. Modules Must Be Entitlement-Aware
+
+Each major module must be independently grantable or blockable by plan/trial. UI navigation alone is insufficient; API access must enforce the same entitlement model.
+
+### 2. Content Must Be Imported and Versioned
+
+Framework spreadsheets, control catalogs and document templates are product data. They should be imported idempotently with source checksums/version metadata instead of being hard-coded into business logic.
+
+### 3. Document Templates and Evidence Must Link to Work Items
+
+Templates, samples and evidence should be discoverable from the relevant framework/control/policy/risk/vendor/asset item. This is required for audit usability and client adoption.
+
+### 4. Cross-Module Deadlines Need a Shared Calendar Layer
+
+Individual modules may own due dates, but reminders and calendar views should be unified so users do not need to inspect every module separately.
+
+### 5. Major External Engines Require ADRs Before Implementation
+
+Document editing/conversion and vulnerability scanning introduce significant operational and security implications. They require separate ADRs before build-out.
+
+## Consequences
+
+### Positive
+
+- Clearer product packaging for free/basic/enterprise and trials.
+- Better alignment between original business requirements and engineering delivery.
+- Repeatable framework/template onboarding.
+- More coherent UX across modules.
+- Stronger auditability and tenant isolation discipline.
+
+### Negative / Tradeoffs
+
+- More upfront modeling work before some features can be completed.
+- Entitlements add checks across API and frontend surfaces.
+- Content import requires governance around source files, versions and mappings.
+- Cross-module calendar/export layers must tolerate partial module availability.
+
+## Implementation Notes
+
+- Requirements are tracked in [../planning/requirements_traceability_matrix.md](../planning/requirements_traceability_matrix.md).
+- BRD lives in [../planning/business_requirements_document.md](../planning/business_requirements_document.md).
+- TRD lives in [../planning/technical_requirements_document.md](../planning/technical_requirements_document.md).
+- Gap tickets are ordered from foundation/content import through module completion and reporting.
+
+## Related Issues
+
+- #132 - Framework spreadsheet import.
+- #133 - Template library import/linking.
+- #134 - Asset register.
+- #135 - Module entitlements and trial packaging.
+- #136 - Calendar and deadline notification hub.
+- #137 - Vulnerability scanning.
+- #138 - Document editing and PDF-only finalized downloads.
+- #139 - Data export coverage.
+- #140 - BRD/TRD/traceability governance.
+- #141 - Knowledge base and in-app guidance.
+- #142 - ISO governance registers and management review artefacts.
+- #143 - Axim operator product analytics and tenant usage metrics.

--- a/docs/planning/business_requirements_document.md
+++ b/docs/planning/business_requirements_document.md
@@ -1,0 +1,177 @@
+# Business Requirements Document: Axim GRC SaaS
+
+## Document Control
+
+- **Product:** Multi-tenant Information Security Governance, Risk and Compliance SaaS
+- **Audience:** Founder/product owner, engineering, delivery, compliance SMEs and implementation partners
+- **Status:** Baseline BRD
+- **Related TRD:** [technical_requirements_document.md](technical_requirements_document.md)
+- **Traceability:** [requirements_traceability_matrix.md](requirements_traceability_matrix.md)
+
+## Executive Summary
+
+Axim GRC is a multi-tenant SaaS platform for managing information security certifications, risk assessments, vendor management, policies, standards, procedures, awareness training, evidence and audit-ready reporting. The platform should let each client operate one module independently or combine modules into a joined GRC operating model.
+
+The current codebase already contains substantial foundations for tenant isolation, framework/control assessments, evidence storage, risk management, policy acknowledgments, training campaigns, analytics, billing and 2FA. The remaining business work is to load the supplied GRC content, close module gaps, formalize product packaging and harden document workflows.
+
+## Business Goals
+
+1. Provide a practical GRC workflow tool for SMEs and enterprise clients.
+2. Support certification readiness for ISO 27001, ISO 20000, ISO 22301, PCI DSS, NIST CSF and future frameworks.
+3. Reduce client effort by linking templates, samples and evidence expectations to relevant controls/items.
+4. Provide recurring SaaS revenue through free, basic and enterprise tiers.
+5. Support controlled trials that demonstrate value without exposing the full product.
+6. Preserve tenant data isolation and auditability as core trust requirements.
+7. Produce exportable evidence, reports and management information for audits and executive reviews.
+
+## Target Users
+
+- **Client administrator:** Configures company account, users, modules, subscriptions and document repositories.
+- **Compliance manager:** Owns frameworks, control applicability, evidence collection and certification readiness.
+- **Risk manager:** Maintains risk register, actions, owners, due dates and remediation evidence.
+- **Vendor manager:** Tracks supplier due diligence, contracts, reviews and vendor tasks.
+- **Policy owner:** Publishes policies, standards and procedures and tracks acknowledgments.
+- **Staff user:** Completes assigned acknowledgments, training and evidence/action tasks.
+- **Axim operator:** Supports tenants, monitors adoption, manages billing and reviews analytics.
+
+## Product Scope
+
+### Core Modules
+
+- Framework and certification workflows.
+- Risk management.
+- Third-party/vendor management.
+- Asset management.
+- Policy, standard and procedure repository.
+- Evidence and document storage.
+- Security awareness and training.
+- Calendar/deadline notifications.
+- Vulnerability scanning.
+- Analytics and reporting.
+- Billing and subscription management.
+
+### Frameworks and Content Packs
+
+Initial content should support:
+
+- ISO 27001.
+- ISO 20000.
+- ISO 22301.
+- PCI DSS guide.
+- NIST CSF.
+- CIS Controls.
+- PSD2.
+- GDPR.
+- SOC 2, HIPAA, Cyber Essentials and additional frameworks later.
+
+Framework content will be imported from provided spreadsheets/documents and represented as reusable catalogs of frameworks, clauses, controls, evidence expectations and documentation links.
+
+### Supplied Template Library
+
+The source archive `Axim App-20260715T065616Z-1-001.zip` contains policy, standard, procedure, ISO mandatory, PCI, risk register and asset register files. These must become a governed in-app template/sample library, not just static files.
+
+Users must be able to:
+
+- Find templates from relevant controls/items.
+- Download editable templates when permitted.
+- Upload existing or customized external documents.
+- Keep completed documents in the tenant repository.
+- Download finalized documents as PDF where required.
+
+## Business Requirements
+
+### BR-001 Multi-Tenancy
+
+The application must support multiple client organizations using the platform simultaneously with strict data separation.
+
+### BR-002 Authentication and 2FA
+
+The application must support secure login with at least email-based 2FA. TOTP support is desirable and currently available.
+
+### BR-003 Subscription Plans
+
+The application must support free, basic and enterprise versions, recurring billing, grandfathering and feature limits.
+
+### BR-004 One-Module Trial
+
+The application must support a one-month trial restricted to one selected module/item.
+
+### BR-005 Framework Workflows
+
+Clients must be able to select applicable controls, answer yes/no applicability questions, assign owners, provide evidence and track completion.
+
+### BR-006 Template and Sample Linkage
+
+Sample/template documents must be linked to relevant controls/items and downloadable/customizable by clients.
+
+### BR-007 Document Repository
+
+The application must store client documents, uploaded evidence, finalized policies and generated reports in a secure repository.
+
+### BR-008 Risk Management
+
+The application must support a risk register where rating is calculated from impact and probability/likelihood, with owners, due dates, actions and remediation evidence.
+
+### BR-009 Vendor Management
+
+The application must support vendor records, due diligence, contract/review dates, tasks and notification workflows.
+
+### BR-010 Policy Acknowledgment
+
+Policies, standards and procedures must be distributable to staff for reading and acknowledgment, with reminders and audit records.
+
+### BR-011 Awareness and Training
+
+The application must support awareness materials and video training, including scheduled email campaigns.
+
+### BR-012 Calendar and Deadline Reminders
+
+Deadline dates should notify task owners one week before expiry and on expiry. The platform should expose important dates in a shared calendar.
+
+### BR-013 Vulnerability Scanning
+
+The application should support vulnerability scanning against approved client systems using an open-source scanner and report findings.
+
+### BR-014 Audit Activity Tracking
+
+The application must track user logins, downloads, uploads, changes and other significant activity.
+
+### BR-015 Analytics
+
+Axim must be able to see product usage and performance analytics for marketing, support and product improvement.
+
+### BR-016 Data Export
+
+Clients must be able to download their module data in spreadsheet and/or PDF formats.
+
+### BR-017 Future Framework Expansion
+
+The product must support adding further frameworks without major code changes.
+
+## Non-Functional Requirements
+
+- Strong tenant isolation.
+- Auditable workflows.
+- Secure file handling.
+- Email notification reliability.
+- Azure-compatible deployment with future platform portability.
+- GitHub-based development and CI/CD.
+- Scalable architecture that supports modular product packaging.
+- Accessible, professional UI suitable for repeated operational use.
+
+## Success Measures
+
+- A new tenant can register, choose a plan/trial and access only entitled modules.
+- A tenant can complete a framework assessment with linked templates and evidence.
+- A tenant can maintain a risk register and receive due-date reminders.
+- A tenant can manage policies and track acknowledgments.
+- A tenant can export audit-ready evidence/reports.
+- Axim can onboard additional framework content through import/configuration rather than custom code.
+
+## Out of Scope for Current Baseline
+
+- Custom CMS/marketing site implementation.
+- Full inline Office editing until the document editing architecture decision is made.
+- Live vulnerability scanning until scanner architecture and security boundaries are approved.
+- Native mobile applications.
+

--- a/docs/planning/requirements_traceability_matrix.md
+++ b/docs/planning/requirements_traceability_matrix.md
@@ -1,0 +1,64 @@
+# Requirements Traceability Matrix
+
+This matrix maps the original GRC SaaS brief to current implementation status and delivery tickets.
+
+Status values:
+
+- **Done:** implemented and broadly aligned.
+- **Partial:** foundation exists, but business requirement is not complete.
+- **Missing:** no clear first-class implementation yet.
+- **Tracked Elsewhere:** existing issue covers the work.
+
+| ID | Requirement | Current Status | Evidence / Notes | Tracking |
+| --- | --- | --- | --- | --- |
+| RTM-001 | Multi-tenant client isolation | Done | `django-tenants`, tenant models and tenant isolation tests exist. | Existing architecture ADRs |
+| RTM-002 | Email 2FA / MFA | Done | Email OTP and TOTP flows exist in `authn`. | Existing ADR-0003/0010 |
+| RTM-003 | Free/basic/enterprise plans | Partial | Plans, subscriptions and limits exist. Module-level entitlements are not complete. | #135 |
+| RTM-004 | One-month trial for one item/module | Missing | Trial fields exist, but one-module trial packaging is not enforced. | #135 |
+| RTM-005 | ISO/NIST/PCI/control workflows | Partial | Generic Framework/Clause/Control/Assessment exists; content packs/imports incomplete. | #132 |
+| RTM-006 | ISO 27001 source templates | Partial | Source ZIP includes ISO mandatory docs; not imported/linked. | #133 |
+| RTM-007 | ISO 20000 / ISO 22301 / CIS / PSD2 / GDPR / future frameworks | Partial | Data model supports custom frameworks; source content not loaded. | #132 |
+| RTM-008 | PCI guide/workflow | Partial | Source ZIP contains `PCI V4.0.xlsx`; import/linking not complete. | #132, #133 |
+| RTM-009 | Templates/samples linked to controls/items | Missing | Document storage exists, but template linkage is not implemented as a product feature. | #133 |
+| RTM-010 | Client document repository | Partial | Tenant-aware document model/storage exists. Repository lifecycle and finalized PDF-only flow incomplete. | #138 |
+| RTM-011 | Upload existing external documents | Partial | Upload/storage exists; module-specific replacement workflow needs completion. | #133, #138 |
+| RTM-012 | Inline Word/spreadsheet modification | Missing | No selected editing architecture. | #138 |
+| RTM-013 | Final downloads only as PDF after modification | Missing | PDF/report generation exists, but controlled document finalization flow is missing. | #138, #129 |
+| RTM-014 | Risk register with calculated rating | Done | Risk model calculates risk level from impact/likelihood. | Existing risk ADRs |
+| RTM-015 | Risk owner overdue notifications | Partial | Risk actions/reminders exist; unified calendar/deadline hub still needed. | #136 |
+| RTM-016 | Risk remediation evidence upload | Partial | Evidence/document models exist; module-specific linkage should be verified. | Existing evidence ADR, #139 |
+| RTM-017 | Vendor management | Partial | Vendor app/models/docs exist; API route mounting issue logged. | #128 |
+| RTM-018 | Vendor activity date checks/reminders | Partial | Vendor task architecture exists; route/usability validation needed. | #128, #136 |
+| RTM-019 | Policy repository | Done | Policy/category/version/document models exist. | Existing ADR-0021 |
+| RTM-020 | Policy acknowledgment tracking | Done | Acknowledgment/distribution/reminder tasks exist. | Existing ADR-0022 |
+| RTM-021 | Security awareness email campaigns | Done | Training campaign models/tasks exist. | Existing ADR-0023 |
+| RTM-022 | Synthesia/video training | Partial | Training video model supports Synthesia/custom URLs; content loading needed. | Future content work |
+| RTM-023 | Knowledge base/how-to content | Missing | No clear first-class knowledge base module found. | #141 |
+| RTM-024 | Calendar module | Missing | No unified calendar/event module found. | #136 |
+| RTM-025 | Vulnerability scanning | Missing | Policies/controls mention scanning; scanner integration not implemented. | #137 |
+| RTM-026 | User activity tracking | Partial | AuditEvent exists; coverage and UI/reporting should be validated. | #139 |
+| RTM-027 | Product analytics for Axim | Partial | GRC analytics exist; operator/product usage metrics need explicit design. | #143 |
+| RTM-028 | Client data exports in spreadsheet/PDF | Partial | Reporting/export modules exist; coverage and API reliability incomplete. | #130, #139 |
+| RTM-029 | Asset register | Missing | Source ZIP includes asset register; no first-class module found. | #134 |
+| RTM-030 | Regulatory and contractual sheet | Partial | Source ZIP includes legal/regulatory sheet; not imported as structured data. | #142 |
+| RTM-031 | Non-conformity log, scope doc, metrics, agenda, management review | Partial | Source ZIP includes several ISO mandatory docs; structured workflows not complete. | #142 |
+| RTM-032 | Azure deployment | Partial | Azure-oriented settings/storage exist; platform-agnostic hosting is also tracked. | #92 |
+| RTM-033 | GitHub-based delivery | Done | GitHub CI/security workflows exist. | Existing CI issues |
+| RTM-034 | ADR documentation | Partial | Many ADRs exist; programme-level BRD/TRD traceability added under #140. | #140 |
+
+## Ordered Delivery Sequence
+
+1. #132 - Import framework spreadsheets into reusable control catalogs.
+2. #133 - Import and link Axim template library.
+3. #128 - Mount or retire vendor management API routes.
+4. #134 - Implement first-class asset register.
+5. #135 - Implement module entitlements and one-module trials.
+6. #136 - Add calendar and cross-module deadline notification hub.
+7. #137 - Implement vulnerability scanning integration.
+8. #138 - Define document editing and PDF-only finalized downloads.
+9. #130 / #139 - Stabilize exports and complete data export coverage.
+10. #141 - Add knowledge base and in-app guidance.
+11. #142 - Model ISO governance registers and management review artefacts.
+12. #143 - Define Axim operator product analytics and tenant usage metrics.
+13. #129 - Evaluate replacing WeasyPrint PDF generation.
+14. #140 - Maintain BRD/TRD/traceability and ADR updates as delivery progresses.

--- a/docs/planning/technical_requirements_document.md
+++ b/docs/planning/technical_requirements_document.md
@@ -1,0 +1,153 @@
+# Technical Requirements Document: Axim GRC SaaS
+
+## Document Control
+
+- **Product:** Multi-tenant Information Security GRC SaaS
+- **Related BRD:** [business_requirements_document.md](business_requirements_document.md)
+- **Traceability:** [requirements_traceability_matrix.md](requirements_traceability_matrix.md)
+- **Architecture ADR:** [../adr/0034-modular-grc-product-architecture.md](../adr/0034-modular-grc-product-architecture.md)
+
+## Current Architecture Baseline
+
+The application is a Django/DRF backend using `django-tenants` schema isolation, PostgreSQL, Redis/Celery for asynchronous work, Azure-oriented tenant-aware blob storage, Stripe billing and a frontend backed by generated OpenAPI types. Existing modules include catalogs, exports, risk, vendors, policies, training, analytics, billing, SSO/authn and core document/audit models.
+
+## Architecture Principles
+
+1. **Tenant isolation first:** every client-owned record must be scoped by tenant schema or equivalent isolation boundary.
+2. **Module-first product model:** frameworks, risk, vendors, policies, assets, training, calendar and scanning must be independently usable and packageable.
+3. **Content as data:** frameworks, clauses, controls and document templates should be imported and versioned data, not hard-coded workflows.
+4. **Evidence-grade auditability:** uploads, downloads, acknowledgments, exports and state changes must be auditable.
+5. **Async for long-running work:** imports, PDF generation, exports, scanner jobs and bulk email tasks must run through workers.
+6. **Security by default:** 2FA, least privilege, file validation, secure storage and dependency hygiene are product requirements, not afterthoughts.
+
+## Major Components
+
+### Backend
+
+- Django and Django REST Framework.
+- `django-tenants` for schema-based tenant isolation.
+- PostgreSQL for relational data.
+- Redis and Celery for background jobs.
+- Azure Blob-compatible tenant-aware document storage.
+- Stripe integration for billing and subscriptions.
+- OpenAPI schema generation for frontend/client contracts.
+
+### Frontend
+
+- Web application consuming generated API client/types.
+- Module-aware navigation driven by entitlements.
+- Operational UI optimized for dashboards, workflows, tables, forms and evidence review.
+
+### Asynchronous Processing
+
+Required async domains:
+
+- Framework/content imports.
+- Template library imports.
+- Email reminders.
+- Policy acknowledgment reminders.
+- PDF/report generation.
+- Data exports.
+- Vulnerability scan jobs.
+
+## Data Domain Requirements
+
+### Framework Catalog
+
+Must support Framework, Clause, Control, ControlAssessment, evidence expectations, applicability, status, ownership, review dates and import metadata.
+
+### Template Library
+
+Must store template metadata and source documents. Documents must link to frameworks, clauses, controls, policies or other module items.
+
+### Risk Register
+
+Must calculate risk level from impact and likelihood/probability. Must support actions, owners, due dates, evidence and reminders.
+
+### Vendor Management
+
+Must support vendor profiles, categories, contacts, services, contracts, due diligence, tasks and reminders. Existing vendor APIs need route validation under #128.
+
+### Policy Repository
+
+Must support policy categories, versioned policy documents, distribution, acknowledgments, expiry and reminders.
+
+### Asset Register
+
+Must be added as a first-class module with owners, classification, criticality, review dates, linked risks/controls/evidence and import support.
+
+### Calendar
+
+Must aggregate cross-module deadlines and custom events, with owner notifications and idempotent reminder logs.
+
+### Vulnerability Scanning
+
+Must model targets, schedules, scan jobs and findings. Scanner workers must run with explicit network and credential boundaries.
+
+### Exports
+
+Must provide tenant-scoped CSV/XLSX/PDF exports for each module, with async lifecycle and audit logging.
+
+## Integration Requirements
+
+- **Email:** 2FA, reminders, policy acknowledgment, training campaigns, billing and system notifications.
+- **Stripe:** subscriptions, webhooks, billing portal, grandfathering and plan limits.
+- **Azure Blob Storage:** tenant-scoped document storage.
+- **Scanner Engine:** selected later via ADR before implementation.
+- **Document Editing/Conversion:** selected later via ADR before inline editing/PDF-only delivery.
+- **OpenAPI:** API schema remains the contract for frontend types and external clients.
+
+## Security Requirements
+
+- Email 2FA must remain available; TOTP may be offered as stronger option.
+- All module APIs must enforce authentication, authorization and tenant isolation.
+- File uploads must validate type and size.
+- Final document downloads must respect permissions and lifecycle state.
+- Scanner credentials must not be stored in plaintext.
+- Import jobs must reject unsafe paths/system files.
+- Reports and exports must not cross tenant boundaries.
+- Audit events must cover critical user and admin activity.
+
+## Module Entitlement Requirements
+
+The product must support explicit module entitlements per tenant/subscription:
+
+- Free plan: limited default functionality.
+- Basic plan: configured subset and limits.
+- Enterprise plan: all modules and higher limits.
+- Trial: one selected module for one month.
+- Grandfathered/custom subscriptions: custom limits and module grants.
+
+API and UI access must both enforce entitlements.
+
+## Content Import Requirements
+
+- Imports must be idempotent.
+- Imports must preserve source identifiers and checksums.
+- Framework imports must support versioning.
+- Template imports must classify content and link templates to controls/items.
+- Import errors must be reportable and actionable.
+
+## Quality Requirements
+
+- Targeted tests for every new module.
+- Tenant isolation tests for all tenant-owned modules.
+- Coverage floors should continue increasing by app.
+- E2E tests should cover the critical buyer workflows.
+- ADRs should be added before introducing major external dependencies.
+
+## Deployment Requirements
+
+- Azure-compatible deployment remains supported.
+- Architecture should remain platform-agnostic where practical.
+- CI must run backend tests, frontend tests, linting, security scanning and branch checks.
+- Long-running operational jobs should be observable and retry-safe.
+
+## Open Technical Decisions
+
+- Document editing approach: Office integration vs OnlyOffice/Collabora vs form-driven document generation.
+- PDF generation replacement: ReportLab vs Playwright/Chromium vs other renderer.
+- Vulnerability scanner: OpenVAS/Greenbone vs Nuclei or layered approach.
+- Content import schema and ownership workflow.
+- Product entitlement model granularity.
+


### PR DESCRIPTION
## Summary
- Add a standard Business Requirements Document for the Axim GRC SaaS product.
- Add a Technical Requirements Document aligned to the current Django/DRF multi-tenant architecture.
- Add a requirements traceability matrix mapping the original brief to implementation status and GitHub issues.
- Add ADR-0034 for the modular GRC product architecture and programme-level traceability approach.

## Gap tickets logged
- #132 GRC Gap 01: Framework spreadsheet import
- #133 GRC Gap 02: Axim template library import/linking
- #134 GRC Gap 03: Asset register module
- #135 GRC Gap 04: Module entitlements and one-module trials
- #136 GRC Gap 05: Calendar and deadline notification hub
- #137 GRC Gap 06: Vulnerability scanning integration
- #138 GRC Gap 07: Document editing and PDF-only finalized downloads
- #139 GRC Gap 08: Complete customer data exports
- #140 GRC Gap 09: BRD/TRD/traceability governance
- #141 GRC Gap 10: Knowledge base and in-app guidance
- #142 GRC Gap 11: ISO governance registers and management review artefacts
- #143 GRC Gap 12: Axim operator product analytics

## Validation
- git diff --check
- Verified traceability entries do not contain placeholder future-ticket text

Closes #140