### PR TITLE
Audit document export lifecycle events

### DIFF
--- a/app/core/document_audit.py
+++ b/app/core/document_audit.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from core.audit import changed_values, log_audit_event, snapshot_model
+
+
+DOCUMENT_FIELDS = (
+    'title',
+    'description',
+    'uploaded_by_id',
+    'file_size',
+    'mime_type',
+    'is_public',
+)
+
+
+def snapshot_document(document):
+    payload = snapshot_model(document, DOCUMENT_FIELDS)
+    payload['file'] = {
+        'present': bool(document.file),
+        'name': document.file.name if document.file else '',
+    }
+    return payload
+
+
+def audit_document_change(
+    *,
+    event: str,
+    actor,
+    target,
+    object_display: str,
+    request=None,
+    previous: Mapping | None = None,
+    new: Mapping | None = None,
+    reason: str = '',
+    source: Mapping | None = None,
+    details: Mapping | None = None,
+):
+    return log_audit_event(
+        event=event,
+        actor=actor,
+        target=target,
+        object_display=object_display,
+        previous=previous,
+        new=new,
+        reason=reason,
+        request=request,
+        source=source or {'type': 'api', 'reference': ''},
+        details=details,
+    )
+
+
+def document_changed_values(previous, new):
+    return changed_values(previous, new)
+
+
+def document_display(document) -> str:
+    return f'document:{document.pk}'

--- a/app/core/test_tenant_isolation.py
+++ b/app/core/test_tenant_isolation.py
@@ -253,14 +253,19 @@ class TestTenantIsolation:
         with tenant_context(tenant_a):
             AuditEvent.objects.create(
                 user=user_a,
-                event="TENANT_A_EVENT",
-                details={"object": {"display": "Tenant A audit event"}},
+                event="DOCUMENT_UPLOADED",
+                details={"object": {"display": "Tenant A document"}},
+            )
+            AuditEvent.objects.create(
+                user=user_a,
+                event="TENANT_DATA_EXPORT_REQUESTED",
+                details={"object": {"display": "Tenant A export"}},
             )
         with tenant_context(tenant_b):
             AuditEvent.objects.create(
                 user=user_b,
-                event="TENANT_B_EVENT",
-                details={"object": {"display": "Tenant B audit event"}},
+                event="DOCUMENT_UPLOADED",
+                details={"object": {"display": "Tenant B document"}},
             )
 
         client = self._authenticated_client(tenant_a, user_a)
@@ -270,8 +275,11 @@ class TestTenantIsolation:
         assert response.status_code == status.HTTP_200_OK
         payload = response.json()
         results = payload.get("results", payload) if isinstance(payload, dict) else payload
-        assert [item["event"] for item in results] == ["TENANT_A_EVENT"]
-        assert results[0]["user_email"] == "alice@example.com"
+        assert {item["event"] for item in results} == {
+            "DOCUMENT_UPLOADED",
+            "TENANT_DATA_EXPORT_REQUESTED",
+        }
+        assert {item["user_email"] for item in results} == {"alice@example.com"}
 
     def test_storage_container_name_uses_current_tenant(self):
         tenant_a = self._create_tenant("tenant_a", "tenant-a", "Tenant A")

--- a/app/core/tests.py
+++ b/app/core/tests.py
@@ -5,6 +5,7 @@ Tests for core application functionality.
 from datetime import timedelta
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -12,7 +13,7 @@ from django_tenants.utils import tenant_context, schema_context
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-from .models import Tenant, Domain, Plan, Subscription, Document, LimitOverrideRequest
+from .models import AuditEvent, Tenant, Domain, Plan, Subscription, Document, LimitOverrideRequest
 from billing.entitlements import ALL_MODULE_KEYS
 from billing.services import PlanEnforcementService
 
@@ -186,6 +187,7 @@ class TestPlanEnforcementService:
         )
         
         assert has_access is False
+        assert error is not None
         assert "not available" in error
 
 
@@ -290,6 +292,58 @@ class TestDocumentAPI:
         response = authenticated_client.get('/api/documents/')
         assert response.status_code == status.HTTP_200_OK
         assert 'results' in response.data or isinstance(response.data, list)
+
+    def test_document_upload_download_and_delete_are_audited(
+        self,
+        authenticated_client,
+        test_tenant,
+        test_subscription,
+    ):
+        authenticated_client.defaults['HTTP_HOST'] = f"{test_tenant.schema_name}.localhost"
+        upload = SimpleUploadedFile(
+            "evidence.txt",
+            b"control evidence content",
+            content_type="text/plain",
+        )
+
+        create_response = authenticated_client.post(
+            "/api/documents/",
+            {
+                "title": "Control evidence",
+                "description": "Evidence metadata only",
+                "file": upload,
+                "is_public": False,
+            },
+            format="multipart",
+            HTTP_USER_AGENT="pytest-agent",
+            REMOTE_ADDR="203.0.113.10",
+        )
+
+        assert create_response.status_code == status.HTTP_201_CREATED
+        document_id = create_response.data["id"]
+        upload_event = AuditEvent.objects.get(event="DOCUMENT_UPLOADED")
+        assert upload_event.details["actor"]["email"] == "test@example.com"
+        assert upload_event.details["new"]["file"]["present"] is True
+        assert upload_event.details["new"]["file"]["name"].endswith("evidence.txt")
+        assert b"control evidence content" not in str(upload_event.details).encode()
+
+        download_response = authenticated_client.get(
+            f"/api/documents/{document_id}/download/",
+            HTTP_USER_AGENT="pytest-agent",
+            REMOTE_ADDR="203.0.113.10",
+        )
+
+        assert download_response.status_code == status.HTTP_200_OK
+        download_event = AuditEvent.objects.get(event="DOCUMENT_DOWNLOADED")
+        assert download_event.details["request"]["ip"] == "203.0.113.10"
+        assert download_event.details["request"]["user_agent"] == "pytest-agent"
+        assert download_event.details["new"]["filename"] == "evidence.txt"
+
+        delete_response = authenticated_client.delete(f"/api/documents/{document_id}/")
+
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+        delete_event = AuditEvent.objects.get(event="DOCUMENT_DELETED")
+        assert delete_event.details["previous"]["file"]["name"].endswith("evidence.txt")
 
 
 @pytest.mark.django_db  

--- a/app/core/views.py
+++ b/app/core/views.py
@@ -8,6 +8,12 @@ from rest_framework.response import Response
 from rest_framework.parsers import MultiPartParser, FormParser
 from django.http import HttpResponse, Http404
 from django.utils import timezone
+from .document_audit import (
+    audit_document_change,
+    document_changed_values,
+    document_display,
+    snapshot_document,
+)
 from .models import AuditEvent, Document, DocumentAccess, Tenant
 from .serializers import (
     AuditEventSerializer,
@@ -142,14 +148,51 @@ class DocumentViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         """Save document with current user as uploader."""
         # Check document limits before creating
-        tenant = Tenant.objects.get(schema_name=self.request.tenant.schema_name)
+        tenant = self.request.tenant
         can_add, usage_info = PlanEnforcementService.check_document_limit(tenant)
         
         if not can_add:
             from rest_framework.exceptions import PermissionDenied
             raise PermissionDenied(usage_info.get('error', 'Document limit exceeded'))
         
-        serializer.save(uploaded_by=self.request.user)
+        document = serializer.save(uploaded_by=self.request.user)
+        audit_document_change(
+            event='DOCUMENT_UPLOADED',
+            actor=self.request.user,
+            target=document,
+            object_display=document_display(document),
+            request=self.request,
+            new=snapshot_document(document),
+        )
+
+    def perform_update(self, serializer):
+        previous = snapshot_document(serializer.instance)
+        document = serializer.save()
+        new = snapshot_document(document)
+        previous_changed, new_changed = document_changed_values(previous, new)
+        if previous_changed or new_changed:
+            event = 'DOCUMENT_REPLACED' if 'file' in new_changed else 'DOCUMENT_UPDATED'
+            audit_document_change(
+                event=event,
+                actor=self.request.user,
+                target=document,
+                object_display=document_display(document),
+                request=self.request,
+                previous=previous_changed,
+                new=new_changed,
+            )
+
+    def perform_destroy(self, instance):
+        previous = snapshot_document(instance)
+        audit_document_change(
+            event='DOCUMENT_DELETED',
+            actor=self.request.user,
+            target=instance,
+            object_display=document_display(instance),
+            request=self.request,
+            previous=previous,
+        )
+        instance.delete()
     
     @extend_schema(
         summary="Download document",
@@ -193,6 +236,20 @@ class DocumentViewSet(viewsets.ModelViewSet):
             accessed_by=request.user,
             ip_address=self._get_client_ip(request),
             user_agent=request.META.get('HTTP_USER_AGENT', '')
+        )
+        audit_document_change(
+            event='DOCUMENT_DOWNLOADED',
+            actor=request.user,
+            target=document,
+            object_display=document_display(document),
+            request=request,
+            new={
+                'document_id': document.id,
+                'filename': document.file_name,
+                'file_size': document.file_size,
+                'mime_type': document.mime_type,
+            },
+            source={'type': 'api', 'reference': 'document.download'},
         )
         
         try:

--- a/app/exports/audit.py
+++ b/app/exports/audit.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from core.audit import changed_values, log_audit_event, snapshot_model
+
+
+ASSESSMENT_REPORT_FIELDS = (
+    'report_type',
+    'title',
+    'framework_id',
+    'requested_by_id',
+    'status',
+    'generated_file_id',
+    'generation_started_at',
+    'generation_completed_at',
+    'include_evidence_summary',
+    'include_implementation_notes',
+    'include_overdue_items',
+    'include_charts',
+)
+TENANT_DATA_EXPORT_FIELDS = (
+    'title',
+    'export_format',
+    'selected_modules',
+    'requested_by_id',
+    'status',
+    'generated_file_id',
+    'generation_started_at',
+    'generation_completed_at',
+    'record_counts',
+    'coverage_manifest',
+)
+
+
+def snapshot_assessment_report(report):
+    payload = snapshot_model(report, ASSESSMENT_REPORT_FIELDS)
+    payload['assessment_ids'] = [
+        str(pk) for pk in report.assessments.order_by('pk').values_list('pk', flat=True)
+    ] if report.pk else []
+    return payload
+
+
+def snapshot_tenant_data_export(data_export):
+    return snapshot_model(data_export, TENANT_DATA_EXPORT_FIELDS)
+
+
+def audit_export_change(
+    *,
+    event: str,
+    actor,
+    target,
+    object_display: str,
+    request=None,
+    previous: Mapping | None = None,
+    new: Mapping | None = None,
+    reason: str = '',
+    source: Mapping | None = None,
+    details: Mapping | None = None,
+):
+    return log_audit_event(
+        event=event,
+        actor=actor,
+        target=target,
+        object_display=object_display,
+        previous=previous,
+        new=new,
+        reason=reason,
+        request=request,
+        source=source or {'type': 'api', 'reference': ''},
+        details=details,
+    )
+
+
+def export_changed_values(previous, new):
+    return changed_values(previous, new)
+
+
+def assessment_report_display(report) -> str:
+    return f'assessment-report:{report.pk}'
+
+
+def tenant_data_export_display(data_export) -> str:
+    return f'tenant-data-export:{data_export.pk}'

--- a/app/exports/services.py
+++ b/app/exports/services.py
@@ -4,6 +4,7 @@ import json
 import zipfile
 from datetime import date, datetime, time
 from decimal import Decimal
+from typing import Any
 from uuid import UUID
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -20,6 +21,14 @@ from catalogs.models import ControlAssessment, Framework, AssessmentEvidence
 from risk.analytics import RiskAnalyticsService, RiskReportGenerator
 from risk.models import Risk, RiskAction
 from .models import AssessmentReport, TenantDataExport
+from .audit import (
+    assessment_report_display,
+    audit_export_change,
+    export_changed_values,
+    snapshot_assessment_report,
+    snapshot_tenant_data_export,
+    tenant_data_export_display,
+)
 
 
 EXCLUDED_FIELD_NAMES = {
@@ -257,7 +266,7 @@ class TenantDataExportGenerator:
 
     def __init__(self, data_export: TenantDataExport):
         self.data_export = data_export
-        self.coverage = [
+        self.coverage: list[dict[str, Any]] = [
             entry for entry in EXPORT_COVERAGE
             if entry['module'] in _normalise_selected_modules(data_export.selected_modules)
         ]
@@ -283,6 +292,7 @@ class TenantDataExportGenerator:
                 raise ValueError(f'Unsupported export format: {self.data_export.export_format}')
 
             document = self._save_export_document(content, filename, mime_type)
+            previous = snapshot_tenant_data_export(self.data_export)
             self.data_export.generated_file = document
             self.data_export.record_counts = record_counts
             self.data_export.status = 'completed'
@@ -293,8 +303,20 @@ class TenantDataExportGenerator:
                 'status',
                 'generation_completed_at',
             ])
+            new = snapshot_tenant_data_export(self.data_export)
+            previous_changed, new_changed = export_changed_values(previous, new)
+            audit_export_change(
+                event='TENANT_DATA_EXPORT_GENERATED',
+                actor=self.data_export.requested_by,
+                target=self.data_export,
+                object_display=tenant_data_export_display(self.data_export),
+                previous=previous_changed,
+                new=new_changed,
+                source={'type': 'worker', 'reference': 'TenantDataExportGenerator.generate_export'},
+            )
             return document
         except Exception as exc:
+            previous = snapshot_tenant_data_export(self.data_export)
             self.data_export.status = 'failed'
             self.data_export.error_message = str(exc)
             self.data_export.generation_completed_at = timezone.now()
@@ -303,10 +325,22 @@ class TenantDataExportGenerator:
                 'error_message',
                 'generation_completed_at',
             ])
+            new = snapshot_tenant_data_export(self.data_export)
+            previous_changed, new_changed = export_changed_values(previous, new)
+            audit_export_change(
+                event='TENANT_DATA_EXPORT_FAILED',
+                actor=self.data_export.requested_by,
+                target=self.data_export,
+                object_display=tenant_data_export_display(self.data_export),
+                previous=previous_changed,
+                new=new_changed,
+                reason=str(exc),
+                source={'type': 'worker', 'reference': 'TenantDataExportGenerator.generate_export'},
+            )
             raise
 
     def _iter_sheet_data(self):
-        used_titles = set()
+        used_titles: set[str] = set()
         for module in self.coverage:
             for sheet in module['sheets']:
                 model_class = _get_model(sheet['model'])
@@ -410,18 +444,43 @@ class AssessmentReportGenerator:
             document = self._save_pdf_document(pdf_content, filename)
             
             # Update report status
+            previous = snapshot_assessment_report(self.report)
             self.report.generated_file = document
             self.report.status = 'completed'
             self.report.generation_completed_at = timezone.now()
             self.report.save()
+            new = snapshot_assessment_report(self.report)
+            previous_changed, new_changed = export_changed_values(previous, new)
+            audit_export_change(
+                event='ASSESSMENT_REPORT_GENERATED',
+                actor=self.report.requested_by,
+                target=self.report,
+                object_display=assessment_report_display(self.report),
+                previous=previous_changed,
+                new=new_changed,
+                source={'type': 'worker', 'reference': 'AssessmentReportGenerator.generate_report'},
+            )
             
             return document
             
         except Exception as e:
+            previous = snapshot_assessment_report(self.report)
             self.report.status = 'failed'
             self.report.error_message = str(e)
             self.report.generation_completed_at = timezone.now()
             self.report.save()
+            new = snapshot_assessment_report(self.report)
+            previous_changed, new_changed = export_changed_values(previous, new)
+            audit_export_change(
+                event='ASSESSMENT_REPORT_FAILED',
+                actor=self.report.requested_by,
+                target=self.report,
+                object_display=assessment_report_display(self.report),
+                previous=previous_changed,
+                new=new_changed,
+                reason=str(e),
+                source={'type': 'worker', 'reference': 'AssessmentReportGenerator.generate_report'},
+            )
             raise
     
     def _generate_assessment_summary(self):

--- a/app/exports/tasks.py
+++ b/app/exports/tasks.py
@@ -4,6 +4,13 @@ import logging
 
 from .models import AssessmentReport
 from .models import TenantDataExport
+from .audit import (
+    assessment_report_display,
+    audit_export_change,
+    snapshot_assessment_report,
+    snapshot_tenant_data_export,
+    tenant_data_export_display,
+)
 from .services import AssessmentReportGenerator, TenantDataExportGenerator
 
 logger = logging.getLogger(__name__)
@@ -103,6 +110,7 @@ def cleanup_old_reports(days_old=30):
     
     for report in old_reports:
         try:
+            previous = snapshot_assessment_report(report)
             if report.generated_file:
                 # Track storage saved
                 if report.generated_file.file_size:
@@ -111,6 +119,14 @@ def cleanup_old_reports(days_old=30):
                 # Delete the file and document
                 report.generated_file.delete()
             
+            audit_export_change(
+                event='ASSESSMENT_REPORT_EXPIRED',
+                actor=report.requested_by,
+                target=report,
+                object_display=assessment_report_display(report),
+                previous=previous,
+                source={'type': 'worker', 'reference': 'cleanup_old_reports'},
+            )
             # Delete the report record
             report.delete()
             deleted_count += 1
@@ -125,6 +141,55 @@ def cleanup_old_reports(days_old=30):
         'deleted_count': deleted_count,
         'storage_saved_bytes': storage_saved,
         'message': f'Cleaned up {deleted_count} reports older than {days_old} days'
+    }
+
+
+@shared_task
+def cleanup_old_tenant_data_exports(days_old=30):
+    """
+    Clean up old tenant data exports and audit the expiry.
+    """
+    from datetime import timedelta
+
+    cutoff_date = timezone.now() - timedelta(days=days_old)
+    old_exports = TenantDataExport.objects.filter(
+        requested_at__lt=cutoff_date,
+        status='completed',
+    ).select_related('generated_file', 'requested_by')
+
+    deleted_count = 0
+    storage_saved = 0
+    for data_export in old_exports:
+        try:
+            previous = snapshot_tenant_data_export(data_export)
+            if data_export.generated_file:
+                if data_export.generated_file.file_size:
+                    storage_saved += data_export.generated_file.file_size
+                data_export.generated_file.delete()
+
+            audit_export_change(
+                event='TENANT_DATA_EXPORT_EXPIRED',
+                actor=data_export.requested_by,
+                target=data_export,
+                object_display=tenant_data_export_display(data_export),
+                previous=previous,
+                source={'type': 'worker', 'reference': 'cleanup_old_tenant_data_exports'},
+            )
+            data_export.delete()
+            deleted_count += 1
+        except Exception as exc:
+            logger.error("Error deleting old tenant data export %s: %s", data_export.id, str(exc))
+
+    logger.info(
+        "Cleaned up %s old tenant data exports, saved %s bytes of storage",
+        deleted_count,
+        storage_saved,
+    )
+    return {
+        'status': 'success',
+        'deleted_count': deleted_count,
+        'storage_saved_bytes': storage_saved,
+        'message': f'Cleaned up {deleted_count} tenant data exports older than {days_old} days',
     }
 
 

--- a/app/exports/tests.py
+++ b/app/exports/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
 from django.urls import reverse
 from django.utils import timezone
 from django_tenants.test.cases import TenantTestCase
@@ -13,11 +14,12 @@ from openpyxl import load_workbook
 
 from catalogs.models import Framework, Clause, Control, ControlAssessment, ControlEvidence, AssessmentEvidence
 from compliance.models import GovernanceArtefact, RegulatoryRequirement
-from core.models import Document
+from core.models import AuditEvent, Document
 from assets.models import Asset
 from risk.models import Risk
 from .models import AssessmentReport, TenantDataExport
 from .services import AssessmentReportGenerator, TenantDataExportGenerator, get_export_coverage_manifest
+from .tasks import cleanup_old_tenant_data_exports
 
 User = get_user_model()
 
@@ -145,6 +147,10 @@ class AssessmentReportAPITest(ExportTenantAPITestCase):
         self.assertEqual(report.title, 'Test API Report')
         self.assertEqual(report.framework, self.framework)
         self.assertEqual(report.requested_by, self.user)
+        event = AuditEvent.objects.get(event='ASSESSMENT_REPORT_REQUESTED')
+        self.assertEqual(event.details['actor']['email'], self.user.email)
+        self.assertEqual(event.details['object']['type'], 'exports.AssessmentReport')
+        self.assertEqual(event.details['new']['title'], 'Test API Report')
     
     def test_list_assessment_reports(self):
         """Test listing assessment reports."""
@@ -243,6 +249,34 @@ class AssessmentReportAPITest(ExportTenantAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], 'completed')
         self.assertIn('message', response.data)
+
+    def test_download_report_is_audited(self):
+        document = Document.objects.create(
+            title='Assessment report',
+            uploaded_by=self.user,
+            mime_type='application/pdf',
+        )
+        document.file.save('assessment-report.pdf', ContentFile(b'pdf bytes'), save=True)
+        report = AssessmentReport.objects.create(
+            report_type='assessment_summary',
+            title='Completed Report',
+            requested_by=self.user,
+            status='completed',
+            generated_file=document,
+        )
+
+        response = self.client.get(
+            reverse('assessment-reports-download', kwargs={'pk': report.id}),
+            HTTP_USER_AGENT='pytest-report-agent',
+            REMOTE_ADDR='203.0.113.30',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(f'/api/documents/{document.id}/download/', response.data['download_url'])
+        event = AuditEvent.objects.get(event='ASSESSMENT_REPORT_DOWNLOAD_REQUESTED')
+        self.assertEqual(event.details['request']['ip'], '203.0.113.30')
+        self.assertEqual(event.details['request']['user_agent'], 'pytest-report-agent')
+        self.assertEqual(event.details['new']['filename'], 'assessment-report.pdf')
     
     @patch('exports.tasks.generate_assessment_report_task.delay')
     def test_quick_generate(self, mock_task):
@@ -381,6 +415,10 @@ class AssessmentReportGeneratorTest(TestCase):
             report.refresh_from_db()
             self.assertEqual(report.status, 'completed')
             self.assertIsNotNone(report.generation_completed_at)
+            event = AuditEvent.objects.get(event='ASSESSMENT_REPORT_GENERATED')
+            self.assertEqual(event.details['actor']['email'], self.user.email)
+            self.assertEqual(event.details['new']['status'], 'completed')
+            self.assertEqual(event.details['new']['generated_file_id'], mock_document.id)
             mock_html_instance.write_pdf.assert_called_once()
             _, write_pdf_kwargs = mock_html_instance.write_pdf.call_args
             self.assertFalse(write_pdf_kwargs['presentational_hints'])
@@ -553,6 +591,44 @@ class TenantDataExportAPITest(ExportTenantAPITestCase):
         self.assertEqual(data_export.status, 'processing')
         self.assertEqual(data_export.selected_modules, ['frameworks', 'risk'])
         mock_delay.assert_called_once_with(data_export.id)
+        requested_event = AuditEvent.objects.get(event='TENANT_DATA_EXPORT_REQUESTED')
+        started_event = AuditEvent.objects.get(event='TENANT_DATA_EXPORT_GENERATION_STARTED')
+        self.assertEqual(requested_event.details['actor']['email'], self.user.email)
+        self.assertEqual(requested_event.details['object']['type'], 'exports.TenantDataExport')
+        self.assertEqual(requested_event.details['new']['selected_modules'], ['frameworks', 'risk'])
+        self.assertEqual(started_event.details['previous']['status'], 'pending')
+        self.assertEqual(started_event.details['new']['status'], 'processing')
+
+    def test_download_export_is_audited(self):
+        data_export = TenantDataExport.objects.create(
+            title='Downloadable export',
+            export_format='xlsx',
+            selected_modules=['assets'],
+            requested_by=self.user,
+            status='completed',
+        )
+        document = Document.objects.create(
+            title='Downloadable export',
+            uploaded_by=self.user,
+            mime_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            file_size=12,
+        )
+        document.file.save('tenant-export.xlsx', ContentFile(b'export bytes'), save=True)
+        data_export.generated_file = document
+        data_export.save(update_fields=['generated_file'])
+
+        response = self.client.get(
+            reverse('tenant-data-exports-download', kwargs={'pk': data_export.id}),
+            HTTP_USER_AGENT='pytest-export-agent',
+            REMOTE_ADDR='203.0.113.20',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        event = AuditEvent.objects.get(event='TENANT_DATA_EXPORT_DOWNLOAD_REQUESTED')
+        self.assertEqual(event.details['request']['ip'], '203.0.113.20')
+        self.assertEqual(event.details['request']['user_agent'], 'pytest-export-agent')
+        self.assertEqual(event.details['new']['filename'], 'tenant-export.xlsx')
+        self.assertEqual(event.details['new']['generated_file_id'], document.id)
 
     def test_invalid_module_is_rejected(self):
         url = reverse('tenant-data-exports-list')
@@ -670,6 +746,11 @@ class TenantDataExportGeneratorTest(TestCase):
         self.assertEqual(data_export.record_counts['catalogs.Framework'], 1)
         self.assertEqual(data_export.record_counts['risk.Risk'], 1)
         self.assertEqual(data_export.record_counts['assets.Asset'], 1)
+        generated_event = AuditEvent.objects.get(event='TENANT_DATA_EXPORT_GENERATED')
+        self.assertEqual(generated_event.details['actor']['email'], self.user.email)
+        self.assertEqual(generated_event.details['previous']['status'], 'processing')
+        self.assertEqual(generated_event.details['new']['status'], 'completed')
+        self.assertEqual(generated_event.details['new']['generated_file_id'], document.id)
 
         workbook = load_workbook(BytesIO(document.file.read()), read_only=True)
         self.assertIn('Frameworks', workbook.sheetnames)
@@ -678,6 +759,78 @@ class TenantDataExportGeneratorTest(TestCase):
         risk_rows = list(workbook['Risks'].iter_rows(values_only=True))
         self.assertIn('risk_id', risk_rows[0])
         self.assertIn('RISK-001', risk_rows[1])
+
+    def test_generate_xlsx_export_includes_audit_records(self):
+        AuditEvent.objects.create(
+            user=self.user,
+            event='DOCUMENT_UPLOADED',
+            details={
+                'event': 'DOCUMENT_UPLOADED',
+                'object': {'display': 'document:1'},
+            },
+        )
+        data_export = TenantDataExport.objects.create(
+            title='Audit trail export',
+            export_format='xlsx',
+            selected_modules=['identity'],
+            requested_by=self.user,
+        )
+
+        document = TenantDataExportGenerator(data_export).generate_export()
+
+        workbook = load_workbook(BytesIO(document.file.read()), read_only=True)
+        self.assertIn('Audit events', workbook.sheetnames)
+        audit_rows = list(workbook['Audit events'].iter_rows(values_only=True))
+        self.assertIn('event', audit_rows[0])
+        event_index = audit_rows[0].index('event')
+        self.assertIn('DOCUMENT_UPLOADED', [row[event_index] for row in audit_rows[1:]])
+
+    def test_generate_export_failure_is_audited(self):
+        data_export = TenantDataExport.objects.create(
+            title='Broken export',
+            export_format='xlsx',
+            selected_modules=['assets'],
+            requested_by=self.user,
+        )
+        data_export.export_format = 'bad_format'
+
+        with self.assertRaises(ValueError):
+            TenantDataExportGenerator(data_export).generate_export()
+
+        data_export.refresh_from_db()
+        self.assertEqual(data_export.status, 'failed')
+        failed_event = AuditEvent.objects.get(event='TENANT_DATA_EXPORT_FAILED')
+        self.assertEqual(failed_event.details['actor']['email'], self.user.email)
+        self.assertEqual(failed_event.details['new']['status'], 'failed')
+        self.assertIn('Unsupported export format', failed_event.details['reason'])
+
+    def test_cleanup_old_tenant_data_exports_is_audited(self):
+        data_export = TenantDataExport.objects.create(
+            title='Expired export',
+            export_format='xlsx',
+            selected_modules=['assets'],
+            requested_by=self.user,
+            status='completed',
+        )
+        document = Document.objects.create(
+            title='Expired export',
+            uploaded_by=self.user,
+            mime_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
+        document.file.save('expired-export.xlsx', ContentFile(b'expired'), save=True)
+        data_export.generated_file = document
+        data_export.save(update_fields=['generated_file'])
+        TenantDataExport.objects.filter(pk=data_export.pk).update(
+            requested_at=timezone.now() - timezone.timedelta(days=60)
+        )
+
+        result = cleanup_old_tenant_data_exports(days_old=30)
+
+        self.assertEqual(result['deleted_count'], 1)
+        self.assertFalse(TenantDataExport.objects.filter(pk=data_export.pk).exists())
+        event = AuditEvent.objects.get(event='TENANT_DATA_EXPORT_EXPIRED')
+        self.assertEqual(event.details['actor']['email'], self.user.email)
+        self.assertEqual(event.details['previous']['status'], 'completed')
 
     def test_generate_xlsx_export_includes_governance_records(self):
         data_export = TenantDataExport.objects.create(

--- a/app/exports/views.py
+++ b/app/exports/views.py
@@ -12,6 +12,14 @@ from drf_spectacular.types import OpenApiTypes
 from catalogs.models import Framework, ControlAssessment
 from .models import AssessmentReport
 from .models import TenantDataExport
+from .audit import (
+    assessment_report_display,
+    audit_export_change,
+    export_changed_values,
+    snapshot_assessment_report,
+    snapshot_tenant_data_export,
+    tenant_data_export_display,
+)
 from .serializers import (
     AssessmentReportSerializer, 
     AssessmentReportCreateSerializer,
@@ -121,7 +129,43 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
     
     def perform_create(self, serializer):
         """Create report and trigger generation."""
-        serializer.save(requested_by=self.request.user)
+        report = serializer.save(requested_by=self.request.user)
+        audit_export_change(
+            event='ASSESSMENT_REPORT_REQUESTED',
+            actor=self.request.user,
+            target=report,
+            object_display=assessment_report_display(report),
+            request=self.request,
+            new=snapshot_assessment_report(report),
+        )
+
+    def perform_update(self, serializer):
+        previous = snapshot_assessment_report(serializer.instance)
+        report = serializer.save()
+        new = snapshot_assessment_report(report)
+        previous_changed, new_changed = export_changed_values(previous, new)
+        if previous_changed or new_changed:
+            audit_export_change(
+                event='ASSESSMENT_REPORT_UPDATED',
+                actor=self.request.user,
+                target=report,
+                object_display=assessment_report_display(report),
+                request=self.request,
+                previous=previous_changed,
+                new=new_changed,
+            )
+
+    def perform_destroy(self, instance):
+        previous = snapshot_assessment_report(instance)
+        audit_export_change(
+            event='ASSESSMENT_REPORT_DELETED',
+            actor=self.request.user,
+            target=instance,
+            object_display=assessment_report_display(instance),
+            request=self.request,
+            previous=previous,
+        )
+        instance.delete()
     
     @extend_schema(
         summary="Generate report",
@@ -168,9 +212,22 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
             generate_assessment_report_task.delay(report.id)
             
             # Update status
+            previous = snapshot_assessment_report(report)
             report.status = 'processing'
             report.generation_started_at = timezone.now()
             report.save()
+            new = snapshot_assessment_report(report)
+            previous_changed, new_changed = export_changed_values(previous, new)
+            audit_export_change(
+                event='ASSESSMENT_REPORT_GENERATION_STARTED',
+                actor=request.user,
+                target=report,
+                object_display=assessment_report_display(report),
+                request=request,
+                previous=previous_changed,
+                new=new_changed,
+                source={'type': 'api', 'reference': 'assessment_report.generate'},
+            )
             
             return Response({
                 'message': 'Report generation started',
@@ -197,7 +254,7 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
         
         if report.status == 'completed' and report.generated_file:
             response_data['download_url'] = request.build_absolute_uri(
-                f'/api/core/documents/{report.generated_file.id}/download/'
+                f'/api/documents/{report.generated_file.id}/download/'
             )
         elif report.status == 'failed':
             response_data['error_details'] = report.error_message
@@ -217,9 +274,22 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
             )
         
         # Redirect to document download endpoint
+        audit_export_change(
+            event='ASSESSMENT_REPORT_DOWNLOAD_REQUESTED',
+            actor=request.user,
+            target=report,
+            object_display=assessment_report_display(report),
+            request=request,
+            new={
+                'generated_file_id': report.generated_file_id,
+                'filename': report.generated_file.file_name,
+                'file_size': report.generated_file.file_size,
+            },
+            source={'type': 'api', 'reference': 'assessment_report.download'},
+        )
         return Response({
             'download_url': request.build_absolute_uri(
-                f'/api/core/documents/{report.generated_file.id}/download/'
+                f'/api/documents/{report.generated_file.id}/download/'
             )
         })
     
@@ -257,15 +327,37 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
         
         if serializer.is_valid():
             report = serializer.save(requested_by=request.user)
+            audit_export_change(
+                event='ASSESSMENT_REPORT_REQUESTED',
+                actor=request.user,
+                target=report,
+                object_display=assessment_report_display(report),
+                request=request,
+                new=snapshot_assessment_report(report),
+                source={'type': 'api', 'reference': 'assessment_report.quick_generate'},
+            )
             
             try:
                 # Start async generation
                 generate_assessment_report_task.delay(report.id)
                 
                 # Update status
+                previous = snapshot_assessment_report(report)
                 report.status = 'processing'
                 report.generation_started_at = timezone.now()
                 report.save()
+                new = snapshot_assessment_report(report)
+                previous_changed, new_changed = export_changed_values(previous, new)
+                audit_export_change(
+                    event='ASSESSMENT_REPORT_GENERATION_STARTED',
+                    actor=request.user,
+                    target=report,
+                    object_display=assessment_report_display(report),
+                    request=request,
+                    previous=previous_changed,
+                    new=new_changed,
+                    source={'type': 'api', 'reference': 'assessment_report.quick_generate'},
+                )
                 
                 return Response({
                     'message': 'Report created and generation started',
@@ -391,10 +483,43 @@ class TenantDataExportViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         data_export = serializer.save(requested_by=self.request.user)
+        audit_export_change(
+            event='TENANT_DATA_EXPORT_REQUESTED',
+            actor=self.request.user,
+            target=data_export,
+            object_display=tenant_data_export_display(data_export),
+            request=self.request,
+            new=snapshot_tenant_data_export(data_export),
+        )
+        previous = snapshot_tenant_data_export(data_export)
         data_export.status = 'processing'
         data_export.generation_started_at = timezone.now()
         data_export.save(update_fields=['status', 'generation_started_at'])
+        new = snapshot_tenant_data_export(data_export)
+        previous_changed, new_changed = export_changed_values(previous, new)
+        audit_export_change(
+            event='TENANT_DATA_EXPORT_GENERATION_STARTED',
+            actor=self.request.user,
+            target=data_export,
+            object_display=tenant_data_export_display(data_export),
+            request=self.request,
+            previous=previous_changed,
+            new=new_changed,
+            source={'type': 'api', 'reference': 'tenant_data_export.create'},
+        )
         generate_tenant_data_export_task.delay(data_export.id)
+
+    def perform_destroy(self, instance):
+        previous = snapshot_tenant_data_export(instance)
+        audit_export_change(
+            event='TENANT_DATA_EXPORT_DELETED',
+            actor=self.request.user,
+            target=instance,
+            object_display=tenant_data_export_display(instance),
+            request=self.request,
+            previous=previous,
+        )
+        instance.delete()
 
     @extend_schema(
         summary="Get export coverage manifest",
@@ -429,11 +554,24 @@ class TenantDataExportViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_200_OK,
             )
 
+        previous = snapshot_tenant_data_export(data_export)
         generate_tenant_data_export_task.delay(data_export.id)
         data_export.status = 'processing'
         data_export.generation_started_at = timezone.now()
         data_export.error_message = ''
         data_export.save(update_fields=['status', 'generation_started_at', 'error_message'])
+        new = snapshot_tenant_data_export(data_export)
+        previous_changed, new_changed = export_changed_values(previous, new)
+        audit_export_change(
+            event='TENANT_DATA_EXPORT_GENERATION_STARTED',
+            actor=request.user,
+            target=data_export,
+            object_display=tenant_data_export_display(data_export),
+            request=request,
+            previous=previous_changed,
+            new=new_changed,
+            source={'type': 'api', 'reference': 'tenant_data_export.generate'},
+        )
         return Response(
             {
                 'message': 'Export generation started',
@@ -469,6 +607,20 @@ class TenantDataExportViewSet(viewsets.ModelViewSet):
             )
 
         serializer = TenantDataExportSerializer(data_export, context={'request': request})
+        audit_export_change(
+            event='TENANT_DATA_EXPORT_DOWNLOAD_REQUESTED',
+            actor=request.user,
+            target=data_export,
+            object_display=tenant_data_export_display(data_export),
+            request=request,
+            new={
+                'generated_file_id': data_export.generated_file_id,
+                'filename': data_export.generated_file.file_name,
+                'file_size': data_export.generated_file.file_size,
+                'record_counts': data_export.record_counts,
+            },
+            source={'type': 'api', 'reference': 'tenant_data_export.download'},
+        )
         return Response({
             'download_url': serializer.data['download_url'],
             'document_id': data_export.generated_file_id,


### PR DESCRIPTION
Closes #163

## Summary
- Add metadata-only audit helpers for documents, assessment reports and tenant data exports.
- Audit document upload, update, replacement, download and deletion with request IP and user agent where available.
- Audit report and tenant export request, generation start, completion, failure, download, deletion and expiry lifecycle events.
- Include audit events in tenant data exports and fix generated assessment report download URLs to use the real /api/documents/ route.

## Verification
- 38 passed: document API, exports tests and tenant audit isolation targeted suite.
- 2 passed: focused assessment report download/status route checks.
- ruff clean on touched files.
- mypy clean on touched files.
- manage.py check passed.
- makemigrations --check --dry-run passed.
- git diff --check passed.
- em-dash scan clean on touched files.