### PR TITLE
Add framework spreadsheet import

### DIFF
--- a/app/catalogs/management/commands/import_framework.py
+++ b/app/catalogs/management/commands/import_framework.py
@@ -1,25 +1,29 @@
 import json
 import yaml
 import hashlib
+import re
 from datetime import datetime
+from decimal import Decimal
 from pathlib import Path
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.dateparse import parse_date
 from django.db import transaction
-from catalogs.models import Framework, Clause
+from openpyxl import load_workbook
+from core.models import AuditEvent
+from catalogs.models import Framework, Clause, Control
 from django.contrib.auth import get_user_model
 
 User = get_user_model()
 
 
 class Command(BaseCommand):
-    help = 'Import compliance frameworks from structured JSON or YAML files'
+    help = 'Import compliance frameworks from structured JSON, YAML, or XLSX files'
     
     def add_arguments(self, parser):
         parser.add_argument(
             'file_path',
             type=str,
-            help='Path to framework definition file (JSON or YAML)'
+            help='Path to framework definition file (JSON, YAML, or XLSX)'
         )
         parser.add_argument(
             '--update',
@@ -37,6 +41,37 @@ class Command(BaseCommand):
             action='store_true',
             help='Show what would be imported without actually importing'
         )
+        parser.add_argument(
+            '--name',
+            type=str,
+            help='Framework name for spreadsheet imports'
+        )
+        parser.add_argument(
+            '--short-name',
+            type=str,
+            help='Framework short name for spreadsheet imports'
+        )
+        parser.add_argument(
+            '--framework-version',
+            dest='framework_version',
+            type=str,
+            help='Framework version for spreadsheet imports'
+        )
+        parser.add_argument(
+            '--issuing-organization',
+            type=str,
+            help='Issuing organisation for spreadsheet imports'
+        )
+        parser.add_argument(
+            '--effective-date',
+            type=str,
+            help='Effective date for spreadsheet imports in YYYY-MM-DD format'
+        )
+        parser.add_argument(
+            '--sheet',
+            type=str,
+            help='Worksheet name for spreadsheet imports. Defaults to the first non-empty sheet.'
+        )
     
     def handle(self, *args, **options):
         file_path = Path(options['file_path'])
@@ -49,8 +84,10 @@ class Command(BaseCommand):
             framework_data = self.load_json_file(file_path)
         elif file_path.suffix.lower() in ['.yaml', '.yml']:
             framework_data = self.load_yaml_file(file_path)
+        elif file_path.suffix.lower() == '.xlsx':
+            framework_data = self.load_xlsx_file(file_path, options)
         else:
-            raise CommandError('Unsupported file format. Use .json, .yaml, or .yml files.')
+            raise CommandError('Unsupported file format. Use .json, .yaml, .yml, or .xlsx files.')
         
         # Validate framework data
         self.validate_framework_data(framework_data)
@@ -80,6 +117,14 @@ class Command(BaseCommand):
                     file_checksum, 
                     user, 
                     options['update']
+                )
+                self.record_import_audit_event(
+                    framework=framework,
+                    framework_data=framework_data,
+                    file_path=file_path,
+                    file_checksum=file_checksum,
+                    user=user,
+                    update_existing=options['update'],
                 )
                 
                 self.stdout.write(
@@ -112,6 +157,261 @@ class Command(BaseCommand):
             raise CommandError(f'Invalid YAML file: {e}')
         except Exception as e:
             raise CommandError(f'Error reading file: {e}')
+
+    def load_xlsx_file(self, file_path, options):
+        """Load framework data from a spreadsheet with common compliance headers."""
+        metadata = self.build_spreadsheet_metadata(file_path, options)
+        workbook = load_workbook(file_path, read_only=True, data_only=True)
+        worksheet = self.get_spreadsheet_worksheet(workbook, options.get('sheet'))
+        header_row, header_map = self.find_header_row(worksheet)
+
+        clauses = []
+        controls = []
+        seen_clause_ids = set()
+
+        for sort_order, row in enumerate(
+            worksheet.iter_rows(min_row=header_row + 1, values_only=True),
+            start=10,
+        ):
+            row_data = self.extract_spreadsheet_row(row, header_map)
+            if not row_data:
+                continue
+
+            clause_id = row_data['clause_id']
+            title = row_data['title']
+            description = row_data['description']
+            testing_procedures = row_data.get('testing_procedures', '')
+            guidance = row_data.get('implementation_guidance', '')
+
+            if clause_id not in seen_clause_ids:
+                clauses.append({
+                    'clause_id': clause_id,
+                    'title': title,
+                    'description': description,
+                    'clause_type': row_data.get('clause_type', 'control'),
+                    'criticality': row_data.get('criticality', 'medium'),
+                    'sort_order': sort_order,
+                    'parent_clause_id': row_data.get('parent_clause_id') or self.infer_parent_clause_id(clause_id),
+                    'implementation_guidance': guidance,
+                    'testing_procedures': testing_procedures,
+                    'external_references': row_data.get('external_references', {}),
+                })
+                seen_clause_ids.add(clause_id)
+
+            if self.should_create_control(row_data):
+                controls.append({
+                    'control_id': row_data.get('control_id') or self.build_control_id(metadata['short_name'], clause_id),
+                    'name': row_data.get('control_name') or title,
+                    'description': description,
+                    'control_type': row_data.get('control_type', 'administrative'),
+                    'status': row_data.get('control_status', 'planned'),
+                    'clauses': [clause_id],
+                    'implementation_details': guidance,
+                    'evidence_requirements': row_data.get('evidence_requirements') or testing_procedures,
+                    'documentation_links': row_data.get('documentation_links', []),
+                    'risk_rating': row_data.get('risk_rating', ''),
+                })
+
+        if not clauses:
+            raise CommandError(f'No importable clauses found in worksheet: {worksheet.title}')
+
+        return {
+            **metadata,
+            'description': metadata.get('description') or f'Imported from spreadsheet {file_path.name}',
+            'framework_type': 'financial' if 'pci' in metadata['short_name'].lower() else 'security',
+            'status': 'active',
+            'clauses': clauses,
+            'controls': controls,
+        }
+
+    def build_spreadsheet_metadata(self, file_path, options):
+        """Build framework metadata required by the common import pipeline."""
+        missing = [
+            option_name
+            for option_name, cli_name in [
+                ('name', '--name'),
+                ('framework_version', '--framework-version'),
+                ('issuing_organization', '--issuing-organization'),
+                ('effective_date', '--effective-date'),
+            ]
+            if not options.get(option_name)
+        ]
+        if missing:
+            cli_options = ', '.join(f'--{name.replace("_", "-")}' for name in missing)
+            raise CommandError(
+                f'Spreadsheet imports require framework metadata: {cli_options}'
+            )
+
+        return {
+            'name': options['name'],
+            'short_name': options.get('short_name') or self.slugify_identifier(file_path.stem)[:50],
+            'version': options['framework_version'],
+            'issuing_organization': options['issuing_organization'],
+            'effective_date': options['effective_date'],
+            'external_id': self.slugify_identifier(file_path.stem),
+            'imported_from': str(file_path),
+        }
+
+    def get_spreadsheet_worksheet(self, workbook, sheet_name):
+        """Return the requested worksheet, or the first worksheet with data."""
+        if sheet_name:
+            if sheet_name not in workbook.sheetnames:
+                raise CommandError(f'Worksheet not found: {sheet_name}')
+            return workbook[sheet_name]
+
+        for worksheet in workbook.worksheets:
+            if worksheet.max_row > 1 and worksheet.max_column > 1:
+                return worksheet
+        raise CommandError('No non-empty worksheet found in spreadsheet.')
+
+    def find_header_row(self, worksheet):
+        """Find a row containing a recognised clause/control identifier header."""
+        for row_number, row in enumerate(worksheet.iter_rows(values_only=True), start=1):
+            header_map = {}
+            for index, value in enumerate(row):
+                normalized = self.normalize_header(value)
+                canonical = self.canonical_header(normalized)
+                if canonical:
+                    header_map[canonical] = index
+
+            if 'clause_id' in header_map and ('description' in header_map or 'title' in header_map):
+                return row_number, header_map
+
+        raise CommandError(
+            'Could not find spreadsheet header row. Expected a recognised ID column and a requirement/title column.'
+        )
+
+    def extract_spreadsheet_row(self, row, header_map):
+        """Normalize a spreadsheet row into clause/control import fields."""
+        raw_clause_id = self.get_cell(row, header_map, 'clause_id')
+        description = self.get_cell(row, header_map, 'description') or self.get_cell(row, header_map, 'title')
+        if not raw_clause_id or not description:
+            return {}
+
+        clause_id = self.normalize_identifier(raw_clause_id)
+        description = self.clean_text(description)
+        title = self.clean_text(self.get_cell(row, header_map, 'title')) or self.extract_title(description, clause_id)
+
+        return {
+            'clause_id': clause_id,
+            'title': title,
+            'description': description,
+            'parent_clause_id': self.normalize_optional_identifier(self.get_cell(row, header_map, 'parent_clause_id')),
+            'testing_procedures': self.clean_text(self.get_cell(row, header_map, 'testing_procedures')),
+            'implementation_guidance': self.clean_text(self.get_cell(row, header_map, 'implementation_guidance')),
+            'evidence_requirements': self.clean_text(self.get_cell(row, header_map, 'evidence_requirements')),
+            'criticality': self.normalize_choice(self.get_cell(row, header_map, 'criticality'), {'low', 'medium', 'high', 'critical'}, 'medium'),
+            'clause_type': self.normalize_choice(
+                self.get_cell(row, header_map, 'clause_type'),
+                {'control', 'policy', 'procedure', 'documentation', 'assessment', 'monitoring', 'reporting'},
+                'control',
+            ),
+            'control_id': self.normalize_optional_identifier(self.get_cell(row, header_map, 'control_id')),
+            'control_name': self.clean_text(self.get_cell(row, header_map, 'control_name')),
+            'control_type': self.normalize_choice(
+                self.get_cell(row, header_map, 'control_type'),
+                {'preventive', 'detective', 'corrective', 'compensating', 'administrative', 'technical', 'physical'},
+                'administrative',
+            ),
+            'control_status': self.normalize_choice(
+                self.get_cell(row, header_map, 'control_status'),
+                {'planned', 'in_progress', 'implemented', 'testing', 'active', 'remediation', 'disabled', 'retired'},
+                'planned',
+            ),
+            'risk_rating': self.normalize_choice(
+                self.get_cell(row, header_map, 'risk_rating'),
+                {'low', 'medium', 'high', 'critical'},
+                '',
+            ),
+        }
+
+    def canonical_header(self, normalized_header):
+        """Map common spreadsheet headers to importer field names."""
+        header_aliases = {
+            'pci dss id': 'clause_id',
+            'id': 'clause_id',
+            'requirement id': 'clause_id',
+            'clause id': 'clause_id',
+            'control id': 'control_id',
+            'parent id': 'parent_clause_id',
+            'parent clause id': 'parent_clause_id',
+            'defined approach requirements': 'description',
+            'requirement': 'description',
+            'requirements': 'description',
+            'description': 'description',
+            'control objective': 'description',
+            'title': 'title',
+            'control title': 'control_name',
+            'name': 'title',
+            'defined approach testing procedures': 'testing_procedures',
+            'testing procedures': 'testing_procedures',
+            'test procedures': 'testing_procedures',
+            'evidence': 'evidence_requirements',
+            'evidence requirements': 'evidence_requirements',
+            'evidence required': 'evidence_requirements',
+            'guidance': 'implementation_guidance',
+            'implementation guidance': 'implementation_guidance',
+            'criticality': 'criticality',
+            'risk rating': 'risk_rating',
+            'clause type': 'clause_type',
+            'control type': 'control_type',
+            'control status': 'control_status',
+        }
+        return header_aliases.get(normalized_header)
+
+    def normalize_header(self, value):
+        return re.sub(r'\s+', ' ', str(value or '').strip().lower())
+
+    def get_cell(self, row, header_map, field_name):
+        index = header_map.get(field_name)
+        if index is None or index >= len(row):
+            return ''
+        return row[index]
+
+    def clean_text(self, value):
+        if value is None:
+            return ''
+        return re.sub(r'\s+', ' ', str(value).strip())
+
+    def normalize_identifier(self, value):
+        if value is None or value == '':
+            return ''
+        if isinstance(value, float | int):
+            value = Decimal(str(value))
+        if isinstance(value, Decimal):
+            return format(value.normalize(), 'f')
+        return str(value).strip()
+
+    def normalize_optional_identifier(self, value):
+        normalized = self.normalize_identifier(value)
+        return normalized or ''
+
+    def slugify_identifier(self, value):
+        return re.sub(r'[^A-Z0-9]+', '-', str(value).upper()).strip('-')
+
+    def build_control_id(self, framework_short_name, clause_id):
+        return self.slugify_identifier(f'{framework_short_name}-{clause_id}')[:50]
+
+    def infer_parent_clause_id(self, clause_id):
+        if '.' not in clause_id:
+            return ''
+        return clause_id.rsplit('.', 1)[0]
+
+    def extract_title(self, description, clause_id):
+        text = re.sub(rf'^{re.escape(clause_id)}\s*', '', description).strip()
+        first_sentence = re.split(r'(?<=[.!?])\s+', text, maxsplit=1)[0]
+        return first_sentence[:300] or clause_id
+
+    def normalize_choice(self, value, valid_choices, default):
+        normalized = self.clean_text(value).lower().replace('-', '_').replace(' ', '_')
+        return normalized if normalized in valid_choices else default
+
+    def should_create_control(self, row_data):
+        return bool(
+            row_data.get('control_id')
+            or row_data.get('testing_procedures')
+            or row_data.get('evidence_requirements')
+        )
     
     def calculate_file_checksum(self, file_path):
         """Calculate SHA256 checksum of the file."""
@@ -150,15 +450,17 @@ class Command(BaseCommand):
         
         self.stdout.write(f'Framework Name: {framework_data["name"]}')
         self.stdout.write(f'Version: {framework_data["version"]}')
-        self.stdout.write(f'Issuing Organization: {framework_data["issuing_organization"]}')
+        self.stdout.write(f'Issuing Organisation: {framework_data["issuing_organization"]}')
         self.stdout.write(f'Effective Date: {framework_data["effective_date"]}')
         self.stdout.write(f'File Checksum: {checksum[:16]}...')
         
         clauses = framework_data.get('clauses', [])
+        controls = framework_data.get('controls', [])
         self.stdout.write(f'Total Clauses: {len(clauses)}')
+        self.stdout.write(f'Total Controls: {len(controls)}')
         
         if clauses:
-            self.stdout.write('\\nSample clauses:')
+            self.stdout.write('\nSample clauses:')
             for clause in clauses[:3]:  # Show first 3 clauses
                 self.stdout.write(f'  - {clause["clause_id"]}: {clause["title"]}')
             
@@ -232,8 +534,38 @@ class Command(BaseCommand):
         # Import clauses
         clauses_data = data.get('clauses', [])
         self.import_clauses(framework, clauses_data)
+
+        # Import controls after clauses so many-to-many links are stable.
+        controls_data = data.get('controls', [])
+        self.import_controls(framework, controls_data, user)
         
         return framework
+
+    def record_import_audit_event(
+        self,
+        *,
+        framework,
+        framework_data,
+        file_path,
+        file_checksum,
+        user,
+        update_existing,
+    ):
+        """Record the catalogue import in the tenant audit trail."""
+        AuditEvent.objects.create(
+            user=user,
+            event='FRAMEWORK_IMPORTED',
+            details={
+                'framework_id': framework.id,
+                'framework_name': framework.name,
+                'framework_version': framework.version,
+                'source_file': str(file_path),
+                'source_checksum': file_checksum,
+                'updated_existing': update_existing,
+                'clause_count': len(framework_data.get('clauses', [])),
+                'control_count': len(framework_data.get('controls', [])),
+            },
+        )
     
     def import_clauses(self, framework, clauses_data):
         """Import clauses for the framework."""
@@ -294,3 +626,50 @@ class Command(BaseCommand):
                     )
         
         self.stdout.write(f'Imported {len(clause_objects)} clauses')
+
+    def import_controls(self, framework, controls_data, user):
+        """Import controls and link them to already imported clauses."""
+        if not controls_data:
+            self.stdout.write('Imported 0 controls')
+            return
+
+        db_clauses = {
+            clause.clause_id: clause
+            for clause in Clause.objects.filter(framework=framework)
+        }
+        imported_count = 0
+
+        for control_data in controls_data:
+            clause_ids = control_data.get('clauses', [])
+            linked_clauses = [
+                db_clauses[clause_id]
+                for clause_id in clause_ids
+                if clause_id in db_clauses
+            ]
+            if not linked_clauses:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f'Skipping control {control_data["control_id"]}: no matching clauses found'
+                    )
+                )
+                continue
+
+            control_defaults = {
+                'name': control_data['name'][:200],
+                'description': control_data.get('description', ''),
+                'control_type': control_data.get('control_type', 'administrative'),
+                'status': control_data.get('status', 'planned'),
+                'implementation_details': control_data.get('implementation_details', ''),
+                'evidence_requirements': control_data.get('evidence_requirements', ''),
+                'documentation_links': control_data.get('documentation_links', []),
+                'risk_rating': control_data.get('risk_rating', ''),
+                'created_by': user,
+            }
+            control, _ = Control.objects.update_or_create(
+                control_id=control_data['control_id'],
+                defaults=control_defaults,
+            )
+            control.clauses.add(*linked_clauses)
+            imported_count += 1
+
+        self.stdout.write(f'Imported {imported_count} controls')

--- a/app/catalogs/tests.py
+++ b/app/catalogs/tests.py
@@ -9,7 +9,8 @@ from rest_framework.test import APITestCase
 from rest_framework import status
 from django_tenants.test.cases import TenantTestCase
 from django_tenants.test.client import TenantClient
-from core.models import Tenant
+from openpyxl import Workbook
+from core.models import AuditEvent, Tenant
 from .models import Framework, Clause, Control, ControlEvidence, FrameworkMapping, ControlAssessment, AssessmentEvidence
 from .management.commands.import_framework import Command as ImportCommand
 import tempfile
@@ -493,6 +494,22 @@ class ImportFrameworkCommandTest(TransactionTestCase):
         json.dump(data, temp_file, indent=2)
         temp_file.close()
         return temp_file.name
+
+    def create_temp_xlsx_file(self, rows):
+        """Create a temporary XLSX file with framework rows."""
+        workbook = Workbook()
+        worksheet = workbook.active
+        worksheet.title = 'Framework'
+        for row in rows:
+            worksheet.append(row)
+
+        temp_file = tempfile.NamedTemporaryFile(
+            suffix='.xlsx',
+            delete=False
+        )
+        temp_file.close()
+        workbook.save(temp_file.name)
+        return temp_file.name
     
     def test_import_json_framework(self):
         """Test importing framework from JSON file."""
@@ -549,6 +566,88 @@ class ImportFrameworkCommandTest(TransactionTestCase):
             
             os.unlink(updated_file)
             
+        finally:
+            os.unlink(temp_file)
+
+    def test_import_xlsx_framework_creates_clauses_and_controls(self):
+        """Test importing a spreadsheet framework with generated controls."""
+        temp_file = self.create_temp_xlsx_file([
+            ['Source', 'Test spreadsheet'],
+            ['Requirement ID', 'Requirement', 'Testing Procedures', 'Guidance'],
+            ['1', 'Governance requirements are defined.', '', ''],
+            ['1.1', 'Access reviews are performed.', 'Inspect access review evidence.', 'Review access quarterly.'],
+            ['1.10', 'Privileged access is reviewed.', 'Inspect privileged access reports.', 'Use PAM reports.'],
+        ])
+
+        try:
+            call_command(
+                'import_framework',
+                temp_file,
+                '--name', 'Spreadsheet Security Framework',
+                '--short-name', 'SSF',
+                '--framework-version', '2024',
+                '--issuing-organization', 'Spreadsheet Standards Body',
+                '--effective-date', '2024-01-01',
+                user=self.user.username,
+            )
+
+            framework = Framework.objects.get(name='Spreadsheet Security Framework')
+            self.assertEqual(framework.short_name, 'SSF')
+            self.assertEqual(framework.clauses.count(), 3)
+
+            parent_clause = framework.clauses.get(clause_id='1')
+            access_clause = framework.clauses.get(clause_id='1.1')
+            privileged_clause = framework.clauses.get(clause_id='1.10')
+            self.assertEqual(access_clause.parent_clause, parent_clause)
+            self.assertEqual(privileged_clause.parent_clause, parent_clause)
+
+            access_control = Control.objects.get(control_id='SSF-1-1')
+            self.assertEqual(access_control.name, 'Access reviews are performed.')
+            self.assertEqual(access_control.control_type, 'administrative')
+            self.assertEqual(access_control.evidence_requirements, 'Inspect access review evidence.')
+            self.assertIn(access_clause, access_control.clauses.all())
+
+            privileged_control = Control.objects.get(control_id='SSF-1-10')
+            self.assertIn(privileged_clause, privileged_control.clauses.all())
+            self.assertFalse(Control.objects.filter(control_id='SSF-1').exists())
+
+            audit_event = AuditEvent.objects.get(event='FRAMEWORK_IMPORTED')
+            self.assertEqual(audit_event.user, self.user)
+            self.assertEqual(audit_event.details['framework_name'], framework.name)
+            self.assertEqual(audit_event.details['framework_version'], '2024')
+            self.assertEqual(audit_event.details['clause_count'], 3)
+            self.assertEqual(audit_event.details['control_count'], 2)
+            self.assertFalse(audit_event.details['updated_existing'])
+        finally:
+            os.unlink(temp_file)
+
+    def test_import_xlsx_framework_update_is_idempotent(self):
+        """Test spreadsheet update replaces clauses without duplicating controls."""
+        temp_file = self.create_temp_xlsx_file([
+            ['Requirement ID', 'Requirement', 'Testing Procedures'],
+            ['1', 'Governance requirements are defined.', 'Inspect governance evidence.'],
+        ])
+
+        try:
+            command_args = [
+                'import_framework',
+                temp_file,
+                '--name', 'Spreadsheet Update Framework',
+                '--short-name', 'SUF',
+                '--framework-version', '2024',
+                '--issuing-organization', 'Spreadsheet Standards Body',
+                '--effective-date', '2024-01-01',
+                '--update',
+            ]
+
+            call_command(*command_args, user=self.user.username)
+            call_command(*command_args, user=self.user.username)
+
+            framework = Framework.objects.get(name='Spreadsheet Update Framework')
+            self.assertEqual(framework.clauses.count(), 1)
+            self.assertEqual(Control.objects.filter(control_id='SUF-1').count(), 1)
+            control = Control.objects.get(control_id='SUF-1')
+            self.assertEqual(control.clauses.filter(framework=framework).count(), 1)
         finally:
             os.unlink(temp_file)
 

--- a/docs/planning/framework_import_guide.md
+++ b/docs/planning/framework_import_guide.md
@@ -1,0 +1,77 @@
+# Framework Import Guide
+
+## Purpose
+
+Frameworks such as ISO 27001, PCI DSS, NIST CSF and CIS Controls should be loaded as versioned catalogue data rather than hard-coded workflow logic. This keeps framework updates repeatable, auditable and tenant-safe.
+
+## Supported Formats
+
+Use the `import_framework` management command for structured framework imports:
+
+```bash
+python manage.py import_framework path/to/framework.json
+python manage.py import_framework path/to/framework.yaml
+python manage.py import_framework path/to/framework.xlsx \
+  --name "PCI DSS" \
+  --short-name PCI-DSS \
+  --framework-version "4.0" \
+  --issuing-organization "PCI Security Standards Council" \
+  --effective-date 2022-03-31 \
+  --sheet "Original Content"
+```
+
+Use `--dry-run` before a real import to verify the detected clause and control counts. Use `--update` only when replacing an existing framework with the same name and version.
+
+## Spreadsheet Requirements
+
+Spreadsheet imports require explicit metadata because workbooks usually do not carry reliable framework identity fields:
+
+- `--name`
+- `--framework-version`
+- `--issuing-organization`
+- `--effective-date`
+- `--short-name` is optional but recommended because generated control identifiers use it.
+
+The importer detects a header row containing a recognised ID column and a requirement/title column. Common aliases are supported, including:
+
+- `PCI DSS ID`, `Requirement ID`, `Clause ID`, `ID`
+- `Defined Approach Requirements`, `Requirement`, `Description`, `Control Objective`
+- `Defined Approach Testing Procedures`, `Testing Procedures`, `Test Procedures`
+- `Guidance`, `Implementation Guidance`
+- `Evidence`, `Evidence Requirements`
+
+Each importable row creates a clause. Rows with testing procedures, evidence requirements or an explicit control ID also create or update a linked control.
+
+## Versioning
+
+Framework versioning is based on the catalogue identity `(name, version)`.
+
+- Importing a new version should use a new `--framework-version` value and creates a separate `Framework` record.
+- Re-importing the same version requires `--update`; this replaces the framework's clauses and upserts generated controls.
+- Imported frameworks store `imported_from` and `import_checksum` so the source file can be traced later.
+- Do not use `--update` for an official version change. Create a new framework version instead so historical assessments can still reference the version they were performed against.
+
+## Audit Trail
+
+Successful imports write a tenant-scoped `AuditEvent` named `FRAMEWORK_IMPORTED`.
+
+The audit payload includes:
+
+- framework ID, name and version
+- source file path
+- source file checksum
+- whether an existing framework version was updated
+- imported clause and control counts
+- importing user when `--user` is supplied
+
+This gives operators enough evidence to answer when a catalogue version entered the tenant, what file was used and whether it was a replacement import.
+
+## Future Frameworks
+
+For each new framework:
+
+1. Preserve the source spreadsheet or structured file in the controlled template library.
+2. Run a dry-run import and record the detected counts in the PR.
+3. Import into local/test data using a stable short name.
+4. Add or update tests when a new spreadsheet shape introduces new headers.
+5. Link relevant templates and sample documents to the imported clauses or controls in the template-library import work.


### PR DESCRIPTION
Closes #132

## Summary
- Extends import_framework to load .xlsx framework spreadsheets with explicit metadata flags.
- Detects common compliance headers, including PCI DSS style requirement/testing/guidance columns.
- Creates clauses for importable rows and generated or explicit controls for rows with testing or evidence content.
- Preserves catalogue versioning through the existing (name, version) framework identity and records source checksum/import metadata.
- Writes a FRAMEWORK_IMPORTED AuditEvent with source file, checksum, counts and update status.
- Adds an operator guide for future framework imports.

## Verification
- ruff check catalogs/management/commands/import_framework.py catalogs/tests.py
- pytest catalogs/tests.py::ImportFrameworkCommandTest -q
- Real PCI workbook smoke: dry-run and import of Axim App/PCI Module/PCI V4.0.xlsx sheet "Original Content" produced 351 clauses and 281 controls, with a FRAMEWORK_IMPORTED audit event.