### PR TITLE
Add operator product analytics

### DIFF
--- a/app/analytics/operator.py
+++ b/app/analytics/operator.py
@@ -1,0 +1,232 @@
+import csv
+import io
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+
+from django.contrib.auth import get_user_model
+from django.db.models import Max
+from django_tenants.utils import schema_context, tenant_context
+from django.utils import timezone
+
+from billing.entitlements import MODULE_CATALOG
+from core.models import AuditEvent, Document, Subscription, Tenant
+from exports.models import TenantDataExport
+from policies.models import PolicyAcknowledgment, PolicyDistribution
+from training.models import CampaignDelivery, VideoView
+
+User = get_user_model()
+
+
+@dataclass(frozen=True)
+class OperatorAnalyticsWindow:
+    start_at: datetime
+    end_at: datetime
+
+    @classmethod
+    def from_days(cls, days):
+        safe_days = min(max(int(days or 90), 1), 365)
+        end_at = timezone.now()
+        return cls(start_at=end_at - timezone.timedelta(days=safe_days), end_at=end_at)
+
+
+class OperatorProductAnalyticsService:
+    """
+    Aggregate product usage metrics for Axim operators without exposing tenant content.
+    """
+
+    def __init__(self, window=None):
+        self.window = window or OperatorAnalyticsWindow.from_days(90)
+
+    def build_dashboard(self):
+        with schema_context('public'):
+            tenants = list(Tenant.objects.order_by('name'))
+            subscriptions = {
+                subscription.tenant_id: subscription
+                for subscription in Subscription.objects.select_related('tenant', 'plan')
+            }
+
+        tenant_summaries = []
+        module_adoption = Counter()
+        plan_counts = Counter()
+        subscription_status_counts = Counter()
+        aggregate_usage = Counter()
+        active_tenant_count = 0
+        collection_errors = []
+
+        for tenant in tenants:
+            subscription = subscriptions.get(tenant.id)
+            enabled_modules = subscription.get_enabled_modules() if subscription else []
+            module_adoption.update(enabled_modules)
+            plan_slug = subscription.plan.slug if subscription else tenant.current_plan
+            subscription_status = subscription.status if subscription else 'none'
+            plan_counts[plan_slug] += 1
+            subscription_status_counts[subscription_status] += 1
+
+            try:
+                tenant_usage = self._tenant_usage(tenant)
+            except Exception as exc:  # pragma: no cover - defensive for partially migrated tenants
+                collection_errors.append({'tenant_schema': tenant.schema_name, 'error': str(exc)})
+                tenant_usage = self._empty_usage()
+
+            aggregate_usage.update(tenant_usage['usage_counts'])
+            if tenant_usage['last_activity_at']:
+                active_tenant_count += 1
+
+            tenant_summaries.append({
+                'tenant_id': tenant.id,
+                'tenant_slug': tenant.slug,
+                'tenant_name': tenant.name,
+                'schema_name': tenant.schema_name,
+                'plan': plan_slug,
+                'subscription_status': subscription_status,
+                'enabled_modules': enabled_modules,
+                'user_count': tenant_usage['user_count'],
+                'usage_counts': tenant_usage['usage_counts'],
+                'last_activity_at': tenant_usage['last_activity_at'],
+            })
+
+        total_tenants = len(tenants)
+        return {
+            'generated_at': timezone.now().isoformat(),
+            'window': {
+                'start_at': self.window.start_at.isoformat(),
+                'end_at': self.window.end_at.isoformat(),
+            },
+            'summary': {
+                'total_tenants': total_tenants,
+                'active_tenants': active_tenant_count,
+                'inactive_tenants': total_tenants - active_tenant_count,
+                'trial_tenants': subscription_status_counts.get('trialing', 0),
+                'paid_active_tenants': self._paid_active_count(subscriptions.values()),
+                'past_due_tenants': subscription_status_counts.get('past_due', 0),
+                'cancelled_tenants': subscription_status_counts.get('canceled', 0),
+                'collection_error_count': len(collection_errors),
+            },
+            'plan_mix': dict(sorted(plan_counts.items())),
+            'subscription_status_mix': dict(sorted(subscription_status_counts.items())),
+            'module_adoption': [
+                {
+                    'module_key': module.key,
+                    'module_label': module.label,
+                    'tenant_count': module_adoption.get(module.key, 0),
+                    'adoption_rate': self._percentage(module_adoption.get(module.key, 0), total_tenants),
+                }
+                for module in MODULE_CATALOG
+            ],
+            'usage_totals': dict(sorted(aggregate_usage.items())),
+            'tenant_summaries': tenant_summaries,
+            'privacy': {
+                'tenant_content_excluded': True,
+                'included_fields': [
+                    'tenant identifiers',
+                    'subscription status',
+                    'enabled modules',
+                    'aggregate counts',
+                    'last activity timestamp',
+                ],
+            },
+            'collection_errors': collection_errors,
+        }
+
+    def to_csv(self, dashboard):
+        buffer = io.StringIO()
+        writer = csv.DictWriter(
+            buffer,
+            fieldnames=[
+                'tenant_id',
+                'tenant_slug',
+                'tenant_name',
+                'schema_name',
+                'plan',
+                'subscription_status',
+                'enabled_modules',
+                'user_count',
+                'document_uploads',
+                'data_exports',
+                'audit_events',
+                'policy_acknowledgements',
+                'policy_distributions',
+                'training_deliveries',
+                'training_views',
+                'training_completions',
+                'last_activity_at',
+            ],
+        )
+        writer.writeheader()
+        for summary in dashboard['tenant_summaries']:
+            usage = summary['usage_counts']
+            writer.writerow({
+                'tenant_id': summary['tenant_id'],
+                'tenant_slug': summary['tenant_slug'],
+                'tenant_name': summary['tenant_name'],
+                'schema_name': summary['schema_name'],
+                'plan': summary['plan'],
+                'subscription_status': summary['subscription_status'],
+                'enabled_modules': ','.join(summary['enabled_modules']),
+                'user_count': summary['user_count'],
+                'document_uploads': usage['document_uploads'],
+                'data_exports': usage['data_exports'],
+                'audit_events': usage['audit_events'],
+                'policy_acknowledgements': usage['policy_acknowledgements'],
+                'policy_distributions': usage['policy_distributions'],
+                'training_deliveries': usage['training_deliveries'],
+                'training_views': usage['training_views'],
+                'training_completions': usage['training_completions'],
+                'last_activity_at': summary['last_activity_at'] or '',
+            })
+        return buffer.getvalue()
+
+    def _tenant_usage(self, tenant):
+        with tenant_context(tenant):
+            last_activity = AuditEvent.objects.aggregate(last_activity=Max('at'))['last_activity']
+            usage_counts = {
+                'document_uploads': Document.objects.filter(uploaded_at__gte=self.window.start_at).count(),
+                'data_exports': TenantDataExport.objects.filter(requested_at__gte=self.window.start_at).count(),
+                'audit_events': AuditEvent.objects.filter(at__gte=self.window.start_at).count(),
+                'policy_acknowledgements': PolicyAcknowledgment.objects.filter(
+                    acknowledged_at__gte=self.window.start_at
+                ).count(),
+                'policy_distributions': PolicyDistribution.objects.filter(
+                    distributed_at__gte=self.window.start_at
+                ).count(),
+                'training_deliveries': CampaignDelivery.objects.filter(sent_at__gte=self.window.start_at).count(),
+                'training_views': VideoView.objects.filter(started_at__gte=self.window.start_at).count(),
+                'training_completions': VideoView.objects.filter(
+                    started_at__gte=self.window.start_at,
+                    completed=True,
+                ).count(),
+            }
+            return {
+                'user_count': User.objects.filter(is_active=True).count(),
+                'usage_counts': usage_counts,
+                'last_activity_at': last_activity.isoformat() if last_activity else None,
+            }
+
+    def _empty_usage(self):
+        return {
+            'user_count': 0,
+            'usage_counts': {
+                'document_uploads': 0,
+                'data_exports': 0,
+                'audit_events': 0,
+                'policy_acknowledgements': 0,
+                'policy_distributions': 0,
+                'training_deliveries': 0,
+                'training_views': 0,
+                'training_completions': 0,
+            },
+            'last_activity_at': None,
+        }
+
+    def _paid_active_count(self, subscriptions):
+        return sum(
+            1
+            for subscription in subscriptions
+            if subscription.status == 'active' and subscription.plan.price_monthly > 0
+        )
+
+    def _percentage(self, value, total):
+        if not total:
+            return 0.0
+        return round((value / total) * 100, 1)

--- a/app/analytics/tests.py
+++ b/app/analytics/tests.py
@@ -1,0 +1,163 @@
+from types import SimpleNamespace
+
+from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
+from django.test import TestCase
+from django.urls import reverse
+from django_tenants.utils import schema_context, tenant_context
+from rest_framework import status
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
+
+from analytics.operator import OperatorProductAnalyticsService
+from analytics.views import operator_usage_dashboard
+from core.models import AuditEvent, Document, Domain, Plan, Subscription, Tenant
+from exports.models import TenantDataExport
+
+User = get_user_model()
+
+
+class OperatorProductAnalyticsTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.factory = APIRequestFactory()
+        with schema_context('public'):
+            self.free_plan = Plan.objects.create(
+                name='Free',
+                slug='free',
+                price_monthly=0,
+                included_modules=['frameworks'],
+            )
+            self.basic_plan = Plan.objects.create(
+                name='Basic',
+                slug='basic',
+                price_monthly=49,
+                included_modules=['frameworks', 'risk', 'exports'],
+            )
+            self.tenant_a = self._create_tenant('tenant_a_analytics', 'tenant-a-analytics', 'Tenant A')
+            self.tenant_b = self._create_tenant('tenant_b_analytics', 'tenant-b-analytics', 'Tenant B')
+            Subscription.objects.create(
+                tenant=self.tenant_a,
+                plan=self.basic_plan,
+                status='active',
+                enabled_modules=['frameworks', 'risk', 'exports'],
+            )
+            Subscription.objects.create(
+                tenant=self.tenant_b,
+                plan=self.free_plan,
+                status='trialing',
+                trial_module='frameworks',
+            )
+            self.public_operator = User.objects.create_superuser(
+                username='public-operator',
+                email='operator@axim.test',
+                password='testpass123',
+            )
+
+        self.tenant_staff = self._create_user(self.tenant_a, 'operator', is_staff=True)
+        self.normal_user = self._create_user(self.tenant_a, 'normal', is_staff=False)
+        tenant_b_user = self._create_user(self.tenant_b, 'tenantb', is_staff=False)
+
+        with tenant_context(self.tenant_a):
+            document = Document(
+                title='Confidential acquisition plan',
+                uploaded_by=self.tenant_staff,
+                mime_type='text/plain',
+            )
+            document.file.save('confidential-plan.txt', ContentFile(b'classified'), save=True)
+            TenantDataExport.objects.create(
+                title='Secret audit export',
+                export_format='xlsx',
+                requested_by=self.tenant_staff,
+            )
+            AuditEvent.objects.create(
+                user=self.tenant_staff,
+                event='SECRET_CUSTOMER_WORKFLOW',
+                details={'document_title': 'Confidential acquisition plan'},
+            )
+
+        with tenant_context(self.tenant_b):
+            AuditEvent.objects.create(
+                user=tenant_b_user,
+                event='TENANT_B_ACTIVITY',
+                details={'sensitive': 'do not expose'},
+            )
+
+    def test_operator_dashboard_aggregates_usage_without_tenant_content(self):
+        dashboard = OperatorProductAnalyticsService().build_dashboard()
+
+        self.assertEqual(dashboard['summary']['total_tenants'], 2)
+        self.assertEqual(dashboard['summary']['active_tenants'], 2)
+        self.assertEqual(dashboard['summary']['trial_tenants'], 1)
+        self.assertEqual(dashboard['summary']['paid_active_tenants'], 1)
+        self.assertEqual(dashboard['usage_totals']['document_uploads'], 1)
+        self.assertEqual(dashboard['usage_totals']['data_exports'], 1)
+        self.assertEqual(dashboard['usage_totals']['audit_events'], 2)
+
+        module_counts = {
+            module['module_key']: module['tenant_count']
+            for module in dashboard['module_adoption']
+        }
+        self.assertEqual(module_counts['frameworks'], 2)
+        self.assertEqual(module_counts['risk'], 1)
+
+        response_text = str(dashboard)
+        self.assertNotIn('Confidential acquisition plan', response_text)
+        self.assertNotIn('Secret audit export', response_text)
+        self.assertNotIn('do not expose', response_text)
+        self.assertTrue(dashboard['privacy']['tenant_content_excluded'])
+
+    def test_operator_endpoint_requires_staff_user(self):
+        self.client.defaults['HTTP_HOST'] = self.tenant_a_domain
+        self.client.force_authenticate(user=self.normal_user)
+
+        response = self.client.get(reverse('analytics:operator_usage_dashboard'))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_operator_endpoint_rejects_tenant_staff_user(self):
+        self.client.defaults['HTTP_HOST'] = self.tenant_a_domain
+        self.client.force_authenticate(user=self.tenant_staff)
+
+        response = self.client.get(reverse('analytics:operator_usage_dashboard'))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_operator_endpoint_returns_json_and_csv(self):
+        response = self._operator_request({'days': '30'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['summary']['total_tenants'], 2)
+
+        csv_response = self._operator_request({'export': 'csv'})
+
+        self.assertEqual(csv_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(csv_response['Content-Type'], 'text/csv')
+        csv_content = csv_response.content.decode('utf-8')
+        self.assertIn('tenant_slug', csv_content)
+        self.assertNotIn('Confidential acquisition plan', csv_content)
+
+    def _create_tenant(self, schema_name, slug, name):
+        tenant = Tenant.objects.create(schema_name=schema_name, slug=slug, name=name)
+        domain = Domain.objects.create(
+            tenant=tenant,
+            domain=f'{slug}.localhost',
+            is_primary=True,
+        )
+        if slug == 'tenant-a-analytics':
+            self.tenant_a_domain = domain.domain
+        return tenant
+
+    def _create_user(self, tenant, username, is_staff):
+        with tenant_context(tenant):
+            return User.objects.create_user(
+                username=username,
+                email=f'{username}@example.com',
+                password='testpass123',
+                is_staff=is_staff,
+            )
+
+    def _operator_request(self, query_params):
+        request = self.factory.get('/api/analytics/operator/usage/', query_params)
+        request.tenant = SimpleNamespace(schema_name='public')
+        force_authenticate(request, user=self.public_operator)
+        return operator_usage_dashboard(request)

--- a/app/analytics/urls.py
+++ b/app/analytics/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
 
     # Operational dashboards
     path('operational/', views.operational_dashboard, name='operational_dashboard'),
+    path('operator/usage/', views.operator_usage_dashboard, name='operator_usage_dashboard'),
 
     # Export and reporting
     path('export/', views.export_report, name='export_report'),

--- a/app/analytics/views.py
+++ b/app/analytics/views.py
@@ -10,6 +10,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework import status
+from django.conf import settings
 from django.http import JsonResponse, HttpResponse, Http404
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
@@ -22,10 +23,55 @@ import mimetypes
 
 from .services import CrossModuleAnalyticsService, AnalyticsReportGenerator
 from .models import AnalyticsReport, DashboardConfiguration
+from .operator import OperatorAnalyticsWindow, OperatorProductAnalyticsService
 # from .tasks import generate_analytics_report, cache_analytics_metrics  # TODO: Add PDF dependencies
 from billing.decorators import require_advanced_reporting
 
 logger = logging.getLogger(__name__)
+
+
+def _is_operator(user, tenant):
+    public_schema_name = getattr(settings, 'PUBLIC_SCHEMA_NAME', 'public')
+    return bool(
+        user
+        and user.is_authenticated
+        and (user.is_staff or user.is_superuser)
+        and getattr(tenant, 'schema_name', None) == public_schema_name
+    )
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def operator_usage_dashboard(request):
+    """
+    Operator-only product analytics across tenants.
+
+    Returns aggregate tenant, subscription, module adoption and usage metrics
+    without returning tenant-owned content such as document names or policy text.
+    """
+    if not _is_operator(request.user, getattr(request, 'tenant', None)):
+        return Response(
+            {'detail': 'Only staff operators can access product analytics.'},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
+    try:
+        window = OperatorAnalyticsWindow.from_days(request.query_params.get('days', 90))
+    except ValueError:
+        return Response(
+            {'days': ['Enter a whole number between 1 and 365.']},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    service = OperatorProductAnalyticsService(window=window)
+    dashboard = service.build_dashboard()
+
+    if request.query_params.get('export') == 'csv':
+        response = HttpResponse(service.to_csv(dashboard), content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename="operator-product-analytics.csv"'
+        return response
+
+    return Response(dashboard)
 
 
 @api_view(['GET'])

--- a/app/billing/middleware.py
+++ b/app/billing/middleware.py
@@ -21,6 +21,8 @@ class PlanEnforcementMiddleware(MiddlewareMixin):
         module_key = get_module_for_path(request.path)
         if not module_key or not hasattr(request, 'tenant'):
             return None
+        if request.path.startswith('/api/analytics/operator/'):
+            return None
 
         try:
             tenant = get_public_tenant(request.tenant.schema_name)

--- a/docs/adr/0038-operator-product-analytics.md
+++ b/docs/adr/0038-operator-product-analytics.md
@@ -1,0 +1,33 @@
+# ADR 0038: Operator Product Analytics
+
+## Status
+
+Accepted
+
+## Context
+
+Axim needs product analytics for marketing, support and product improvement. Existing analytics endpoints are tenant-visible GRC dashboards, so they must not be reused as cross-tenant operator reporting without explicit privacy controls.
+
+## Decision
+
+Add an operator-only analytics endpoint at `/api/analytics/operator/usage/`.
+
+The endpoint aggregates:
+
+- tenant and subscription counts;
+- plan and subscription status mix;
+- module adoption based on enabled subscription modules;
+- document upload, export, audit event, policy acknowledgement and training engagement counts;
+- last activity timestamp per tenant.
+
+The endpoint is restricted to staff/superusers authenticated on the public/platform schema and supports JSON plus CSV export through `?export=csv`. Tenant staff accounts are intentionally rejected because the response spans multiple tenants.
+
+The reporting window uses timezone-aware server-side datetimes. A `days` filter represents a rolling absolute time window and is not derived from operator browser locale or geolocation.
+
+## Privacy Controls
+
+The operator response intentionally excludes tenant-owned content. It returns tenant identifiers, subscription state, enabled module keys, aggregate counts and last activity timestamps. It does not return document names, policy text, audit details, export titles, training titles, evidence content or user personal activity logs.
+
+## Consequences
+
+The first version uses durable business records that already exist rather than adding request-level analytics writes. This avoids extra write load on every API request and gives operators useful adoption and engagement signals immediately. If Axim later needs clickstream-style product analytics, that should be implemented as a separate event pipeline with sampling, retention and consent controls.

--- a/docs/planning/requirements_traceability_matrix.md
+++ b/docs/planning/requirements_traceability_matrix.md
@@ -37,7 +37,7 @@ Status values:
 | RTM-024 | Calendar module | Missing | No unified calendar/event module found. | #136 |
 | RTM-025 | Vulnerability scanning | Missing | Policies/controls mention scanning; scanner integration not implemented. | #137 |
 | RTM-026 | User activity tracking | Partial | AuditEvent exists; coverage and UI/reporting should be validated. | #139 |
-| RTM-027 | Product analytics for Axim | Partial | GRC analytics exist; operator/product usage metrics need explicit design. | #143 |
+| RTM-027 | Product analytics for Axim | Done | Operator-only analytics aggregate tenant, subscription, module adoption and usage metrics without exposing tenant content. | #143 |
 | RTM-028 | Client data exports in spreadsheet/PDF | Partial | Reporting/export modules exist; coverage and API reliability incomplete. | #130, #139 |
 | RTM-029 | Asset register | Missing | Source ZIP includes asset register; no first-class module found. | #134 |
 | RTM-030 | Regulatory and contractual sheet | Done | `compliance.RegulatoryRequirement` and `GovernanceArtefact` model applicable obligations and link them to frameworks, controls, risks and documents. | #142 |


### PR DESCRIPTION
## Summary
- add an operator-only product analytics service and endpoint for tenant, subscription, module adoption and usage metrics
- restrict cross-tenant analytics to staff/superusers authenticated on the public/platform schema, rejecting tenant staff accounts
- support JSON and CSV export through `?export=csv`, with ADR coverage for privacy and timezone-aware rolling windows
- mark RTM-027 as done

Closes #143

## Tests
- `ruff check app/analytics app/billing`
- `pytest app/analytics/tests.py -q` (4 passed)
- `pytest app/core/tests.py::TestPlanEnforcementService -q` (2 passed)
- `python manage.py makemigrations --check --dry-run`
- `python manage.py check`
- `git diff --check`