### PR TITLE
chore: refresh OpenAPI schema

### DIFF
--- a/.github/scripts/check-openapi-schema.sh
+++ b/.github/scripts/check-openapi-schema.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCHEMA_FILE="$ROOT_DIR/app/schema.yml"
+GENERATED_SCHEMA="$(mktemp)"
+DIAGNOSTICS_LOG="$(mktemp)"
+
+cleanup() {
+  rm -f "$GENERATED_SCHEMA" "$DIAGNOSTICS_LOG"
+}
+trap cleanup EXIT
+
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR/app${PYTHONPATH:+:$PYTHONPATH}"
+
+if ! python manage.py spectacular --file "$GENERATED_SCHEMA" >"$DIAGNOSTICS_LOG" 2>&1; then
+  cat "$DIAGNOSTICS_LOG"
+  exit 1
+fi
+
+if ! python - "$SCHEMA_FILE" "$GENERATED_SCHEMA" <<'PY'; then
+from pathlib import Path
+import sys
+
+import yaml
+
+committed_path = Path(sys.argv[1])
+generated_path = Path(sys.argv[2])
+
+with committed_path.open() as committed_file:
+    committed = yaml.safe_load(committed_file)
+with generated_path.open() as generated_file:
+    generated = yaml.safe_load(generated_file)
+
+if committed != generated:
+    sys.exit(1)
+PY
+  echo "::error::Committed OpenAPI schema is stale. Run 'python manage.py spectacular --file app/schema.yml' and commit the result."
+  exit 1
+fi
+
+warnings="$(awk '/^Warnings:/{print $2}' "$DIAGNOSTICS_LOG" | tail -1)"
+errors="$(awk '/^Errors:/{print $2}' "$DIAGNOSTICS_LOG" | tail -1)"
+warnings="${warnings:-0}"
+errors="${errors:-0}"
+
+# Baseline current drf-spectacular diagnostics so new schema noise is caught.
+# Future cleanup should lower these ceilings until both reach zero.
+max_warnings="${OPENAPI_MAX_WARNINGS:-191}"
+max_errors="${OPENAPI_MAX_ERRORS:-167}"
+
+if (( warnings > max_warnings )); then
+  cat "$DIAGNOSTICS_LOG"
+  echo "::error::OpenAPI warnings increased from the baseline of $max_warnings to $warnings."
+  exit 1
+fi
+
+if (( errors > max_errors )); then
+  cat "$DIAGNOSTICS_LOG"
+  echo "::error::OpenAPI errors increased from the baseline of $max_errors to $errors."
+  exit 1
+fi
+
+echo "OpenAPI schema is current."
+echo "drf-spectacular diagnostics: $warnings warnings, $errors errors. Baseline ceilings: $max_warnings warnings, $max_errors errors."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,9 @@ jobs:
         echo "Django system check..."
         python manage.py check
 
+        echo "Checking OpenAPI schema freshness..."
+        bash ../.github/scripts/check-openapi-schema.sh
+
     - name: Run tests
       working-directory: ./app
       env:

--- a/app/schema.yml
+++ b/app/schema.yml
@@ -3,20 +3,19 @@ info:
   title: GRC SaaS API
   version: 1.0.0
   description: "\n    Comprehensive API for Governance, Risk, and Compliance (GRC)\
-    \ management.\n    \n    This API provides complete functionality for compliance\
-    \ framework management,\n    control assessments, evidence collection, reporting,\
-    \ and automated reminders.\n    \n    ## Features\n    - **Framework Management**:\
-    \ Import and manage compliance frameworks (ISO 27001, NIST CSF, SOC 2, etc.)\n\
-    \    - **Assessment Workflow**: Complete control assessment lifecycle with status\
-    \ tracking\n    - **Evidence Management**: Upload, link, and organize evidence\
-    \ with bulk operations\n    - **Automated Reporting**: Generate professional PDF\
-    \ reports for audits and compliance\n    - **Smart Reminders**: Configurable email\
-    \ notifications for due dates and overdue items\n    - **Multi-tenant Architecture**:\
-    \ Complete tenant isolation with secure data scoping\n    \n    ## Authentication\n\
-    \    This API uses session-based authentication. Users must be authenticated to\
-    \ access endpoints.\n    \n    ## Tenant Scoping\n    All data is automatically\
-    \ scoped to the authenticated user's tenant. Cross-tenant access is prevented.\n\
-    \    "
+    \ management.\n\n    This API provides complete functionality for compliance framework\
+    \ management,\n    control assessments, evidence collection, reporting, and automated\
+    \ reminders.\n\n    ## Features\n    - **Framework Management**: Import and manage\
+    \ compliance frameworks (ISO 27001, NIST CSF, SOC 2, etc.)\n    - **Assessment\
+    \ Workflow**: Complete control assessment lifecycle with status tracking\n   \
+    \ - **Evidence Management**: Upload, link, and organize evidence with bulk operations\n\
+    \    - **Automated Reporting**: Generate professional PDF reports for audits and\
+    \ compliance\n    - **Smart Reminders**: Configurable email notifications for\
+    \ due dates and overdue items\n    - **Multi-tenant Architecture**: Complete tenant\
+    \ isolation with secure data scoping\n\n    ## Authentication\n    This API uses\
+    \ session-based authentication. Users must be authenticated to access endpoints.\n\
+    \n    ## Tenant Scoping\n    All data is automatically scoped to the authenticated\
+    \ user's tenant. Cross-tenant access is prevented.\n    "
   contact:
     name: GRC SaaS Support
     email: support@grcsaas.com
@@ -281,6 +280,742 @@ paths:
       responses:
         '200':
           description: No response body
+  /api/assets/assets/:
+    post:
+      operationId: assets_assets_create
+      description: CRUD API for information assets.
+      tags:
+      - assets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetDetail'
+          description: ''
+    get:
+      operationId: assets_assets_list
+      description: CRUD API for information assets.
+      parameters:
+      - in: query
+        name: asset_type
+        schema:
+          type: string
+          enum:
+          - application
+          - database
+          - document
+          - infrastructure
+          - mobile_device
+          - monitor
+          - other
+          - printer
+          - server
+          - workstation
+        description: |-
+          * `server` - Server
+          * `workstation` - Workstation
+          * `monitor` - Monitor
+          * `mobile_device` - Mobile Device
+          * `printer` - Printer
+          * `infrastructure` - Infrastructure
+          * `application` - Application
+          * `database` - Database
+          * `document` - Document
+          * `other` - Other
+      - in: query
+        name: classification
+        schema:
+          type: string
+          enum:
+          - confidential
+          - internal
+          - public
+          - restricted
+        description: |-
+          * `public` - Public
+          * `internal` - Internal
+          * `confidential` - Confidential
+          * `restricted` - Restricted
+      - in: query
+        name: criticality
+        schema:
+          type: string
+          enum:
+          - critical
+          - high
+          - low
+          - medium
+        description: |-
+          * `low` - Low
+          * `medium` - Medium
+          * `high` - High
+          * `critical` - Critical
+      - in: query
+        name: lifecycle_status
+        schema:
+          type: string
+          enum:
+          - active
+          - disposed
+          - maintenance
+          - planned
+          - retired
+        description: |-
+          * `planned` - Planned
+          * `active` - Active
+          * `maintenance` - Maintenance
+          * `retired` - Retired
+          * `disposed` - Disposed
+      - in: query
+        name: location
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: owner
+        schema:
+          type: integer
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - assets
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAssetListList'
+          description: ''
+  /api/assets/assets/due_for_review/:
+    get:
+      operationId: assets_assets_due_for_review_retrieve
+      description: List assets with reviews due today or overdue.
+      tags:
+      - assets
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetDetail'
+          description: ''
+  /api/assets/assets/import-register/:
+    post:
+      operationId: assets_assets_import_register_create
+      description: Import an asset register spreadsheet from the admin web interface.
+      tags:
+      - assets
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetDetail'
+          description: ''
+  /api/assets/assets/{id}/:
+    patch:
+      operationId: assets_assets_partial_update
+      description: CRUD API for information assets.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this asset.
+        required: true
+      tags:
+      - assets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedAssetDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedAssetDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedAssetDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetDetail'
+          description: ''
+    get:
+      operationId: assets_assets_retrieve
+      description: CRUD API for information assets.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this asset.
+        required: true
+      tags:
+      - assets
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetDetail'
+          description: ''
+    put:
+      operationId: assets_assets_update
+      description: CRUD API for information assets.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this asset.
+        required: true
+      tags:
+      - assets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetDetail'
+          description: ''
+    delete:
+      operationId: assets_assets_destroy
+      description: CRUD API for information assets.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this asset.
+        required: true
+      tags:
+      - assets
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/assets/review-reminders/:
+    get:
+      operationId: assets_review_reminders_list
+      parameters:
+      - in: query
+        name: asset
+        schema:
+          type: integer
+      - in: query
+        name: email_sent
+        schema:
+          type: boolean
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: owner
+        schema:
+          type: integer
+      - in: query
+        name: reminder_type
+        schema:
+          type: string
+          enum:
+          - advance_warning
+          - due_today
+          - overdue
+        description: |-
+          * `advance_warning` - Advance Warning
+          * `due_today` - Due Today
+          * `overdue` - Overdue
+      tags:
+      - assets
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AssetReviewReminderLog'
+          description: ''
+  /api/assets/review-reminders/{id}/:
+    get:
+      operationId: assets_review_reminders_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this asset review reminder
+          log.
+        required: true
+      tags:
+      - assets
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetReviewReminderLog'
+          description: ''
+  /api/calendar/events/:
+    post:
+      operationId: calendar_events_create
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
+    get:
+      operationId: calendar_events_list
+      parameters:
+      - in: query
+        name: event_type
+        schema:
+          type: string
+          enum:
+          - custom
+          - deadline
+          - meeting
+          - review
+          - training
+        description: |-
+          * `deadline` - Deadline
+          * `review` - Review
+          * `meeting` - Meeting
+          * `training` - Training
+          * `custom` - Custom
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: owner
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - cancelled
+          - completed
+          - scheduled
+        description: |-
+          * `scheduled` - Scheduled
+          * `completed` - Completed
+          * `cancelled` - Cancelled
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CalendarEvent'
+          description: ''
+  /api/calendar/events/combined/:
+    get:
+      operationId: calendar_events_combined_retrieve
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
+  /api/calendar/events/{id}/:
+    patch:
+      operationId: calendar_events_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this calendar event.
+        required: true
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarEventRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarEventRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarEventRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
+    get:
+      operationId: calendar_events_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this calendar event.
+        required: true
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
+    put:
+      operationId: calendar_events_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this calendar event.
+        required: true
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
+    delete:
+      operationId: calendar_events_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this calendar event.
+        required: true
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/calendar/preferences/:
+    post:
+      operationId: calendar_preferences_create
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          description: No response body
+    get:
+      operationId: calendar_preferences_retrieve
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/calendar/reminders/:
+    get:
+      operationId: calendar_reminders_list
+      parameters:
+      - in: query
+        name: email_sent
+        schema:
+          type: boolean
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: recipient
+        schema:
+          type: integer
+      - in: query
+        name: reminder_type
+        schema:
+          type: string
+          enum:
+          - advance_warning
+          - due_today
+          - overdue
+        description: |-
+          * `advance_warning` - Advance warning
+          * `due_today` - Due today
+          * `overdue` - Overdue
+      - in: query
+        name: source_type
+        schema:
+          type: string
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CalendarReminderLog'
+          description: ''
+  /api/calendar/reminders/{id}/:
+    get:
+      operationId: calendar_reminders_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this calendar reminder log.
+        required: true
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarReminderLog'
+          description: ''
+  /api/calendar/audit/:
+    get:
+      operationId: calendar_audit_list
+      parameters:
+      - in: query
+        name: action
+        schema:
+          type: string
+          enum:
+          - created
+          - deleted
+          - reminder_sent
+          - updated
+        description: |-
+          * `created` - Created
+          * `updated` - Updated
+          * `deleted` - Deleted
+          * `reminder_sent` - Reminder sent
+      - in: query
+        name: actor
+        schema:
+          type: integer
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: source_type
+        schema:
+          type: string
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CalendarAuditLog'
+          description: ''
+  /api/calendar/audit/{id}/:
+    get:
+      operationId: calendar_audit_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this calendar audit log.
+        required: true
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarAuditLog'
+          description: ''
   /api/catalogs/api/frameworks/:
     post:
       operationId: catalogs_api_frameworks_create
@@ -403,11 +1138,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/FrameworkDetail'
           description: ''
-    delete:
-      operationId: catalogs_api_frameworks_destroy
-      description: Delete a compliance framework. This will also remove all associated
-        clauses and mappings.
-      summary: Delete framework
+    get:
+      operationId: catalogs_api_frameworks_retrieve
+      description: Retrieve detailed information about a specific compliance framework
+        including metadata and configuration.
+      summary: Get framework details
       parameters:
       - in: path
         name: id
@@ -421,8 +1156,12 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '204':
-          description: No response body
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FrameworkDetail'
+          description: ''
     put:
       operationId: catalogs_api_frameworks_update
       description: Update an existing compliance framework. Requires all fields.
@@ -458,11 +1197,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/FrameworkDetail'
           description: ''
-    get:
-      operationId: catalogs_api_frameworks_retrieve
-      description: Retrieve detailed information about a specific compliance framework
-        including metadata and configuration.
-      summary: Get framework details
+    delete:
+      operationId: catalogs_api_frameworks_destroy
+      description: Delete a compliance framework. This will also remove all associated
+        clauses and mappings.
+      summary: Delete framework
       parameters:
       - in: path
         name: id
@@ -476,12 +1215,8 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FrameworkDetail'
-          description: ''
+        '204':
+          description: No response body
   /api/catalogs/api/frameworks/{id}/clauses/:
     get:
       operationId: catalogs_api_frameworks_clauses_list
@@ -813,8 +1548,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ClauseDetail'
           description: ''
-    delete:
-      operationId: catalogs_api_clauses_destroy
+    get:
+      operationId: catalogs_api_clauses_retrieve
       description: |-
         ViewSet for managing framework clauses.
         Provides CRUD operations and clause-specific endpoints.
@@ -831,8 +1566,12 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '204':
-          description: No response body
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClauseDetail'
+          description: ''
     put:
       operationId: catalogs_api_clauses_update
       description: |-
@@ -869,8 +1608,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ClauseDetail'
           description: ''
-    get:
-      operationId: catalogs_api_clauses_retrieve
+    delete:
+      operationId: catalogs_api_clauses_destroy
       description: |-
         ViewSet for managing framework clauses.
         Provides CRUD operations and clause-specific endpoints.
@@ -887,12 +1626,8 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClauseDetail'
-          description: ''
+        '204':
+          description: No response body
   /api/catalogs/api/clauses/{id}/controls/:
     get:
       operationId: catalogs_api_clauses_controls_retrieve
@@ -920,6 +1655,29 @@ paths:
     get:
       operationId: catalogs_api_clauses_subclauses_retrieve
       description: Get all subclauses for a specific clause.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this clause.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClauseDetail'
+          description: ''
+  /api/catalogs/api/clauses/{id}/templates/:
+    get:
+      operationId: catalogs_api_clauses_templates_retrieve
+      description: Get template documents linked to a specific clause.
       parameters:
       - in: path
         name: id
@@ -1175,8 +1933,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ControlCreateUpdate'
           description: ''
-    delete:
-      operationId: catalogs_api_controls_destroy
+    get:
+      operationId: catalogs_api_controls_retrieve
       description: |-
         ViewSet for managing controls.
         Provides CRUD operations and control-specific endpoints.
@@ -1193,8 +1951,12 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '204':
-          description: No response body
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlDetail'
+          description: ''
     put:
       operationId: catalogs_api_controls_update
       description: |-
@@ -1231,11 +1993,30 @@ paths:
               schema:
                 $ref: '#/components/schemas/ControlCreateUpdate'
           description: ''
-    get:
-      operationId: catalogs_api_controls_retrieve
+    delete:
+      operationId: catalogs_api_controls_destroy
       description: |-
         ViewSet for managing controls.
         Provides CRUD operations and control-specific endpoints.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this control.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/catalogs/api/controls/{id}/evidence/:
+    get:
+      operationId: catalogs_api_controls_evidence_retrieve
+      description: Get all evidence for a specific control.
       parameters:
       - in: path
         name: id
@@ -1255,10 +2036,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ControlDetail'
           description: ''
-  /api/catalogs/api/controls/{id}/evidence/:
+  /api/catalogs/api/controls/{id}/templates/:
     get:
-      operationId: catalogs_api_controls_evidence_retrieve
-      description: Get all evidence for a specific control.
+      operationId: catalogs_api_controls_templates_retrieve
+      description: Get template documents linked to a specific control.
       parameters:
       - in: path
         name: id
@@ -1441,8 +2222,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ControlEvidence'
           description: ''
-    delete:
-      operationId: catalogs_api_evidence_destroy
+    get:
+      operationId: catalogs_api_evidence_retrieve
       description: ViewSet for managing control evidence.
       parameters:
       - in: path
@@ -1457,8 +2238,12 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '204':
-          description: No response body
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlEvidence'
+          description: ''
     put:
       operationId: catalogs_api_evidence_update
       description: ViewSet for managing control evidence.
@@ -1493,8 +2278,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ControlEvidence'
           description: ''
-    get:
-      operationId: catalogs_api_evidence_retrieve
+    delete:
+      operationId: catalogs_api_evidence_destroy
       description: ViewSet for managing control evidence.
       parameters:
       - in: path
@@ -1509,12 +2294,8 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlEvidence'
-          description: ''
+        '204':
+          description: No response body
   /api/catalogs/api/evidence/{id}/assessments/:
     get:
       operationId: catalogs_api_evidence_assessments_retrieve
@@ -1572,6 +2353,145 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ControlEvidence'
+          description: ''
+  /api/catalogs/api/template-documents/:
+    get:
+      operationId: catalogs_api_template_documents_list
+      description: ViewSet for discovering imported template and sample documents.
+      parameters:
+      - in: query
+        name: clause
+        schema:
+          type: integer
+      - in: query
+        name: control
+        schema:
+          type: integer
+      - in: query
+        name: document_type
+        schema:
+          type: string
+          enum:
+          - asset_register
+          - framework_spreadsheet
+          - mandatory_document
+          - other
+          - policy
+          - procedure
+          - risk_register
+          - sample
+          - standard
+          - template
+        description: |-
+          * `policy` - Policy
+          * `standard` - Standard
+          * `procedure` - Procedure
+          * `mandatory_document` - Mandatory Document
+          * `risk_register` - Risk Register
+          * `asset_register` - Asset Register
+          * `framework_spreadsheet` - Framework Spreadsheet
+          * `template` - Template
+          * `sample` - Sample
+          * `other` - Other
+      - in: query
+        name: framework
+        schema:
+          type: integer
+      - in: query
+        name: module
+        schema:
+          type: string
+          enum:
+          - asset
+          - iso_mandatory
+          - other
+          - pci
+          - policy
+          - procedure
+          - risk
+          - standard
+        description: |-
+          * `policy` - Policy
+          * `standard` - Standard
+          * `procedure` - Procedure
+          * `iso_mandatory` - ISO Mandatory Document
+          * `pci` - PCI
+          * `risk` - Risk
+          * `asset` - Asset
+          * `other` - Other
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TemplateDocument'
+          description: ''
+  /api/catalogs/api/template-documents/import-library/:
+    post:
+      operationId: catalogs_api_template_documents_import_library_create
+      description: Import a ZIP template library from the admin web interface.
+      tags:
+      - catalogs
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TemplateDocumentRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TemplateDocumentRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemplateDocument'
+          description: ''
+  /api/catalogs/api/template-documents/{id}/:
+    get:
+      operationId: catalogs_api_template_documents_retrieve
+      description: ViewSet for discovering imported template and sample documents.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this template document.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemplateDocument'
           description: ''
   /api/catalogs/api/mappings/:
     post:
@@ -1687,8 +2607,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/FrameworkMapping'
           description: ''
-    delete:
-      operationId: catalogs_api_mappings_destroy
+    get:
+      operationId: catalogs_api_mappings_retrieve
       description: ViewSet for managing framework mappings.
       parameters:
       - in: path
@@ -1703,8 +2623,12 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '204':
-          description: No response body
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FrameworkMapping'
+          description: ''
     put:
       operationId: catalogs_api_mappings_update
       description: ViewSet for managing framework mappings.
@@ -1739,8 +2663,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/FrameworkMapping'
           description: ''
-    get:
-      operationId: catalogs_api_mappings_retrieve
+    delete:
+      operationId: catalogs_api_mappings_destroy
       description: ViewSet for managing framework mappings.
       parameters:
       - in: path
@@ -1755,12 +2679,8 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FrameworkMapping'
-          description: ''
+        '204':
+          description: No response body
   /api/catalogs/api/assessments/:
     post:
       operationId: catalogs_api_assessments_create
@@ -2052,10 +2972,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ControlAssessmentCreateUpdate'
           description: ''
-    delete:
-      operationId: catalogs_api_assessments_destroy
-      description: Delete a control assessment and all associated evidence links.
-      summary: Delete assessment
+    get:
+      operationId: catalogs_api_assessments_retrieve
+      description: Retrieve detailed information about a specific control assessment
+        including evidence links and progress.
+      summary: Get assessment details
       parameters:
       - in: path
         name: id
@@ -2069,8 +2990,12 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '204':
-          description: No response body
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlAssessmentDetail'
+          description: ''
     put:
       operationId: catalogs_api_assessments_update
       description: Update an existing control assessment. Requires all fields.
@@ -2106,11 +3031,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ControlAssessmentCreateUpdate'
           description: ''
-    get:
-      operationId: catalogs_api_assessments_retrieve
-      description: Retrieve detailed information about a specific control assessment
-        including evidence links and progress.
-      summary: Get assessment details
+    delete:
+      operationId: catalogs_api_assessments_destroy
+      description: Delete a control assessment and all associated evidence links.
+      summary: Delete assessment
       parameters:
       - in: path
         name: id
@@ -2124,12 +3048,8 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlAssessmentDetail'
-          description: ''
+        '204':
+          description: No response body
   /api/catalogs/api/assessments/{id}/bulk_upload_evidence/:
     post:
       operationId: catalogs_api_assessments_bulk_upload_evidence_create
@@ -2440,8 +3360,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/AssessmentEvidence'
           description: ''
-    delete:
-      operationId: catalogs_api_assessment_evidence_destroy
+    get:
+      operationId: catalogs_api_assessment_evidence_retrieve
       description: ViewSet for managing assessment evidence links.
       parameters:
       - in: path
@@ -2456,8 +3376,12 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '204':
-          description: No response body
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssessmentEvidence'
+          description: ''
     put:
       operationId: catalogs_api_assessment_evidence_update
       description: ViewSet for managing assessment evidence links.
@@ -2492,8 +3416,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/AssessmentEvidence'
           description: ''
-    get:
-      operationId: catalogs_api_assessment_evidence_retrieve
+    delete:
+      operationId: catalogs_api_assessment_evidence_destroy
       description: ViewSet for managing assessment evidence links.
       parameters:
       - in: path
@@ -2508,12 +3432,898 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
+        '204':
+          description: No response body
+  /api/compliance/artefacts/:
+    post:
+      operationId: compliance_artefacts_create
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GovernanceArtefact'
+          description: ''
+    get:
+      operationId: compliance_artefacts_list
+      parameters:
+      - in: query
+        name: artefact_type
+        schema:
+          type: string
+          enum:
+          - agenda
+          - management_review_pack
+          - metrics_pack
+          - nonconformity_log
+          - other
+          - regulatory_contractual_sheet
+          - scope_document
+        description: |-
+          * `scope_document` - Scope Document
+          * `metrics_pack` - Metrics Pack
+          * `agenda` - Agenda
+          * `management_review_pack` - Management Review Pack
+          * `regulatory_contractual_sheet` - Regulatory and Contractual Sheet
+          * `nonconformity_log` - Non-Conformity Log
+          * `other` - Other
+      - in: query
+        name: linked_frameworks
+        schema:
+          type: array
+          items:
+            type: integer
+        explode: true
+        style: form
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: owner
+        schema:
+          type: integer
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - approved
+          - archived
+          - draft
+          - published
+        description: |-
+          * `draft` - Draft
+          * `approved` - Approved
+          * `published` - Published
+          * `archived` - Archived
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AssessmentEvidence'
+                $ref: '#/components/schemas/PaginatedGovernanceArtefactList'
           description: ''
+  /api/compliance/artefacts/{id}/:
+    patch:
+      operationId: compliance_artefacts_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this governance artefact.
+        required: true
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedGovernanceArtefactRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedGovernanceArtefactRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedGovernanceArtefactRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GovernanceArtefact'
+          description: ''
+    get:
+      operationId: compliance_artefacts_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this governance artefact.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GovernanceArtefact'
+          description: ''
+    put:
+      operationId: compliance_artefacts_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this governance artefact.
+        required: true
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GovernanceArtefact'
+          description: ''
+    delete:
+      operationId: compliance_artefacts_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this governance artefact.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/compliance/regulatory-requirements/:
+    post:
+      operationId: compliance_regulatory_requirements_create
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryRequirement'
+          description: ''
+    get:
+      operationId: compliance_regulatory_requirements_list
+      parameters:
+      - in: query
+        name: applicability_status
+        schema:
+          type: string
+          enum:
+          - applicable
+          - not_applicable
+          - under_review
+        description: |-
+          * `under_review` - Under Review
+          * `applicable` - Applicable
+          * `not_applicable` - Not Applicable
+      - in: query
+        name: compliance_status
+        schema:
+          type: string
+          enum:
+          - accepted_risk
+          - compliant
+          - in_progress
+          - non_compliant
+          - not_started
+        description: |-
+          * `not_started` - Not Started
+          * `in_progress` - In Progress
+          * `compliant` - Compliant
+          * `non_compliant` - Non-Compliant
+          * `accepted_risk` - Accepted Risk
+      - in: query
+        name: linked_frameworks
+        schema:
+          type: array
+          items:
+            type: integer
+        explode: true
+        style: form
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: owner
+        schema:
+          type: integer
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: priority
+        schema:
+          type: string
+          enum:
+          - critical
+          - high
+          - low
+          - medium
+        description: |-
+          * `low` - Low
+          * `medium` - Medium
+          * `high` - High
+          * `critical` - Critical
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: source_type
+        schema:
+          type: string
+          enum:
+          - contract
+          - other
+          - policy
+          - regulation
+          - standard
+        description: |-
+          * `regulation` - Regulation
+          * `contract` - Contract
+          * `standard` - Standard
+          * `policy` - Policy
+          * `other` - Other
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRegulatoryRequirementList'
+          description: ''
+  /api/compliance/regulatory-requirements/{id}/:
+    patch:
+      operationId: compliance_regulatory_requirements_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this regulatory requirement.
+        required: true
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedRegulatoryRequirementRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedRegulatoryRequirementRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedRegulatoryRequirementRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryRequirement'
+          description: ''
+    get:
+      operationId: compliance_regulatory_requirements_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this regulatory requirement.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryRequirement'
+          description: ''
+    put:
+      operationId: compliance_regulatory_requirements_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this regulatory requirement.
+        required: true
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryRequirement'
+          description: ''
+    delete:
+      operationId: compliance_regulatory_requirements_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this regulatory requirement.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/compliance/non-conformities/:
+    post:
+      operationId: compliance_non_conformities_create
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NonConformityRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/NonConformityRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/NonConformityRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NonConformity'
+          description: ''
+    get:
+      operationId: compliance_non_conformities_list
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: owner
+        schema:
+          type: integer
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: regulatory_requirement
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: severity
+        schema:
+          type: string
+          enum:
+          - critical
+          - major
+          - minor
+        description: |-
+          * `minor` - Minor
+          * `major` - Major
+          * `critical` - Critical
+      - in: query
+        name: source_type
+        schema:
+          type: string
+          enum:
+          - assessment
+          - external_audit
+          - incident
+          - internal_audit
+          - management_review
+          - other
+          - vendor_review
+        description: |-
+          * `internal_audit` - Internal Audit
+          * `external_audit` - External Audit
+          * `assessment` - Assessment
+          * `incident` - Incident
+          * `management_review` - Management Review
+          * `vendor_review` - Vendor Review
+          * `other` - Other
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - accepted
+          - closed
+          - corrective_action
+          - open
+          - root_cause_review
+          - verification
+        description: |-
+          * `open` - Open
+          * `root_cause_review` - Root Cause Review
+          * `corrective_action` - Corrective Action
+          * `verification` - Verification
+          * `closed` - Closed
+          * `accepted` - Accepted
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedNonConformityList'
+          description: ''
+  /api/compliance/non-conformities/{id}/:
+    patch:
+      operationId: compliance_non_conformities_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this non conformity.
+        required: true
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedNonConformityRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedNonConformityRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedNonConformityRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NonConformity'
+          description: ''
+    get:
+      operationId: compliance_non_conformities_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this non conformity.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NonConformity'
+          description: ''
+    put:
+      operationId: compliance_non_conformities_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this non conformity.
+        required: true
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NonConformityRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/NonConformityRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/NonConformityRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NonConformity'
+          description: ''
+    delete:
+      operationId: compliance_non_conformities_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this non conformity.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/compliance/management-reviews/:
+    post:
+      operationId: compliance_management_reviews_create
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ManagementReviewRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ManagementReviewRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ManagementReviewRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagementReview'
+          description: ''
+    get:
+      operationId: compliance_management_reviews_list
+      parameters:
+      - in: query
+        name: chair
+        schema:
+          type: integer
+      - in: query
+        name: linked_nonconformities
+        schema:
+          type: array
+          items:
+            type: integer
+        explode: true
+        style: form
+      - in: query
+        name: linked_requirements
+        schema:
+          type: array
+          items:
+            type: integer
+        explode: true
+        style: form
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - actions_open
+          - cancelled
+          - closed
+          - held
+          - planned
+        description: |-
+          * `planned` - Planned
+          * `held` - Held
+          * `actions_open` - Actions Open
+          * `closed` - Closed
+          * `cancelled` - Cancelled
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedManagementReviewList'
+          description: ''
+  /api/compliance/management-reviews/{id}/:
+    patch:
+      operationId: compliance_management_reviews_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this management review.
+        required: true
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedManagementReviewRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedManagementReviewRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedManagementReviewRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagementReview'
+          description: ''
+    get:
+      operationId: compliance_management_reviews_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this management review.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagementReview'
+          description: ''
+    put:
+      operationId: compliance_management_reviews_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this management review.
+        required: true
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ManagementReviewRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ManagementReviewRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ManagementReviewRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagementReview'
+          description: ''
+    delete:
+      operationId: compliance_management_reviews_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this management review.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/exports/assessment-reports/:
     post:
       operationId: exports_assessment_reports_create
@@ -2700,10 +4510,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/AssessmentReport'
           description: ''
-    delete:
-      operationId: exports_assessment_reports_destroy
-      description: Delete an assessment report and its generated file if it exists.
-      summary: Delete report
+    get:
+      operationId: exports_assessment_reports_retrieve
+      description: Retrieve detailed information about a specific assessment report
+        including generation status.
+      summary: Get report details
       parameters:
       - in: path
         name: id
@@ -2716,8 +4527,12 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '204':
-          description: No response body
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssessmentReport'
+          description: ''
     put:
       operationId: exports_assessment_reports_update
       description: Update an existing assessment report configuration. Cannot update
@@ -2753,11 +4568,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/AssessmentReport'
           description: ''
-    get:
-      operationId: exports_assessment_reports_retrieve
-      description: Retrieve detailed information about a specific assessment report
-        including generation status.
-      summary: Get report details
+    delete:
+      operationId: exports_assessment_reports_destroy
+      description: Delete an assessment report and its generated file if it exists.
+      summary: Delete report
       parameters:
       - in: path
         name: id
@@ -2770,12 +4584,8 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssessmentReport'
-          description: ''
+        '204':
+          description: No response body
   /api/exports/assessment-reports/{id}/download/:
     get:
       operationId: exports_assessment_reports_download_retrieve
@@ -2855,6 +4665,5578 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssessmentReport'
+          description: ''
+  /api/exports/tenant-data-exports/:
+    post:
+      operationId: exports_tenant_data_exports_create
+      description: Create a tenant-wide GRC data export and start asynchronous generation.
+      summary: Create tenant data export
+      tags:
+      - Data Exports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantDataExportCreateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TenantDataExportCreateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TenantDataExportCreateRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantDataExportCreate'
+          description: ''
+    get:
+      operationId: exports_tenant_data_exports_list
+      description: Retrieve tenant data export jobs requested by the current user.
+      summary: List tenant data exports
+      tags:
+      - Data Exports
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TenantDataExport'
+          description: ''
+  /api/exports/tenant-data-exports/coverage/:
+    get:
+      operationId: exports_tenant_data_exports_coverage_retrieve
+      description: Return documented module coverage and supported formats for tenant
+        data exports.
+      summary: Get export coverage manifest
+      tags:
+      - Data Exports
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantDataExport'
+          description: ''
+  /api/exports/tenant-data-exports/{id}/:
+    get:
+      operationId: exports_tenant_data_exports_retrieve
+      description: Retrieve status and download metadata for a tenant data export.
+      summary: Get tenant data export
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Data Exports
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantDataExport'
+          description: ''
+    delete:
+      operationId: exports_tenant_data_exports_destroy
+      description: Delete a tenant data export job and its generated document reference.
+      summary: Delete tenant data export
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Data Exports
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/exports/tenant-data-exports/{id}/download/:
+    get:
+      operationId: exports_tenant_data_exports_download_retrieve
+      description: Tenant-scoped customer data exports across all GRC modules.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - exports
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantDataExport'
+          description: ''
+  /api/exports/tenant-data-exports/{id}/generate/:
+    post:
+      operationId: exports_tenant_data_exports_generate_create
+      description: Start asynchronous generation for a failed or pending tenant data
+        export.
+      summary: Regenerate tenant data export
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - Data Exports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantDataExportRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TenantDataExportRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TenantDataExportRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '202':
+          description: Export generation started
+        '400':
+          description: Export already processing or completed
+  /api/exports/tenant-data-exports/{id}/status_check/:
+    get:
+      operationId: exports_tenant_data_exports_status_check_retrieve
+      description: Tenant-scoped customer data exports across all GRC modules.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - exports
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantDataExport'
+          description: ''
+  /api/risk/risks/:
+    post:
+      operationId: risk_risks_create
+      description: Create a new risk entry with impact and likelihood assessment.
+      summary: Create new risk
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskCreateUpdate'
+          description: ''
+    get:
+      operationId: risk_risks_list
+      description: Retrieve a paginated list of risks with comprehensive filtering,
+        searching, and ordering capabilities.
+      summary: List risks
+      parameters:
+      - in: query
+        name: active_only
+        schema:
+          type: boolean
+        description: Show only active risks (excludes closed/transferred)
+      - in: query
+        name: category
+        schema:
+          type: integer
+        description: Filter by category ID
+      - in: query
+        name: has_treatment
+        schema:
+          type: boolean
+        description: Filter risks that have a treatment strategy defined.
+      - in: query
+        name: high_priority
+        schema:
+          type: boolean
+        description: Filter only high and critical priority risks.
+      - in: query
+        name: identified_date_after
+        schema:
+          type: string
+          format: date
+        description: Filter risks identified on or after this date (YYYY-MM-DD).
+      - in: query
+        name: identified_date_before
+        schema:
+          type: string
+          format: date
+        description: Filter risks identified on or before this date (YYYY-MM-DD).
+      - in: query
+        name: impact_max
+        schema:
+          type: integer
+        description: Filter risks with impact <= this value (1-5).
+      - in: query
+        name: impact_min
+        schema:
+          type: integer
+        description: Filter risks with impact >= this value (1-5).
+      - in: query
+        name: last_assessed_after
+        schema:
+          type: string
+          format: date
+        description: Filter risks last assessed on or after this date (YYYY-MM-DD).
+      - in: query
+        name: last_assessed_before
+        schema:
+          type: string
+          format: date
+        description: Filter risks last assessed on or before this date (YYYY-MM-DD).
+      - in: query
+        name: likelihood_max
+        schema:
+          type: integer
+        description: Filter risks with likelihood <= this value (1-5).
+      - in: query
+        name: likelihood_min
+        schema:
+          type: integer
+        description: Filter risks with likelihood >= this value (1-5).
+      - in: query
+        name: my_risks
+        schema:
+          type: boolean
+        description: Show only risks owned by current user
+      - in: query
+        name: next_review_after
+        schema:
+          type: string
+          format: date
+        description: Filter risks with next review on or after this date (YYYY-MM-DD).
+      - in: query
+        name: next_review_before
+        schema:
+          type: string
+          format: date
+        description: Filter risks with next review on or before this date (YYYY-MM-DD).
+      - in: query
+        name: ordering
+        schema:
+          type: string
+        description: 'Order by: risk_level, risk_score, title, identified_date, next_review_date
+          (prefix with - for descending)'
+      - in: query
+        name: overdue_review
+        schema:
+          type: boolean
+        description: Show only risks overdue for review
+      - in: query
+        name: risk_level
+        schema:
+          type: string
+        description: Filter by risk level (low, medium, high, critical)
+      - in: query
+        name: risk_owner
+        schema:
+          type: integer
+        description: Filter by risk owner user ID
+      - in: query
+        name: risk_score_max
+        schema:
+          type: number
+        description: Filter risks with risk score <= this value.
+      - in: query
+        name: risk_score_min
+        schema:
+          type: number
+        description: Filter risks with risk score >= this value.
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: Search across risk_id, title, description
+      - in: query
+        name: status
+        schema:
+          type: string
+        description: Filter by risk status
+      - in: query
+        name: treatment_strategy
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - accept
+            - avoid
+            - mitigate
+            - transfer
+        description: |-
+          Filter by treatment strategy. Supports multiple values.
+
+          * `mitigate` - Mitigate
+          * `accept` - Accept
+          * `transfer` - Transfer
+          * `avoid` - Avoid
+        explode: true
+        style: form
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskList'
+              examples:
+                HighPriorityRisks:
+                  value:
+                  - ?risk_level=high,critical&active_only=true
+                  summary: Get high and critical risks
+                  description: Example of filtering for high priority risks
+          description: ''
+  /api/risk/risks/bulk_create/:
+    post:
+      operationId: risk_risks_bulk_create_create
+      description: Create multiple risks in a single operation with common defaults
+        and individual overrides.
+      summary: Bulk create risks
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkRiskCreateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BulkRiskCreateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BulkRiskCreateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          description: Risks created successfully
+        '400':
+          description: Invalid bulk creation data
+  /api/risk/risks/by_category/:
+    get:
+      operationId: risk_risks_by_category_retrieve
+      description: Retrieve risks grouped by category with counts and summaries.
+      summary: Get risks by category
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: Risks grouped by category
+  /api/risk/risks/summary/:
+    get:
+      operationId: risk_risks_summary_retrieve
+      description: Generate comprehensive risk summary with statistics, breakdowns,
+        and priority lists.
+      summary: Get risk summary and analytics
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskSummary'
+          description: ''
+  /api/risk/risks/{id}/:
+    patch:
+      operationId: risk_risks_partial_update
+      description: Update specific fields of an existing risk entry.
+      summary: Partially update risk
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk.
+        required: true
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskCreateUpdateRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskCreateUpdate'
+          description: ''
+    get:
+      operationId: risk_risks_retrieve
+      description: Retrieve detailed information about a specific risk including notes
+        and history.
+      summary: Get risk details
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk.
+        required: true
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskDetail'
+          description: ''
+    put:
+      operationId: risk_risks_update
+      description: Update an existing risk entry. Risk level will be automatically
+        recalculated.
+      summary: Update risk
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk.
+        required: true
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskCreateUpdate'
+          description: ''
+    delete:
+      operationId: risk_risks_destroy
+      description: Delete a risk entry and all associated notes.
+      summary: Delete risk
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk.
+        required: true
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/risk/risks/{id}/add_note/:
+    post:
+      operationId: risk_risks_add_note_create
+      description: Add a note or comment to a risk for tracking progress and decisions.
+      summary: Add risk note
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk.
+        required: true
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                note:
+                  type: string
+                  description: Note content
+                note_type:
+                  type: string
+                  enum:
+                  - general
+                  - assessment
+                  - treatment
+                  - review
+                  - status_change
+                  description: Type of note
+              required:
+              - note
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskNote'
+          description: ''
+        '400':
+          description: Invalid note data
+  /api/risk/risks/{id}/update_status/:
+    post:
+      operationId: risk_risks_update_status_create
+      description: Update risk status with optional treatment strategy and notes.
+        Automatically creates a status change note.
+      summary: Update risk status
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk.
+        required: true
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskStatusUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskStatusUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskStatusUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskDetail'
+          description: ''
+        '400':
+          description: Invalid status update data
+        '404':
+          description: Risk not found
+  /api/risk/categories/:
+    post:
+      operationId: risk_categories_create
+      description: Create a new risk category for organizing risks.
+      summary: Create risk category
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskCategory'
+          description: ''
+    get:
+      operationId: risk_categories_list
+      description: Retrieve all risk categories with risk counts.
+      summary: List risk categories
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskCategory'
+          description: ''
+  /api/risk/categories/{id}/:
+    patch:
+      operationId: risk_categories_partial_update
+      description: |-
+        **Risk Category Management**
+
+        Manage risk categories for organizing and classifying risks.
+        Categories help in grouping related risks and generating targeted reports.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk category.
+        required: true
+      tags:
+      - risk
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskCategoryRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskCategory'
+          description: ''
+    get:
+      operationId: risk_categories_retrieve
+      description: Retrieve detailed information about a risk category.
+      summary: Get category details
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk category.
+        required: true
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskCategory'
+          description: ''
+    put:
+      operationId: risk_categories_update
+      description: Update an existing risk category.
+      summary: Update risk category
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk category.
+        required: true
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskCategory'
+          description: ''
+    delete:
+      operationId: risk_categories_destroy
+      description: Delete a risk category. Risks in this category will become uncategorized.
+      summary: Delete risk category
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk category.
+        required: true
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/risk/matrices/:
+    post:
+      operationId: risk_matrices_create
+      description: Create a new risk assessment matrix with custom configuration.
+      summary: Create risk matrix
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskMatrix'
+          description: ''
+    get:
+      operationId: risk_matrices_list
+      description: Retrieve all available risk assessment matrices.
+      summary: List risk matrices
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskMatrix'
+          description: ''
+  /api/risk/matrices/{id}/:
+    patch:
+      operationId: risk_matrices_partial_update
+      description: |-
+        **Risk Matrix Management**
+
+        Manage configurable risk assessment matrices for calculating risk levels
+        based on impact and likelihood combinations.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk matrix.
+        required: true
+      tags:
+      - risk
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskMatrixRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskMatrixRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskMatrixRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskMatrix'
+          description: ''
+    get:
+      operationId: risk_matrices_retrieve
+      description: Retrieve detailed information about a risk matrix including configuration.
+      summary: Get matrix details
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk matrix.
+        required: true
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskMatrix'
+          description: ''
+    put:
+      operationId: risk_matrices_update
+      description: Update an existing risk matrix configuration.
+      summary: Update risk matrix
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk matrix.
+        required: true
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskMatrix'
+          description: ''
+    delete:
+      operationId: risk_matrices_destroy
+      description: Delete a risk matrix. Cannot delete if it's the default matrix
+        or in use by risks.
+      summary: Delete risk matrix
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk matrix.
+        required: true
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/risk/actions/:
+    post:
+      operationId: risk_actions_create
+      description: Create a new risk action with assignment and scheduling.
+      summary: Create new risk action
+      tags:
+      - Risk Actions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionCreateUpdate'
+          description: ''
+    get:
+      operationId: risk_actions_list
+      description: Retrieve a paginated list of risk actions with comprehensive filtering,
+        searching, and ordering capabilities.
+      summary: List risk actions
+      parameters:
+      - in: query
+        name: action_type
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - assessment
+            - corrective
+            - detective
+            - other
+            - policy
+            - preventive
+            - technical
+            - training
+        description: |-
+          Filter by action type. Supports multiple values.
+
+          * `preventive` - Preventive Control
+          * `detective` - Detective Control
+          * `corrective` - Corrective Action
+          * `policy` - Policy/Procedure
+          * `training` - Training/Awareness
+          * `technical` - Technical Implementation
+          * `assessment` - Assessment/Review
+          * `other` - Other
+        explode: true
+        style: form
+      - in: query
+        name: active_only
+        schema:
+          type: boolean
+        description: Show only active actions (excludes completed/cancelled)
+      - in: query
+        name: assigned_to
+        schema:
+          type: integer
+        description: Filter by assigned user ID
+      - in: query
+        name: assigned_to_me
+        schema:
+          type: boolean
+        description: Show only actions assigned to current user
+      - in: query
+        name: completed_date_after
+        schema:
+          type: string
+          format: date
+        description: Filter actions completed on or after this date (YYYY-MM-DD).
+      - in: query
+        name: completed_date_before
+        schema:
+          type: string
+          format: date
+        description: Filter actions completed on or before this date (YYYY-MM-DD).
+      - in: query
+        name: due_date_after
+        schema:
+          type: string
+          format: date
+        description: Filter actions due on or after this date (YYYY-MM-DD).
+      - in: query
+        name: due_date_before
+        schema:
+          type: string
+          format: date
+        description: Filter actions due on or before this date (YYYY-MM-DD).
+      - in: query
+        name: due_soon
+        schema:
+          type: boolean
+        description: Show only actions due within 7 days
+      - in: query
+        name: has_evidence
+        schema:
+          type: boolean
+        description: Filter actions that have evidence uploaded.
+      - in: query
+        name: high_priority
+        schema:
+          type: boolean
+        description: Filter only high and critical priority actions.
+      - in: query
+        name: ordering
+        schema:
+          type: string
+        description: 'Order by: due_date, priority, status, title, progress_percentage
+          (prefix with - for descending)'
+      - in: query
+        name: overdue
+        schema:
+          type: boolean
+        description: Show only overdue actions
+      - in: query
+        name: priority
+        schema:
+          type: string
+        description: Filter by action priority (low, medium, high, critical)
+      - in: query
+        name: progress_max
+        schema:
+          type: integer
+        description: Filter actions with progress <= this value (0-100).
+      - in: query
+        name: progress_min
+        schema:
+          type: integer
+        description: Filter actions with progress >= this value (0-100).
+      - in: query
+        name: risk
+        schema:
+          type: array
+          items:
+            type: integer
+        description: Filter by risk ID(s). Supports multiple values.
+        explode: true
+        style: form
+      - in: query
+        name: risk_level
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - critical
+            - high
+            - low
+            - medium
+        description: |-
+          Filter by related risk level. Supports multiple values.
+
+          * `low` - Low
+          * `medium` - Medium
+          * `high` - High
+          * `critical` - Critical
+        explode: true
+        style: form
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: Search across action_id, title, description, risk details
+      - in: query
+        name: start_date_after
+        schema:
+          type: string
+          format: date
+        description: Filter actions with start date on or after this date (YYYY-MM-DD).
+      - in: query
+        name: start_date_before
+        schema:
+          type: string
+          format: date
+        description: Filter actions with start date on or before this date (YYYY-MM-DD).
+      - in: query
+        name: status
+        schema:
+          type: string
+        description: Filter by action status (pending, in_progress, completed, cancelled,
+          deferred)
+      tags:
+      - Risk Actions
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskActionList'
+          description: ''
+  /api/risk/actions/bulk_create/:
+    post:
+      operationId: risk_actions_bulk_create_create
+      description: Create multiple risk actions in a single operation for efficiency.
+      summary: Bulk create risk actions
+      tags:
+      - Risk Actions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionBulkCreateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionBulkCreateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionBulkCreateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          description: Actions created successfully
+        '400':
+          description: Invalid bulk creation data
+  /api/risk/actions/by_risk/:
+    get:
+      operationId: risk_actions_by_risk_retrieve
+      description: Retrieve risk actions grouped by risk with counts and summaries.
+      summary: Get actions by risk
+      tags:
+      - Risk Actions
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: Actions grouped by risk
+  /api/risk/actions/summary/:
+    get:
+      operationId: risk_actions_summary_retrieve
+      description: Retrieve comprehensive statistics and analytics for risk actions.
+      summary: Get risk action summary
+      tags:
+      - Risk Actions
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionSummary'
+          description: ''
+  /api/risk/actions/{id}/:
+    patch:
+      operationId: risk_actions_partial_update
+      description: Update specific fields of an existing risk action.
+      summary: Partially update risk action
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk action.
+        required: true
+      tags:
+      - Risk Actions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskActionCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskActionCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskActionCreateUpdateRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionCreateUpdate'
+          description: ''
+    get:
+      operationId: risk_actions_retrieve
+      description: Retrieve detailed information about a specific risk action including
+        notes and evidence.
+      summary: Get risk action details
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk action.
+        required: true
+      tags:
+      - Risk Actions
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionDetail'
+          description: ''
+    put:
+      operationId: risk_actions_update
+      description: Update an existing risk action. Progress and status will be validated.
+      summary: Update risk action
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk action.
+        required: true
+      tags:
+      - Risk Actions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionCreateUpdate'
+          description: ''
+    delete:
+      operationId: risk_actions_destroy
+      description: Delete a risk action and all associated notes and evidence.
+      summary: Delete risk action
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk action.
+        required: true
+      tags:
+      - Risk Actions
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/risk/actions/{id}/add_note/:
+    post:
+      operationId: risk_actions_add_note_create
+      description: Add a progress note to track work done on this risk action.
+      summary: Add progress note
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk action.
+        required: true
+      tags:
+      - Risk Actions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionNoteCreateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionNoteCreateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionNoteCreateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionNote'
+          description: ''
+        '400':
+          description: Invalid note data
+        '404':
+          description: Risk action not found
+  /api/risk/actions/{id}/update_status/:
+    post:
+      operationId: risk_actions_update_status_create
+      description: Update the status of a risk action with optional progress percentage
+        and note.
+      summary: Update risk action status
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk action.
+        required: true
+      tags:
+      - Risk Actions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionStatusUpdateRequest'
+            examples:
+              CompleteAction:
+                value:
+                  status: completed
+                  progress_percentage: 100
+                  note: All required tasks completed and evidence uploaded.
+                summary: Mark action as completed
+                description: Example of completing a risk action with note
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionStatusUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionStatusUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionDetail'
+              examples:
+                CompleteAction:
+                  value:
+                    status: completed
+                    progress_percentage: 100
+                    note: All required tasks completed and evidence uploaded.
+                  summary: Mark action as completed
+                  description: Example of completing a risk action with note
+          description: ''
+        '400':
+          description: Invalid status update data
+        '404':
+          description: Risk action not found
+  /api/risk/actions/{id}/upload_evidence/:
+    post:
+      operationId: risk_actions_upload_evidence_create
+      description: Upload evidence file or link to document action completion.
+      summary: Upload evidence
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk action.
+        required: true
+      tags:
+      - Risk Actions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionEvidenceCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionEvidenceCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionEvidenceCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionEvidence'
+          description: ''
+        '400':
+          description: Invalid evidence data
+        '404':
+          description: Risk action not found
+  /api/risk/reminder-config/:
+    post:
+      operationId: risk_reminder_config_create
+      description: Create risk action reminder configuration for current user.
+      summary: Create reminder configuration
+      tags:
+      - Risk Action Reminders
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionReminderConfiguration'
+          description: ''
+    get:
+      operationId: risk_reminder_config_list
+      description: Retrieve risk action reminder configurations for all users.
+      summary: List reminder configurations
+      tags:
+      - Risk Action Reminders
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskActionReminderConfiguration'
+          description: ''
+  /api/risk/reminder-config/{id}/:
+    patch:
+      operationId: risk_reminder_config_partial_update
+      description: |-
+        **Risk Action Reminder Configuration Management**
+
+        Manage automated reminder settings for risk actions including:
+        - Email notification preferences
+        - Reminder timing and frequency
+        - Weekly digest settings
+        - Auto-silence options
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Risk Action Reminder
+          Configuration.
+        required: true
+      tags:
+      - risk
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskActionReminderConfigurationRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskActionReminderConfigurationRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskActionReminderConfigurationRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionReminderConfiguration'
+          description: ''
+    get:
+      operationId: risk_reminder_config_retrieve
+      description: Retrieve detailed risk action reminder configuration.
+      summary: Get reminder configuration
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Risk Action Reminder
+          Configuration.
+        required: true
+      tags:
+      - Risk Action Reminders
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionReminderConfiguration'
+          description: ''
+    put:
+      operationId: risk_reminder_config_update
+      description: Update risk action reminder configuration settings.
+      summary: Update reminder configuration
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Risk Action Reminder
+          Configuration.
+        required: true
+      tags:
+      - Risk Action Reminders
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionReminderConfiguration'
+          description: ''
+    delete:
+      operationId: risk_reminder_config_destroy
+      description: |-
+        **Risk Action Reminder Configuration Management**
+
+        Manage automated reminder settings for risk actions including:
+        - Email notification preferences
+        - Reminder timing and frequency
+        - Weekly digest settings
+        - Auto-silence options
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Risk Action Reminder
+          Configuration.
+        required: true
+      tags:
+      - risk
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/risk/analytics/action_overview/:
+    get:
+      operationId: risk_analytics_action_overview_retrieve
+      description: |-
+        Get risk action overview statistics and progress metrics.
+
+        Provides:
+        - Action counts and status distribution
+        - Progress tracking and completion rates
+        - Due date analysis and overdue alerts
+        - Assignee workload and performance metrics
+      tags:
+      - risk
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/risk/analytics/action_progress/:
+    get:
+      operationId: risk_analytics_action_progress_retrieve
+      description: |-
+        Get detailed risk action progress and effectiveness analysis.
+
+        Provides:
+        - Action velocity and completion metrics
+        - Treatment effectiveness by strategy type
+        - Evidence collection and validation statistics
+        - Performance analysis by risk level and category
+      tags:
+      - risk
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/risk/analytics/category_analysis/:
+    get:
+      operationId: risk_analytics_category_analysis_retrieve
+      description: |-
+        Get detailed analysis for specific risk category or all categories.
+
+        Query Parameters:
+        - category_id: Specific category ID for deep dive (optional)
+
+        Provides:
+        - Category-specific risk metrics and breakdowns
+        - Treatment analysis and action progress
+        - Comparative analysis across categories
+      tags:
+      - risk
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/risk/analytics/control_integration/:
+    get:
+      operationId: risk_analytics_control_integration_retrieve
+      description: |-
+        Get risk-control integration analysis (basic version).
+
+        Provides:
+        - Control coverage analysis for risks
+        - Gap identification by category
+        - Integration readiness metrics
+
+        Note: This will be enhanced with full risk-control mapping in future iterations.
+      tags:
+      - risk
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/risk/analytics/dashboard/:
+    get:
+      operationId: risk_analytics_dashboard_retrieve
+      description: |-
+        Get comprehensive risk analytics dashboard data.
+
+        Returns complete dashboard dataset including:
+        - Risk overview statistics
+        - Risk action progress metrics
+        - Heat map visualization data
+        - Trend analysis and forecasting
+        - Executive summary metrics
+      tags:
+      - risk
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/risk/analytics/executive_summary/:
+    get:
+      operationId: risk_analytics_executive_summary_retrieve
+      description: |-
+        Get executive-level risk summary for leadership reporting.
+
+        Provides high-level metrics including:
+        - Key risk indicators and exposure metrics
+        - Quarterly trend analysis and net risk changes
+        - Treatment progress and completion rates
+        - Governance indicators and maturity metrics
+        - Top risk areas and priority recommendations
+      tags:
+      - risk
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/risk/analytics/heat_map/:
+    get:
+      operationId: risk_analytics_heat_map_retrieve
+      description: |-
+        Get risk heat map data for impact vs likelihood visualization.
+
+        Returns matrix data showing:
+        - Risk distribution across impact/likelihood combinations
+        - Risk counts and levels for each matrix cell
+        - Detailed risk information for drill-down analysis
+        - Matrix configuration and labeling
+      tags:
+      - risk
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/risk/analytics/risk_overview/:
+    get:
+      operationId: risk_analytics_risk_overview_retrieve
+      description: |-
+        Get risk overview statistics including counts, distributions, and key metrics.
+
+        Provides:
+        - Total and active risk counts
+        - Risk level and status distributions
+        - Category analysis and treatment strategy breakdown
+        - Recent activity and overdue review alerts
+      tags:
+      - risk
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/risk/analytics/trends/:
+    get:
+      operationId: risk_analytics_trends_retrieve
+      description: |-
+        Get risk trend analysis over specified time period.
+
+        Query Parameters:
+        - days: Number of days for trend analysis (default: 90, max: 365)
+
+        Provides:
+        - Risk creation and closure trends over time
+        - Active risk count evolution
+        - Monthly and quarterly trend analysis
+        - Forecasting indicators
+      tags:
+      - risk
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/policies/categories/:
+    post:
+      operationId: policies_categories_create
+      description: ViewSet for managing policy categories.
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyCategoryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCategory'
+          description: ''
+    get:
+      operationId: policies_categories_list
+      description: ViewSet for managing policy categories.
+      parameters:
+      - in: query
+        name: name
+        schema:
+          type: string
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyCategory'
+          description: ''
+  /api/policies/categories/{id}/:
+    patch:
+      operationId: policies_categories_partial_update
+      description: ViewSet for managing policy categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Category.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCategoryRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCategory'
+          description: ''
+    get:
+      operationId: policies_categories_retrieve
+      description: ViewSet for managing policy categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Category.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCategory'
+          description: ''
+    put:
+      operationId: policies_categories_update
+      description: ViewSet for managing policy categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Category.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyCategoryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCategory'
+          description: ''
+    delete:
+      operationId: policies_categories_destroy
+      description: ViewSet for managing policy categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Category.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/policies/categories/{id}/policies/:
+    get:
+      operationId: policies_categories_policies_retrieve
+      description: Get all policies in this category.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Category.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCategory'
+          description: ''
+  /api/policies/policies/:
+    post:
+      operationId: policies_policies_create
+      description: ViewSet for managing policies with versioning support.
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCreateUpdate'
+          description: ''
+    get:
+      operationId: policies_policies_list
+      description: ViewSet for managing policies with versioning support.
+      parameters:
+      - in: query
+        name: category
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: category_name
+        schema:
+          type: string
+      - in: query
+        name: created_after
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: created_before
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: created_by
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: due_for_review
+        schema:
+          type: boolean
+      - in: query
+        name: has_active_version
+        schema:
+          type: boolean
+      - in: query
+        name: owner
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: policy_type
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - framework
+            - guideline
+            - policy
+            - procedure
+            - standard
+        description: |-
+          * `procedure` - Procedure
+          * `policy` - Policy
+          * `standard` - Standard
+          * `guideline` - Guideline
+          * `framework` - Framework
+        explode: true
+        style: form
+      - in: query
+        name: requires_acknowledgment
+        schema:
+          type: boolean
+      - in: query
+        name: review_overdue
+        schema:
+          type: boolean
+      - in: query
+        name: search
+        schema:
+          type: string
+      - in: query
+        name: status
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - approved
+            - archived
+            - draft
+            - under_review
+        description: |-
+          * `draft` - Draft
+          * `under_review` - Under Review
+          * `approved` - Approved
+          * `archived` - Archived
+        explode: true
+        style: form
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyList'
+          description: ''
+  /api/policies/policies/acknowledgment_dashboard/:
+    get:
+      operationId: policies_policies_acknowledgment_dashboard_retrieve
+      description: Get acknowledgment dashboard data for all policies.
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDetail'
+          description: ''
+  /api/policies/policies/my_policies/:
+    get:
+      operationId: policies_policies_my_policies_retrieve
+      description: Get policies requiring acknowledgment by the current user.
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDetail'
+          description: ''
+  /api/policies/policies/summary/:
+    get:
+      operationId: policies_policies_summary_retrieve
+      description: Get policy repository summary statistics.
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDetail'
+          description: ''
+  /api/policies/policies/{id}/:
+    patch:
+      operationId: policies_policies_partial_update
+      description: ViewSet for managing policies with versioning support.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCreateUpdateRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCreateUpdate'
+          description: ''
+    get:
+      operationId: policies_policies_retrieve
+      description: ViewSet for managing policies with versioning support.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDetail'
+          description: ''
+    put:
+      operationId: policies_policies_update
+      description: ViewSet for managing policies with versioning support.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCreateUpdate'
+          description: ''
+    delete:
+      operationId: policies_policies_destroy
+      description: ViewSet for managing policies with versioning support.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/policies/policies/{id}/acknowledge/:
+    post:
+      operationId: policies_policies_acknowledge_create
+      description: Acknowledge the current version of a policy.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDetail'
+          description: ''
+  /api/policies/policies/{id}/acknowledgment_status/:
+    get:
+      operationId: policies_policies_acknowledgment_status_retrieve
+      description: Get detailed acknowledgment status for a specific policy.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDetail'
+          description: ''
+  /api/policies/policies/{id}/distribute/:
+    post:
+      operationId: policies_policies_distribute_create
+      description: Distribute policy to users.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDetail'
+          description: ''
+  /api/policies/policies/{id}/versions/:
+    get:
+      operationId: policies_policies_versions_retrieve
+      description: Get all versions of a specific policy.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDetail'
+          description: ''
+  /api/policies/versions/:
+    post:
+      operationId: policies_versions_create
+      description: ViewSet for managing policy versions.
+      tags:
+      - policies
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+    get:
+      operationId: policies_versions_list
+      description: ViewSet for managing policy versions.
+      parameters:
+      - in: query
+        name: approved_by
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: created_after
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: created_before
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: created_by
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: effective_after
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: effective_before
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: has_document
+        schema:
+          type: boolean
+      - in: query
+        name: is_active
+        schema:
+          type: boolean
+      - in: query
+        name: is_approved
+        schema:
+          type: boolean
+      - in: query
+        name: is_published
+        schema:
+          type: boolean
+      - in: query
+        name: policy
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: policy_code
+        schema:
+          type: string
+      - in: query
+        name: policy_title
+        schema:
+          type: string
+      - in: query
+        name: version_number
+        schema:
+          type: string
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyVersionList'
+          description: ''
+  /api/policies/versions/{id}/:
+    patch:
+      operationId: policies_versions_partial_update
+      description: ViewSet for managing policy versions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyVersionDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyVersionDetailRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyVersionDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+    get:
+      operationId: policies_versions_retrieve
+      description: ViewSet for managing policy versions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+    put:
+      operationId: policies_versions_update
+      description: ViewSet for managing policy versions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+    delete:
+      operationId: policies_versions_destroy
+      description: ViewSet for managing policy versions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/policies/versions/{id}/activate/:
+    post:
+      operationId: policies_versions_activate_create
+      description: Activate this version as the current version.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+  /api/policies/versions/{id}/approve/:
+    post:
+      operationId: policies_versions_approve_create
+      description: Approve this version.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+  /api/policies/versions/{id}/audit-logs/:
+    get:
+      operationId: policies_versions_audit_logs_retrieve
+      description: Return audit events for a policy version.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+  /api/policies/versions/{id}/download/:
+    get:
+      operationId: policies_versions_download_retrieve
+      description: Download policy document.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+  /api/policies/versions/{id}/download-source/:
+    get:
+      operationId: policies_versions_download_source_retrieve
+      description: Download editable source document for authorised editors and administrators.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+  /api/policies/versions/{id}/finalize/:
+    post:
+      operationId: policies_versions_finalize_create
+      description: Generate final PDF and lock normal downloads to PDF.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+  /api/policies/versions/{id}/publish/:
+    post:
+      operationId: policies_versions_publish_create
+      description: Publish this version.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+  /api/policies/acknowledgments/:
+    get:
+      operationId: policies_acknowledgments_list
+      description: ViewSet for viewing policy acknowledgments.
+      parameters:
+      - in: query
+        name: acknowledged_after
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: acknowledged_before
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: expires_soon
+        schema:
+          type: number
+      - in: query
+        name: is_expired
+        schema:
+          type: boolean
+      - in: query
+        name: policy
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: policy_code
+        schema:
+          type: string
+      - in: query
+        name: policy_version
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: user
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: user_email
+        schema:
+          type: string
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyAcknowledgment'
+          description: ''
+  /api/policies/acknowledgments/my_acknowledgments/:
+    get:
+      operationId: policies_acknowledgments_my_acknowledgments_retrieve
+      description: Get current user's acknowledgments.
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyAcknowledgment'
+          description: ''
+  /api/policies/acknowledgments/{id}/:
+    get:
+      operationId: policies_acknowledgments_retrieve
+      description: ViewSet for viewing policy acknowledgments.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Acknowledgment.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyAcknowledgment'
+          description: ''
+  /api/policies/distributions/:
+    get:
+      operationId: policies_distributions_list
+      description: ViewSet for viewing policy distributions.
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyDistribution'
+          description: ''
+  /api/policies/distributions/my_distributions/:
+    get:
+      operationId: policies_distributions_my_distributions_retrieve
+      description: Get policies distributed to current user.
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDistribution'
+          description: ''
+  /api/policies/distributions/pending/:
+    get:
+      operationId: policies_distributions_pending_retrieve
+      description: Get pending acknowledgments (policies distributed but not acknowledged).
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDistribution'
+          description: ''
+  /api/policies/distributions/{id}/:
+    get:
+      operationId: policies_distributions_retrieve
+      description: ViewSet for viewing policy distributions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Distribution.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDistribution'
+          description: ''
+  /api/training/categories/:
+    post:
+      operationId: training_categories_create
+      description: ViewSet for managing training categories.
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainingCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TrainingCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TrainingCategoryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingCategory'
+          description: ''
+    get:
+      operationId: training_categories_list
+      description: ViewSet for managing training categories.
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrainingCategory'
+          description: ''
+  /api/training/categories/{id}/:
+    patch:
+      operationId: training_categories_partial_update
+      description: ViewSet for managing training categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training category.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedTrainingCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedTrainingCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedTrainingCategoryRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingCategory'
+          description: ''
+    get:
+      operationId: training_categories_retrieve
+      description: ViewSet for managing training categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training category.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingCategory'
+          description: ''
+    put:
+      operationId: training_categories_update
+      description: ViewSet for managing training categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training category.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainingCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TrainingCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TrainingCategoryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingCategory'
+          description: ''
+    delete:
+      operationId: training_categories_destroy
+      description: ViewSet for managing training categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training category.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/training/videos/:
+    post:
+      operationId: training_videos_create
+      description: ViewSet for managing training videos.
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingVideoDetail'
+          description: ''
+    get:
+      operationId: training_videos_list
+      description: ViewSet for managing training videos.
+      parameters:
+      - in: query
+        name: category
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: category_name
+        schema:
+          type: string
+      - in: query
+        name: created_after
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: created_before
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: created_by
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: difficulty_level
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - beginner
+            - intermediate
+        description: |-
+          * `beginner` - Beginner
+          * `intermediate` - Intermediate
+          * `advanced` - Advanced
+        explode: true
+        style: form
+      - in: query
+        name: duration_max
+        schema:
+          type: integer
+      - in: query
+        name: duration_min
+        schema:
+          type: integer
+      - in: query
+        name: has_duration
+        schema:
+          type: boolean
+      - in: query
+        name: is_published
+        schema:
+          type: boolean
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: popular
+        schema:
+          type: boolean
+      - in: query
+        name: published_after
+        schema:
+          type: string
+          format: date
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: video_provider
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - custom
+            - synthesia
+            - vimeo
+            - youtube
+        description: |-
+          * `synthesia` - Synthesia.io
+          * `youtube` - YouTube
+          * `vimeo` - Vimeo
+          * `custom` - Custom URL
+        explode: true
+        style: form
+      - in: query
+        name: view_count_min
+        schema:
+          type: integer
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrainingVideoList'
+          description: ''
+  /api/training/videos/analytics/:
+    get:
+      operationId: training_videos_analytics_retrieve
+      description: Get video analytics.
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingVideoDetail'
+          description: ''
+  /api/training/videos/{id}/:
+    patch:
+      operationId: training_videos_partial_update
+      description: ViewSet for managing training videos.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training video.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedTrainingVideoDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedTrainingVideoDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedTrainingVideoDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingVideoDetail'
+          description: ''
+    get:
+      operationId: training_videos_retrieve
+      description: ViewSet for managing training videos.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training video.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingVideoDetail'
+          description: ''
+    put:
+      operationId: training_videos_update
+      description: ViewSet for managing training videos.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training video.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingVideoDetail'
+          description: ''
+    delete:
+      operationId: training_videos_destroy
+      description: ViewSet for managing training videos.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training video.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/training/videos/{id}/track_view/:
+    post:
+      operationId: training_videos_track_view_create
+      description: Track a video view.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training video.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingVideoDetail'
+          description: ''
+  /api/training/campaigns/:
+    post:
+      operationId: training_campaigns_create
+      description: ViewSet for managing security awareness campaigns.
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
+    get:
+      operationId: training_campaigns_list
+      description: ViewSet for managing security awareness campaigns.
+      parameters:
+      - in: query
+        name: created_by
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: due_to_send
+        schema:
+          type: boolean
+      - in: query
+        name: end_date_after
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: end_date_before
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: has_sends
+        schema:
+          type: boolean
+      - in: query
+        name: has_target_users
+        schema:
+          type: boolean
+      - in: query
+        name: high_open_rate
+        schema:
+          type: boolean
+      - in: query
+        name: is_active
+        schema:
+          type: boolean
+      - in: query
+        name: low_open_rate
+        schema:
+          type: boolean
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: overdue
+        schema:
+          type: boolean
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: send_frequency
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - biweekly
+            - monthly
+            - quarterly
+            - weekly
+        description: |-
+          * `weekly` - Weekly
+          * `biweekly` - Bi-weekly
+          * `monthly` - Monthly
+          * `quarterly` - Quarterly
+        explode: true
+        style: form
+      - in: query
+        name: send_to_all_users
+        schema:
+          type: boolean
+      - in: query
+        name: start_date_after
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: start_date_before
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - active
+          - ended
+          - inactive
+          - ready_to_send
+          - scheduled
+        description: |-
+          * `active` - Active
+          * `inactive` - Inactive
+          * `scheduled` - Scheduled
+          * `ended` - Ended
+          * `ready_to_send` - Ready to Send
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SecurityAwarenessCampaignList'
+          description: ''
+  /api/training/campaigns/analytics/:
+    get:
+      operationId: training_campaigns_analytics_retrieve
+      description: Get campaign analytics.
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
+  /api/training/campaigns/due_to_send/:
+    get:
+      operationId: training_campaigns_due_to_send_retrieve
+      description: Get campaigns due to send.
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
+  /api/training/campaigns/{id}/:
+    patch:
+      operationId: training_campaigns_partial_update
+      description: ViewSet for managing security awareness campaigns.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this security awareness campaign.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedSecurityAwarenessCampaignDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedSecurityAwarenessCampaignDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedSecurityAwarenessCampaignDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
+    get:
+      operationId: training_campaigns_retrieve
+      description: ViewSet for managing security awareness campaigns.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this security awareness campaign.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
+    put:
+      operationId: training_campaigns_update
+      description: ViewSet for managing security awareness campaigns.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this security awareness campaign.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
+    delete:
+      operationId: training_campaigns_destroy
+      description: ViewSet for managing security awareness campaigns.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this security awareness campaign.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/training/campaigns/{id}/send_now/:
+    post:
+      operationId: training_campaigns_send_now_create
+      description: Send campaign immediately.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this security awareness campaign.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
+  /api/training/campaigns/{id}/test_send/:
+    post:
+      operationId: training_campaigns_test_send_create
+      description: Send test email to current user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this security awareness campaign.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
+  /api/training/deliveries/:
+    get:
+      operationId: training_deliveries_list
+      description: ViewSet for viewing campaign deliveries.
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CampaignDelivery'
+          description: ''
+  /api/training/deliveries/{id}/:
+    get:
+      operationId: training_deliveries_retrieve
+      description: ViewSet for viewing campaign deliveries.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this campaign delivery.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignDelivery'
+          description: ''
+  /api/training/deliveries/{id}/mark_clicked/:
+    post:
+      operationId: training_deliveries_mark_clicked_create
+      description: Mark delivery as clicked (for link tracking).
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this campaign delivery.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CampaignDeliveryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CampaignDeliveryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CampaignDeliveryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignDelivery'
+          description: ''
+  /api/training/deliveries/{id}/mark_opened/:
+    post:
+      operationId: training_deliveries_mark_opened_create
+      description: Mark delivery as opened (for email tracking).
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this campaign delivery.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CampaignDeliveryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CampaignDeliveryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CampaignDeliveryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignDelivery'
+          description: ''
+  /api/training/views/:
+    get:
+      operationId: training_views_list
+      description: ViewSet for viewing video view analytics.
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/VideoView'
+          description: ''
+  /api/training/views/my_views/:
+    get:
+      operationId: training_views_my_views_retrieve
+      description: Get current user's video views.
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VideoView'
+          description: ''
+  /api/training/views/{id}/:
+    get:
+      operationId: training_views_retrieve
+      description: ViewSet for viewing video view analytics.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this video view.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VideoView'
+          description: ''
+  /api/knowledge/categories/:
+    post:
+      operationId: knowledge_categories_create
+      tags:
+      - knowledge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeCategory'
+          description: ''
+    get:
+      operationId: knowledge_categories_list
+      parameters:
+      - in: query
+        name: is_active
+        schema:
+          type: boolean
+      - in: query
+        name: module_key
+        schema:
+          type: string
+          enum:
+          - administration
+          - analytics
+          - assets
+          - dashboard
+          - exports
+          - frameworks
+          - policies
+          - risk
+          - training
+          - vendors
+          - vulnerability_scanning
+        description: |-
+          * `dashboard` - Dashboard
+          * `frameworks` - Frameworks and assessments
+          * `risk` - Risk
+          * `assets` - Assets
+          * `vendors` - Vendors
+          * `policies` - Policies
+          * `training` - Training
+          * `analytics` - Analytics
+          * `vulnerability_scanning` - Vulnerability scanning
+          * `exports` - Exports
+          * `administration` - Administration
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedKnowledgeCategoryList'
+          description: ''
+  /api/knowledge/categories/{id}/:
+    patch:
+      operationId: knowledge_categories_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this knowledge category.
+        required: true
+      tags:
+      - knowledge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedKnowledgeCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedKnowledgeCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedKnowledgeCategoryRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeCategory'
+          description: ''
+    get:
+      operationId: knowledge_categories_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this knowledge category.
+        required: true
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeCategory'
+          description: ''
+    put:
+      operationId: knowledge_categories_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this knowledge category.
+        required: true
+      tags:
+      - knowledge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeCategory'
+          description: ''
+    delete:
+      operationId: knowledge_categories_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this knowledge category.
+        required: true
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/knowledge/articles/:
+    post:
+      operationId: knowledge_articles_create
+      tags:
+      - knowledge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeArticleDetail'
+          description: ''
+    get:
+      operationId: knowledge_articles_list
+      parameters:
+      - in: query
+        name: category
+        schema:
+          type: integer
+      - in: query
+        name: content_scope
+        schema:
+          type: string
+          enum:
+          - global
+          - tenant
+        description: |-
+          * `tenant` - Tenant
+          * `global` - Axim-managed global
+      - in: query
+        name: module_key
+        schema:
+          type: string
+          enum:
+          - administration
+          - analytics
+          - assets
+          - dashboard
+          - exports
+          - frameworks
+          - policies
+          - risk
+          - training
+          - vendors
+          - vulnerability_scanning
+        description: |-
+          * `dashboard` - Dashboard
+          * `frameworks` - Frameworks and assessments
+          * `risk` - Risk
+          * `assets` - Assets
+          * `vendors` - Vendors
+          * `policies` - Policies
+          * `training` - Training
+          * `analytics` - Analytics
+          * `vulnerability_scanning` - Vulnerability scanning
+          * `exports` - Exports
+          * `administration` - Administration
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - archived
+          - draft
+          - published
+        description: |-
+          * `draft` - Draft
+          * `published` - Published
+          * `archived` - Archived
+      - in: query
+        name: workflow_key
+        schema:
+          type: string
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedKnowledgeArticleListList'
+          description: ''
+  /api/knowledge/articles/contextual/:
+    get:
+      operationId: knowledge_articles_contextual_retrieve
+      description: Return published guidance for a module and optional workflow key.
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeArticleDetail'
+          description: ''
+  /api/knowledge/articles/{slug}/:
+    patch:
+      operationId: knowledge_articles_partial_update
+      parameters:
+      - in: path
+        name: slug
+        schema:
+          type: string
+        required: true
+      tags:
+      - knowledge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedKnowledgeArticleDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedKnowledgeArticleDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedKnowledgeArticleDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeArticleDetail'
+          description: ''
+    get:
+      operationId: knowledge_articles_retrieve
+      parameters:
+      - in: path
+        name: slug
+        schema:
+          type: string
+        required: true
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeArticleDetail'
+          description: ''
+    put:
+      operationId: knowledge_articles_update
+      parameters:
+      - in: path
+        name: slug
+        schema:
+          type: string
+        required: true
+      tags:
+      - knowledge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeArticleDetail'
+          description: ''
+    delete:
+      operationId: knowledge_articles_destroy
+      parameters:
+      - in: path
+        name: slug
+        schema:
+          type: string
+        required: true
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/knowledge/articles/{slug}/revisions/:
+    get:
+      operationId: knowledge_articles_revisions_retrieve
+      parameters:
+      - in: path
+        name: slug
+        schema:
+          type: string
+        required: true
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeArticleDetail'
+          description: ''
+  /api/analytics/executive/:
+    get:
+      operationId: analytics_executive_retrieve
+      description: |-
+        Executive dashboard with high-level KPIs across all modules.
+
+        Returns comprehensive metrics for C-level reporting including risk posture,
+        compliance status, vendor management, policy compliance, and training effectiveness.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/compliance/:
+    get:
+      operationId: analytics_compliance_retrieve
+      description: |-
+        Compliance-focused dashboard with framework completion rates and control effectiveness.
+
+        Provides detailed compliance metrics including assessment progress,
+        control maturity, and evidence collection statistics.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/vendor-risk/:
+    get:
+      operationId: analytics_vendor_risk_retrieve
+      description: |-
+        Vendor management and risk assessment dashboard.
+
+        Provides vendor risk distribution, contract management metrics,
+        and vendor task analytics for procurement and risk teams.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/policy-management/:
+    get:
+      operationId: analytics_policy_management_retrieve
+      description: |-
+        Policy management and acknowledgment tracking dashboard.
+
+        Provides policy distribution metrics, acknowledgment rates,
+        and compliance tracking for governance teams.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/training-effectiveness/:
+    get:
+      operationId: analytics_training_effectiveness_retrieve
+      description: |-
+        Training program effectiveness and engagement dashboard.
+
+        Provides training completion rates, user engagement metrics,
+        and security awareness campaign performance.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/integrated-risk-posture/:
+    get:
+      operationId: analytics_integrated_risk_posture_retrieve
+      description: |-
+        Integrated risk posture analysis across all modules.
+
+        Premium feature providing cross-module risk correlation,
+        risk maturity indicators, and comprehensive risk trending.
+        Requires advanced reporting subscription tier.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/executive-report/:
+    get:
+      operationId: analytics_executive_report_retrieve
+      description: |-
+        Comprehensive executive report data for leadership presentations.
+
+        Premium feature providing complete analytics package including
+        all dashboard data, trends, and cross-module insights formatted
+        for executive consumption and reporting.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/operational/:
+    get:
+      operationId: analytics_operational_retrieve
+      description: |-
+        Operational dashboard for day-to-day management and monitoring.
+
+        Provides actionable metrics focused on operational tasks,
+        overdue items, progress tracking, and immediate attention items.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/operator/usage/:
+    get:
+      operationId: analytics_operator_usage_retrieve
+      description: |-
+        Operator-only product analytics across tenants.
+
+        Returns aggregate tenant, subscription, module adoption and usage metrics
+        without returning tenant-owned content such as document names or policy text.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/export/:
+    post:
+      operationId: analytics_export_create
+      description: |-
+        Create an async export job for analytics reports.
+
+        Accepts report configuration and queues a background job for
+        PDF, Excel, CSV, or JSON export generation.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/reports/:
+    get:
+      operationId: analytics_reports_retrieve
+      description: |-
+        List analytics reports created by the current user.
+
+        Returns paginated list of reports with status and metadata.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/reports/{report_id}/status/:
+    get:
+      operationId: analytics_reports_status_retrieve
+      description: |-
+        Check the status of an analytics report generation job.
+
+        Returns current status, progress information, and download link
+        when completed.
+      parameters:
+      - in: path
+        name: report_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/reports/{report_id}/download/:
+    get:
+      operationId: analytics_reports_download_retrieve
+      description: |-
+        Download a completed analytics report file.
+
+        Serves the generated report file and increments download counter.
+      parameters:
+      - in: path
+        name: report_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/reports/{report_id}/:
+    delete:
+      operationId: analytics_reports_destroy
+      description: |-
+        Delete an analytics report and its associated file.
+
+        Users can only delete their own reports.
+      parameters:
+      - in: path
+        name: report_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/analytics/cache/refresh/:
+    post:
+      operationId: analytics_cache_refresh_create
+      description: |-
+        Manually trigger analytics metrics cache refresh.
+
+        Premium feature for forcing immediate cache refresh of
+        analytics metrics for improved dashboard performance.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/analytics/health/:
+    get:
+      operationId: analytics_health_retrieve
+      description: |-
+        Health check endpoint for analytics service availability.
+
+        Provides basic system health information and data freshness
+        indicators for monitoring and alerting purposes.
+      tags:
+      - analytics
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/vuln/targets/:
+    post:
+      operationId: vuln_targets_create
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanTarget'
+          description: ''
+    get:
+      operationId: vuln_targets_list
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: owner
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - approved
+          - disabled
+          - pending_approval
+        description: |-
+          * `pending_approval` - Pending approval
+          * `approved` - Approved
+          * `disabled` - Disabled
+      - in: query
+        name: target_type
+        schema:
+          type: string
+          enum:
+          - api
+          - host
+          - web
+        description: |-
+          * `web` - Web application
+          * `host` - Host
+          * `api` - API endpoint
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScanTarget'
+          description: ''
+  /api/vuln/targets/{id}/:
+    patch:
+      operationId: vuln_targets_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan target.
+        required: true
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedScanTargetRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedScanTargetRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedScanTargetRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanTarget'
+          description: ''
+    get:
+      operationId: vuln_targets_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan target.
+        required: true
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanTarget'
+          description: ''
+    put:
+      operationId: vuln_targets_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan target.
+        required: true
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanTarget'
+          description: ''
+    delete:
+      operationId: vuln_targets_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan target.
+        required: true
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/vuln/targets/{id}/start-scan/:
+    post:
+      operationId: vuln_targets_start_scan_create
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan target.
+        required: true
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanTarget'
+          description: ''
+  /api/vuln/schedules/:
+    post:
+      operationId: vuln_schedules_create
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanSchedule'
+          description: ''
+    get:
+      operationId: vuln_schedules_list
+      parameters:
+      - in: query
+        name: frequency
+        schema:
+          type: string
+          enum:
+          - daily
+          - manual
+          - monthly
+          - weekly
+        description: |-
+          * `manual` - Manual
+          * `daily` - Daily
+          * `weekly` - Weekly
+          * `monthly` - Monthly
+      - in: query
+        name: is_active
+        schema:
+          type: boolean
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: target
+        schema:
+          type: string
+          format: uuid
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScanSchedule'
+          description: ''
+  /api/vuln/schedules/run-due/:
+    post:
+      operationId: vuln_schedules_run_due_create
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanSchedule'
+          description: ''
+  /api/vuln/schedules/{id}/:
+    patch:
+      operationId: vuln_schedules_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan schedule.
+        required: true
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedScanScheduleRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedScanScheduleRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedScanScheduleRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanSchedule'
+          description: ''
+    get:
+      operationId: vuln_schedules_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan schedule.
+        required: true
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanSchedule'
+          description: ''
+    put:
+      operationId: vuln_schedules_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan schedule.
+        required: true
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanSchedule'
+          description: ''
+    delete:
+      operationId: vuln_schedules_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan schedule.
+        required: true
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/vuln/jobs/:
+    get:
+      operationId: vuln_jobs_list
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: scanner
+        schema:
+          type: string
+          enum:
+          - nuclei
+        description: '* `nuclei` - Nuclei'
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - cancelled
+          - failed
+          - queued
+          - running
+          - succeeded
+        description: |-
+          * `queued` - Queued
+          * `running` - Running
+          * `succeeded` - Succeeded
+          * `failed` - Failed
+          * `cancelled` - Cancelled
+      - in: query
+        name: target
+        schema:
+          type: string
+          format: uuid
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScanJob'
+          description: ''
+  /api/vuln/jobs/{id}/:
+    get:
+      operationId: vuln_jobs_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan job.
+        required: true
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanJob'
+          description: ''
+  /api/vuln/jobs/{id}/retry/:
+    post:
+      operationId: vuln_jobs_retry_create
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan job.
+        required: true
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanJobRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScanJobRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScanJobRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanJob'
+          description: ''
+  /api/vuln/findings/:
+    get:
+      operationId: vuln_findings_list
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: scanner_name
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: severity
+        schema:
+          type: string
+          enum:
+          - critical
+          - high
+          - info
+          - low
+          - medium
+        description: |-
+          * `critical` - Critical
+          * `high` - High
+          * `medium` - Medium
+          * `low` - Low
+          * `info` - Info
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - accepted_risk
+          - false_positive
+          - open
+          - remediated
+        description: |-
+          * `open` - Open
+          * `accepted_risk` - Accepted risk
+          * `remediated` - Remediated
+          * `false_positive` - False positive
+      - in: query
+        name: target
+        schema:
+          type: string
+          format: uuid
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/VulnerabilityFinding'
+          description: ''
+  /api/vuln/findings/export/:
+    get:
+      operationId: vuln_findings_export_retrieve
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VulnerabilityFinding'
+          description: ''
+  /api/vuln/findings/{id}/:
+    patch:
+      operationId: vuln_findings_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this vulnerability finding.
+        required: true
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedVulnerabilityFindingRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedVulnerabilityFindingRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedVulnerabilityFindingRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VulnerabilityFinding'
+          description: ''
+    get:
+      operationId: vuln_findings_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this vulnerability finding.
+        required: true
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VulnerabilityFinding'
+          description: ''
+  /api/vuln/findings/{id}/create-risk/:
+    post:
+      operationId: vuln_findings_create_risk_create
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this vulnerability finding.
+        required: true
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VulnerabilityFindingRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VulnerabilityFindingRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VulnerabilityFindingRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VulnerabilityFinding'
+          description: ''
+  /api/vuln/findings/{id}/create-risk-action/:
+    post:
+      operationId: vuln_findings_create_risk_action_create
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this vulnerability finding.
+        required: true
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VulnerabilityFindingRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VulnerabilityFindingRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VulnerabilityFindingRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VulnerabilityFinding'
           description: ''
   /api/plans/:
     get:
@@ -2975,6 +10357,37 @@ paths:
           description: ''
         '500':
           description: Failed to fetch subscription
+  /api/billing/start_trial/:
+    post:
+      operationId: billing_start_trial_create
+      description: Create a one-month trial subscription restricted to a single selected
+        module.
+      summary: Start one-module trial
+      tags:
+      - Billing
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                module:
+                  type: string
+                  description: Module key selected for the trial
+              required:
+              - module
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscription'
+          description: ''
+        '400':
+          description: Invalid module or tenant already has a non-trial subscription
   /api/limit-overrides/:
     post:
       operationId: limit_overrides_create
@@ -3086,8 +10499,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/LimitOverrideRequest'
           description: ''
-    delete:
-      operationId: limit_overrides_destroy
+    get:
+      operationId: limit_overrides_retrieve
       description: ViewSet for managing limit override requests with approval workflow.
       parameters:
       - in: path
@@ -3102,8 +10515,12 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '204':
-          description: No response body
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LimitOverrideRequest'
+          description: ''
     put:
       operationId: limit_overrides_update
       description: ViewSet for managing limit override requests with approval workflow.
@@ -3138,8 +10555,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/LimitOverrideRequest'
           description: ''
-    get:
-      operationId: limit_overrides_retrieve
+    delete:
+      operationId: limit_overrides_destroy
       description: ViewSet for managing limit override requests with approval workflow.
       parameters:
       - in: path
@@ -3154,12 +10571,8 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LimitOverrideRequest'
-          description: ''
+        '204':
+          description: No response body
   /api/limit-overrides/{id}/apply_override/:
     post:
       operationId: limit_overrides_apply_override_create
@@ -3448,11 +10861,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Document'
           description: ''
-    delete:
-      operationId: documents_destroy
-      description: Delete a document and its file from storage. Only the uploader
-        can delete documents.
-      summary: Delete document
+    get:
+      operationId: documents_retrieve
+      description: Retrieve detailed information about a specific document including
+        metadata and access information.
+      summary: Get document details
       parameters:
       - in: path
         name: id
@@ -3466,8 +10879,12 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '204':
-          description: No response body
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+          description: ''
     put:
       operationId: documents_update
       description: Update document metadata. File cannot be changed after upload.
@@ -3500,11 +10917,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Document'
           description: ''
-    get:
-      operationId: documents_retrieve
-      description: Retrieve detailed information about a specific document including
-        metadata and access information.
-      summary: Get document details
+    delete:
+      operationId: documents_destroy
+      description: Delete a document and its file from storage. Only the uploader
+        can delete documents.
+      summary: Delete document
       parameters:
       - in: path
         name: id
@@ -3518,12 +10935,8 @@ paths:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Document'
-          description: ''
+        '204':
+          description: No response body
   /api/documents/{id}/access_logs/:
     get:
       operationId: documents_access_logs_retrieve
@@ -3572,8 +10985,96 @@ paths:
           description: Permission denied
         '404':
           description: File not found or inaccessible
+  /api/audit-events/:
+    get:
+      operationId: audit_events_list
+      description: Retrieve the current tenant audit trail. Staff users only.
+      summary: List audit events
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - Audit
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuditEvent'
+          description: ''
+  /api/audit-events/{id}/:
+    get:
+      operationId: audit_events_retrieve
+      description: Retrieve one current-tenant audit event. Staff users only.
+      summary: Get audit event
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this audit event.
+        required: true
+      tags:
+      - Audit
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditEvent'
+          description: ''
 components:
   schemas:
+    ActionEnum:
+      enum:
+      - created
+      - updated
+      - deleted
+      - reminder_sent
+      type: string
+      description: |-
+        * `created` - Created
+        * `updated` - Updated
+        * `deleted` - Deleted
+        * `reminder_sent` - Reminder sent
+    ActionTypeEnum:
+      enum:
+      - preventive
+      - detective
+      - corrective
+      - policy
+      - training
+      - technical
+      - assessment
+      - other
+      type: string
+      description: |-
+        * `preventive` - Preventive Control
+        * `detective` - Detective Control
+        * `corrective` - Corrective Action
+        * `policy` - Policy/Procedure
+        * `training` - Training/Awareness
+        * `technical` - Technical Implementation
+        * `assessment` - Assessment/Review
+        * `other` - Other
     ApplicabilityEnum:
       enum:
       - applicable
@@ -3584,6 +11085,16 @@ components:
         * `applicable` - Applicable
         * `not_applicable` - Not Applicable
         * `to_be_determined` - To Be Determined
+    ApplicabilityStatusEnum:
+      enum:
+      - under_review
+      - applicable
+      - not_applicable
+      type: string
+      description: |-
+        * `under_review` - Under Review
+        * `applicable` - Applicable
+        * `not_applicable` - Not Applicable
     ApprovalAction:
       type: object
       description: Serializer for approval/rejection actions.
@@ -3608,6 +11119,24 @@ components:
           type: string
           description: Required for rejections - explain why the request was rejected
           maxLength: 1000
+    ArtefactTypeEnum:
+      enum:
+      - scope_document
+      - metrics_pack
+      - agenda
+      - management_review_pack
+      - regulatory_contractual_sheet
+      - nonconformity_log
+      - other
+      type: string
+      description: |-
+        * `scope_document` - Scope Document
+        * `metrics_pack` - Metrics Pack
+        * `agenda` - Agenda
+        * `management_review_pack` - Management Review Pack
+        * `regulatory_contractual_sheet` - Regulatory and Contractual Sheet
+        * `nonconformity_log` - Non-Conformity Log
+        * `other` - Other
     AssessmentEvidence:
       type: object
       description: Serializer for assessment evidence links.
@@ -3735,7 +11264,7 @@ components:
           readOnly: true
         status:
           allOf:
-          - $ref: '#/components/schemas/AssessmentReportStatusEnum'
+          - $ref: '#/components/schemas/StatusA39Enum'
           readOnly: true
         generated_file:
           type: integer
@@ -3871,18 +11400,400 @@ components:
       required:
       - report_type
       - title
-    AssessmentReportStatusEnum:
+    AssetDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        asset_id:
+          type: string
+          maxLength: 80
+        name:
+          type: string
+          maxLength: 255
+        asset_type:
+          $ref: '#/components/schemas/AssetTypeEnum'
+        description:
+          type: string
+        classification:
+          $ref: '#/components/schemas/ClassificationEnum'
+        criticality:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        lifecycle_status:
+          $ref: '#/components/schemas/LifecycleStatusEnum'
+        owner:
+          type: integer
+          nullable: true
+        owner_display:
+          type: string
+          readOnly: true
+        owner_name:
+          type: string
+          maxLength: 255
+        custodian:
+          type: string
+          maxLength: 255
+        location:
+          type: string
+          maxLength: 255
+        domain:
+          type: string
+          maxLength: 255
+        ip_address:
+          type: string
+          nullable: true
+        mac_address:
+          type: string
+          maxLength: 64
+        serial_number:
+          type: string
+          maxLength: 128
+        manufacturer:
+          type: string
+          maxLength: 255
+        model:
+          type: string
+          maxLength: 255
+        operating_system:
+          type: string
+          maxLength: 255
+        version:
+          type: string
+          maxLength: 100
+        acquisition_date:
+          type: string
+          format: date
+          nullable: true
+        last_seen_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_reviewed_at:
+          type: string
+          format: date-time
+          nullable: true
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        disposal_date:
+          type: string
+          format: date
+          nullable: true
+        linked_risks:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+        source_path:
+          type: string
+          readOnly: true
+        source_sheet:
+          type: string
+          readOnly: true
+        source_row:
+          type: integer
+          readOnly: true
+          nullable: true
+        source_checksum:
+          type: string
+          readOnly: true
+        metadata:
+          readOnly: true
+        is_review_overdue:
+          type: string
+          readOnly: true
+        days_until_review:
+          type: string
+          readOnly: true
+        created_by_username:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - asset_id
+      - created_at
+      - created_by_username
+      - days_until_review
+      - id
+      - is_review_overdue
+      - metadata
+      - name
+      - owner_display
+      - source_checksum
+      - source_path
+      - source_row
+      - source_sheet
+      - updated_at
+    AssetDetailRequest:
+      type: object
+      properties:
+        asset_id:
+          type: string
+          minLength: 1
+          maxLength: 80
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        asset_type:
+          $ref: '#/components/schemas/AssetTypeEnum'
+        description:
+          type: string
+        classification:
+          $ref: '#/components/schemas/ClassificationEnum'
+        criticality:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        lifecycle_status:
+          $ref: '#/components/schemas/LifecycleStatusEnum'
+        owner:
+          type: integer
+          nullable: true
+        owner_name:
+          type: string
+          maxLength: 255
+        custodian:
+          type: string
+          maxLength: 255
+        location:
+          type: string
+          maxLength: 255
+        domain:
+          type: string
+          maxLength: 255
+        ip_address:
+          type: string
+          nullable: true
+          minLength: 1
+        mac_address:
+          type: string
+          maxLength: 64
+        serial_number:
+          type: string
+          maxLength: 128
+        manufacturer:
+          type: string
+          maxLength: 255
+        model:
+          type: string
+          maxLength: 255
+        operating_system:
+          type: string
+          maxLength: 255
+        version:
+          type: string
+          maxLength: 100
+        acquisition_date:
+          type: string
+          format: date
+          nullable: true
+        last_seen_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_reviewed_at:
+          type: string
+          format: date-time
+          nullable: true
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        disposal_date:
+          type: string
+          format: date
+          nullable: true
+        linked_risks:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+      required:
+      - asset_id
+      - name
+    AssetList:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        asset_id:
+          type: string
+          maxLength: 80
+        name:
+          type: string
+          maxLength: 255
+        asset_type:
+          $ref: '#/components/schemas/AssetTypeEnum'
+        classification:
+          $ref: '#/components/schemas/ClassificationEnum'
+        criticality:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        lifecycle_status:
+          $ref: '#/components/schemas/LifecycleStatusEnum'
+        owner:
+          type: integer
+          nullable: true
+        owner_display:
+          type: string
+          readOnly: true
+        owner_name:
+          type: string
+          maxLength: 255
+        location:
+          type: string
+          maxLength: 255
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        is_review_overdue:
+          type: string
+          readOnly: true
+        days_until_review:
+          type: string
+          readOnly: true
+        linked_risk_count:
+          type: string
+          readOnly: true
+        linked_control_count:
+          type: string
+          readOnly: true
+        linked_document_count:
+          type: string
+          readOnly: true
+      required:
+      - asset_id
+      - days_until_review
+      - id
+      - is_review_overdue
+      - linked_control_count
+      - linked_document_count
+      - linked_risk_count
+      - name
+      - owner_display
+    AssetReviewReminderLog:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        asset:
+          type: integer
+        asset_identifier:
+          type: string
+          readOnly: true
+        owner:
+          type: integer
+        owner_username:
+          type: string
+          readOnly: true
+        reminder_type:
+          $ref: '#/components/schemas/AssetReviewReminderLogReminderTypeEnum'
+        review_date:
+          type: string
+          format: date
+        sent_at:
+          type: string
+          format: date-time
+          readOnly: true
+        email_sent:
+          type: boolean
+      required:
+      - asset
+      - asset_identifier
+      - id
+      - owner
+      - owner_username
+      - reminder_type
+      - review_date
+      - sent_at
+    AssetReviewReminderLogReminderTypeEnum:
       enum:
-      - pending
-      - processing
-      - completed
-      - failed
+      - advance_warning
+      - due_today
+      - overdue
       type: string
       description: |-
-        * `pending` - Pending Generation
-        * `processing` - Processing
-        * `completed` - Completed
-        * `failed` - Failed
+        * `advance_warning` - Advance Warning
+        * `due_today` - Due Today
+        * `overdue` - Overdue
+    AssetTypeEnum:
+      enum:
+      - server
+      - workstation
+      - monitor
+      - mobile_device
+      - printer
+      - infrastructure
+      - application
+      - database
+      - document
+      - other
+      type: string
+      description: |-
+        * `server` - Server
+        * `workstation` - Workstation
+        * `monitor` - Monitor
+        * `mobile_device` - Mobile Device
+        * `printer` - Printer
+        * `infrastructure` - Infrastructure
+        * `application` - Application
+        * `database` - Database
+        * `document` - Document
+        * `other` - Other
+    AuditEvent:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        event:
+          type: string
+          readOnly: true
+        user:
+          type: integer
+          readOnly: true
+          nullable: true
+        user_email:
+          type: string
+          format: email
+          readOnly: true
+        details:
+          readOnly: true
+        at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - at
+      - details
+      - event
+      - id
+      - user
+      - user_email
     AutomationLevelEnum:
       enum:
       - manual
@@ -3921,6 +11832,329 @@ components:
             for all framework controls.
       required:
       - framework_id
+    BulkRiskCreateRequest:
+      type: object
+      description: Serializer for bulk risk creation.
+      properties:
+        category:
+          type: integer
+          nullable: true
+        risk_owner:
+          type: integer
+          nullable: true
+        risk_matrix:
+          type: integer
+          nullable: true
+        default_impact:
+          type: integer
+          maximum: 5
+          minimum: 1
+          default: 3
+        default_likelihood:
+          type: integer
+          maximum: 5
+          minimum: 1
+          default: 3
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        risks:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: List of risk dictionaries with title, description, and optional
+            overrides
+          maxItems: 100
+          minItems: 1
+      required:
+      - risks
+    CalendarAuditLog:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        action:
+          allOf:
+          - $ref: '#/components/schemas/ActionEnum'
+          readOnly: true
+        event:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        source_type:
+          type: string
+          readOnly: true
+        source_id:
+          type: string
+          readOnly: true
+        actor:
+          type: integer
+          readOnly: true
+          nullable: true
+        actor_email:
+          type: string
+          format: email
+          readOnly: true
+        details:
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - action
+      - actor
+      - actor_email
+      - created_at
+      - details
+      - event
+      - id
+      - source_id
+      - source_type
+    CalendarEvent:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        title:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        event_type:
+          $ref: '#/components/schemas/EventTypeEnum'
+        due_date:
+          type: string
+          format: date
+        owner:
+          type: integer
+          nullable: true
+        owner_email:
+          type: string
+          format: email
+          readOnly: true
+        status:
+          $ref: '#/components/schemas/CalendarEventStatusEnum'
+        source_url:
+          type: string
+          maxLength: 500
+        metadata: {}
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - due_date
+      - id
+      - owner_email
+      - title
+      - updated_at
+    CalendarEventRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+        event_type:
+          $ref: '#/components/schemas/EventTypeEnum'
+        due_date:
+          type: string
+          format: date
+        owner:
+          type: integer
+          nullable: true
+        status:
+          $ref: '#/components/schemas/CalendarEventStatusEnum'
+        source_url:
+          type: string
+          maxLength: 500
+        metadata: {}
+      required:
+      - due_date
+      - title
+    CalendarEventStatusEnum:
+      enum:
+      - scheduled
+      - completed
+      - cancelled
+      type: string
+      description: |-
+        * `scheduled` - Scheduled
+        * `completed` - Completed
+        * `cancelled` - Cancelled
+    CalendarReminderLog:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        source_type:
+          type: string
+          readOnly: true
+        source_id:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+        due_date:
+          type: string
+          format: date
+          readOnly: true
+        recipient:
+          type: integer
+          readOnly: true
+        recipient_email:
+          type: string
+          format: email
+          readOnly: true
+        reminder_type:
+          allOf:
+          - $ref: '#/components/schemas/CalendarReminderLogReminderTypeEnum'
+          readOnly: true
+        sent_at:
+          type: string
+          format: date-time
+          readOnly: true
+        email_sent:
+          type: boolean
+          readOnly: true
+        metadata:
+          readOnly: true
+      required:
+      - due_date
+      - email_sent
+      - id
+      - metadata
+      - recipient
+      - recipient_email
+      - reminder_type
+      - sent_at
+      - source_id
+      - source_type
+      - title
+    CalendarReminderLogReminderTypeEnum:
+      enum:
+      - advance_warning
+      - due_today
+      - overdue
+      type: string
+      description: |-
+        * `advance_warning` - Advance warning
+        * `due_today` - Due today
+        * `overdue` - Overdue
+    CampaignDelivery:
+      type: object
+      description: Serializer for campaign delivery tracking.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        campaign:
+          type: string
+          format: uuid
+        campaign_name:
+          type: string
+          readOnly: true
+        user:
+          type: integer
+        user_email:
+          type: string
+          readOnly: true
+        user_name:
+          type: string
+          readOnly: true
+        sent_at:
+          type: string
+          format: date-time
+          readOnly: true
+        opened_at:
+          type: string
+          format: date-time
+          nullable: true
+        clicked_at:
+          type: string
+          format: date-time
+          nullable: true
+        email_subject:
+          type: string
+          maxLength: 200
+        recipient_email:
+          type: string
+          format: email
+          maxLength: 254
+        delivery_status:
+          $ref: '#/components/schemas/DeliveryStatusEnum'
+      required:
+      - campaign
+      - campaign_name
+      - email_subject
+      - id
+      - recipient_email
+      - sent_at
+      - user
+      - user_email
+      - user_name
+    CampaignDeliveryRequest:
+      type: object
+      description: Serializer for campaign delivery tracking.
+      properties:
+        campaign:
+          type: string
+          format: uuid
+        user:
+          type: integer
+        opened_at:
+          type: string
+          format: date-time
+          nullable: true
+        clicked_at:
+          type: string
+          format: date-time
+          nullable: true
+        email_subject:
+          type: string
+          minLength: 1
+          maxLength: 200
+        recipient_email:
+          type: string
+          format: email
+          minLength: 1
+          maxLength: 254
+        delivery_status:
+          $ref: '#/components/schemas/DeliveryStatusEnum'
+      required:
+      - campaign
+      - email_subject
+      - recipient_email
+      - user
+    ClassificationEnum:
+      enum:
+      - public
+      - internal
+      - confidential
+      - restricted
+      type: string
+      description: |-
+        * `public` - Public
+        * `internal` - Internal
+        * `confidential` - Confidential
+        * `restricted` - Restricted
     ClauseDetail:
       type: object
       description: Detailed clause serializer with full information.
@@ -3965,7 +12199,7 @@ components:
         clause_type:
           $ref: '#/components/schemas/ClauseTypeEnum'
         criticality:
-          $ref: '#/components/schemas/UrgencyEnum'
+          $ref: '#/components/schemas/RiskLevelEnum'
         is_testable:
           type: boolean
           description: Whether this clause can be tested/audited
@@ -3976,8 +12210,6 @@ components:
           type: string
           description: Procedures for testing compliance with this clause
         external_references:
-          type: object
-          additionalProperties: {}
           description: References to other standards, regulations, or frameworks
         control_count:
           type: string
@@ -4039,7 +12271,7 @@ components:
         clause_type:
           $ref: '#/components/schemas/ClauseTypeEnum'
         criticality:
-          $ref: '#/components/schemas/UrgencyEnum'
+          $ref: '#/components/schemas/RiskLevelEnum'
         is_testable:
           type: boolean
           description: Whether this clause can be tested/audited
@@ -4050,8 +12282,6 @@ components:
           type: string
           description: Procedures for testing compliance with this clause
         external_references:
-          type: object
-          additionalProperties: {}
           description: References to other standards, regulations, or frameworks
       required:
       - clause_id
@@ -4079,7 +12309,7 @@ components:
         clause_type:
           $ref: '#/components/schemas/ClauseTypeEnum'
         criticality:
-          $ref: '#/components/schemas/UrgencyEnum'
+          $ref: '#/components/schemas/RiskLevelEnum'
         is_testable:
           type: boolean
           description: Whether this clause can be tested/audited
@@ -4122,7 +12352,7 @@ components:
         clause_type:
           $ref: '#/components/schemas/ClauseTypeEnum'
         criticality:
-          $ref: '#/components/schemas/UrgencyEnum'
+          $ref: '#/components/schemas/RiskLevelEnum'
         is_testable:
           type: boolean
           description: Whether this clause can be tested/audited
@@ -4152,6 +12382,28 @@ components:
         * `assessment` - Assessment Requirement
         * `monitoring` - Monitoring Requirement
         * `reporting` - Reporting Requirement
+    ComplianceStatusEnum:
+      enum:
+      - not_started
+      - in_progress
+      - compliant
+      - non_compliant
+      - accepted_risk
+      type: string
+      description: |-
+        * `not_started` - Not Started
+        * `in_progress` - In Progress
+        * `compliant` - Compliant
+        * `non_compliant` - Non-Compliant
+        * `accepted_risk` - Accepted Risk
+    ContentScopeEnum:
+      enum:
+      - tenant
+      - global
+      type: string
+      description: |-
+        * `tenant` - Tenant
+        * `global` - Axim-managed global
     ControlAssessmentCreateUpdate:
       type: object
       description: Serializer for creating and updating assessments.
@@ -4159,6 +12411,10 @@ components:
         control:
           type: integer
           description: The control being assessed
+        framework:
+          type: integer
+          nullable: true
+          description: Framework version this assessment was created against
         applicability:
           allOf:
           - $ref: '#/components/schemas/ApplicabilityEnum'
@@ -4240,7 +12496,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -4275,6 +12531,10 @@ components:
         control:
           type: integer
           description: The control being assessed
+        framework:
+          type: integer
+          nullable: true
+          description: Framework version this assessment was created against
         applicability:
           allOf:
           - $ref: '#/components/schemas/ApplicabilityEnum'
@@ -4356,7 +12616,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -4395,6 +12655,17 @@ components:
           type: string
           readOnly: true
           description: Unique assessment identifier
+        framework:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: Framework version this assessment was created against
+        framework_name:
+          type: string
+          readOnly: true
+        framework_version:
+          type: string
+          readOnly: true
         control:
           type: integer
           description: The control being assessed
@@ -4501,7 +12772,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -4535,8 +12806,6 @@ components:
           readOnly: true
           description: Assessment version number
         change_log:
-          type: object
-          additionalProperties: {}
           readOnly: true
           description: History of changes to this assessment
         is_overdue:
@@ -4580,6 +12849,9 @@ components:
       - created_by_username
       - days_until_due
       - evidence_count
+      - framework
+      - framework_name
+      - framework_version
       - id
       - is_complete
       - is_overdue
@@ -4677,7 +12949,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -4722,7 +12994,14 @@ components:
         control_name:
           type: string
           readOnly: true
+        framework:
+          type: integer
+          nullable: true
+          description: Framework version this assessment was created against
         framework_name:
+          type: string
+          readOnly: true
+        framework_version:
           type: string
           readOnly: true
         applicability:
@@ -4789,7 +13068,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -4821,6 +13100,7 @@ components:
       - days_until_due
       - evidence_count
       - framework_name
+      - framework_version
       - has_primary_evidence
       - id
       - is_complete
@@ -4853,7 +13133,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status9ffEnum'
+          $ref: '#/components/schemas/Status98bEnum'
         control_owner:
           type: integer
           nullable: true
@@ -4893,8 +13173,6 @@ components:
           type: string
           description: What evidence is needed to demonstrate this control's effectiveness
         documentation_links:
-          type: object
-          additionalProperties: {}
           description: Links to related policies, procedures, and documentation
         risk_rating:
           description: |-
@@ -4905,7 +13183,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         remediation_plan:
           type: string
@@ -4948,7 +13226,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status9ffEnum'
+          $ref: '#/components/schemas/Status98bEnum'
         control_owner:
           type: integer
           nullable: true
@@ -4988,8 +13266,6 @@ components:
           type: string
           description: What evidence is needed to demonstrate this control's effectiveness
         documentation_links:
-          type: object
-          additionalProperties: {}
           description: Links to related policies, procedures, and documentation
         risk_rating:
           description: |-
@@ -5000,7 +13276,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         remediation_plan:
           type: string
@@ -5049,7 +13325,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status9ffEnum'
+          $ref: '#/components/schemas/Status98bEnum'
         control_owner:
           type: integer
           nullable: true
@@ -5092,8 +13368,6 @@ components:
           type: string
           description: What evidence is needed to demonstrate this control's effectiveness
         documentation_links:
-          type: object
-          additionalProperties: {}
           description: Links to related policies, procedures, and documentation
         risk_rating:
           description: |-
@@ -5104,7 +13378,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         remediation_plan:
           type: string
@@ -5113,8 +13387,6 @@ components:
           type: string
           maxLength: 20
         change_log:
-          type: object
-          additionalProperties: {}
           description: History of changes to this control
         is_active:
           type: string
@@ -5129,6 +13401,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ControlEvidence'
+          readOnly: true
+        template_documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/TemplateDocumentSummary'
           readOnly: true
         created_by_username:
           type: string
@@ -5156,6 +13433,7 @@ components:
       - is_active
       - name
       - needs_testing
+      - template_documents
       - updated_at
     ControlDetailRequest:
       type: object
@@ -5186,7 +13464,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status9ffEnum'
+          $ref: '#/components/schemas/Status98bEnum'
         control_owner:
           type: integer
           nullable: true
@@ -5226,8 +13504,6 @@ components:
           type: string
           description: What evidence is needed to demonstrate this control's effectiveness
         documentation_links:
-          type: object
-          additionalProperties: {}
           description: Links to related policies, procedures, and documentation
         risk_rating:
           description: |-
@@ -5238,7 +13514,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         remediation_plan:
           type: string
@@ -5248,8 +13524,6 @@ components:
           minLength: 1
           maxLength: 20
         change_log:
-          type: object
-          additionalProperties: {}
           description: History of changes to this control
       required:
       - clauses
@@ -5401,7 +13675,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status9ffEnum'
+          $ref: '#/components/schemas/Status98bEnum'
         control_owner_name:
           type: string
           readOnly: true
@@ -5429,7 +13703,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         is_active:
           type: string
@@ -5476,7 +13750,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status9ffEnum'
+          $ref: '#/components/schemas/Status98bEnum'
         effectiveness_rating:
           description: |-
             Current effectiveness assessment
@@ -5501,7 +13775,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         version:
           type: string
@@ -5529,6 +13803,26 @@ components:
         * `administrative` - Administrative Control
         * `technical` - Technical Control
         * `physical` - Physical Control
+    DefaultActionTypeEnum:
+      enum:
+      - preventive
+      - detective
+      - corrective
+      - policy
+      - training
+      - technical
+      - assessment
+      - other
+      type: string
+      description: |-
+        * `preventive` - Preventive Control
+        * `detective` - Detective Control
+        * `corrective` - Corrective Action
+        * `policy` - Policy/Procedure
+        * `training` - Training/Awareness
+        * `technical` - Technical Implementation
+        * `assessment` - Assessment/Review
+        * `other` - Other
     DefaultApplicabilityEnum:
       enum:
       - applicable
@@ -5539,6 +13833,32 @@ components:
         * `applicable` - Applicable
         * `not_applicable` - Not Applicable
         * `to_be_determined` - To Be Determined
+    DeliveryStatusEnum:
+      enum:
+      - sent
+      - delivered
+      - opened
+      - clicked
+      - bounced
+      - failed
+      type: string
+      description: |-
+        * `sent` - Sent
+        * `delivered` - Delivered
+        * `opened` - Opened
+        * `clicked` - Clicked
+        * `bounced` - Bounced
+        * `failed` - Failed
+    DifficultyLevelEnum:
+      enum:
+      - beginner
+      - intermediate
+      - advanced
+      type: string
+      description: |-
+        * `beginner` - Beginner
+        * `intermediate` - Intermediate
+        * `advanced` - Advanced
     Document:
       type: object
       description: Serializer for document uploads with file validation and metadata.
@@ -5651,6 +13971,30 @@ components:
       required:
       - file
       - title
+    DocumentTypeEnum:
+      enum:
+      - policy
+      - standard
+      - procedure
+      - mandatory_document
+      - risk_register
+      - asset_register
+      - framework_spreadsheet
+      - template
+      - sample
+      - other
+      type: string
+      description: |-
+        * `policy` - Policy
+        * `standard` - Standard
+        * `procedure` - Procedure
+        * `mandatory_document` - Mandatory Document
+        * `risk_register` - Risk Register
+        * `asset_register` - Asset Register
+        * `framework_spreadsheet` - Framework Spreadsheet
+        * `template` - Template
+        * `sample` - Sample
+        * `other` - Other
     EffectivenessRatingEnum:
       enum:
       - not_effective
@@ -5663,6 +14007,40 @@ components:
         * `partially_effective` - Partially Effective
         * `largely_effective` - Largely Effective
         * `fully_effective` - Fully Effective
+    EventTypeEnum:
+      enum:
+      - deadline
+      - review
+      - meeting
+      - training
+      - custom
+      type: string
+      description: |-
+        * `deadline` - Deadline
+        * `review` - Review
+        * `meeting` - Meeting
+        * `training` - Training
+        * `custom` - Custom
+    EvidenceTypeAe0Enum:
+      enum:
+      - document
+      - screenshot
+      - report
+      - certificate
+      - configuration
+      - training_record
+      - audit_log
+      - other
+      type: string
+      description: |-
+        * `document` - Document/Policy
+        * `screenshot` - Screenshot
+        * `report` - Report/Analysis
+        * `certificate` - Certificate
+        * `configuration` - Configuration File
+        * `training_record` - Training Record
+        * `audit_log` - Audit Log
+        * `other` - Other
     EvidenceTypeEnum:
       enum:
       - document
@@ -5685,6 +14063,14 @@ components:
         * `test_result` - Test Result
         * `meeting_notes` - Meeting Notes
         * `other` - Other
+    ExportFormatEnum:
+      enum:
+      - xlsx
+      - csv_zip
+      type: string
+      description: |-
+        * `xlsx` - Excel workbook
+        * `csv_zip` - CSV archive
     FrameworkDetail:
       type: object
       description: Detailed framework serializer with full information.
@@ -5735,7 +14121,7 @@ components:
           nullable: true
           description: Date when this version expires
         status:
-          $ref: '#/components/schemas/StatusB25Enum'
+          $ref: '#/components/schemas/Status4daEnum'
         is_mandatory:
           type: boolean
           description: Whether compliance with this framework is mandatory for the
@@ -5835,7 +14221,7 @@ components:
           nullable: true
           description: Date when this version expires
         status:
-          $ref: '#/components/schemas/StatusB25Enum'
+          $ref: '#/components/schemas/Status4daEnum'
         is_mandatory:
           type: boolean
           description: Whether compliance with this framework is mandatory for the
@@ -5869,7 +14255,7 @@ components:
         framework_type:
           $ref: '#/components/schemas/FrameworkTypeEnum'
         status:
-          $ref: '#/components/schemas/StatusB25Enum'
+          $ref: '#/components/schemas/Status4daEnum'
         is_mandatory:
           type: boolean
           description: Whether compliance with this framework is mandatory for the
@@ -5991,6 +14377,148 @@ components:
         * `operational` - Operational Framework
         * `industry` - Industry-Specific Framework
         * `custom` - Custom Framework
+    FrequencyEnum:
+      enum:
+      - manual
+      - daily
+      - weekly
+      - monthly
+      type: string
+      description: |-
+        * `manual` - Manual
+        * `daily` - Daily
+        * `weekly` - Weekly
+        * `monthly` - Monthly
+    GovernanceArtefact:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        artefact_id:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          maxLength: 255
+        artefact_type:
+          $ref: '#/components/schemas/ArtefactTypeEnum'
+        description:
+          type: string
+        status:
+          $ref: '#/components/schemas/GovernanceArtefactStatusEnum'
+        version:
+          type: string
+          maxLength: 30
+        owner:
+          type: integer
+          nullable: true
+        owner_username:
+          type: string
+          readOnly: true
+        effective_date:
+          type: string
+          format: date
+          nullable: true
+        review_due_date:
+          type: string
+          format: date
+          nullable: true
+        linked_frameworks:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+        source_template:
+          type: integer
+          nullable: true
+        metadata: {}
+        created_by_username:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - artefact_id
+      - artefact_type
+      - created_at
+      - created_by_username
+      - id
+      - owner_username
+      - title
+      - updated_at
+    GovernanceArtefactRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        artefact_type:
+          $ref: '#/components/schemas/ArtefactTypeEnum'
+        description:
+          type: string
+        status:
+          $ref: '#/components/schemas/GovernanceArtefactStatusEnum'
+        version:
+          type: string
+          minLength: 1
+          maxLength: 30
+        owner:
+          type: integer
+          nullable: true
+        effective_date:
+          type: string
+          format: date
+          nullable: true
+        review_due_date:
+          type: string
+          format: date
+          nullable: true
+        linked_frameworks:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+        source_template:
+          type: integer
+          nullable: true
+        metadata: {}
+      required:
+      - artefact_type
+      - title
+    GovernanceArtefactStatusEnum:
+      enum:
+      - draft
+      - approved
+      - published
+      - archived
+      type: string
+      description: |-
+        * `draft` - Draft
+        * `approved` - Approved
+        * `published` - Published
+        * `archived` - Archived
     ImplementationStatusEnum:
       enum:
       - not_implemented
@@ -6003,6 +14531,238 @@ components:
         * `partially_implemented` - Partially Implemented
         * `implemented` - Implemented
         * `not_applicable` - Not Applicable
+    KnowledgeArticleDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          maxLength: 220
+        slug:
+          type: string
+          maxLength: 240
+          pattern: ^[-a-zA-Z0-9_]+$
+        summary:
+          type: string
+        body:
+          type: string
+        category:
+          type: integer
+          nullable: true
+        category_name:
+          type: string
+          readOnly: true
+        module_key:
+          oneOf:
+          - $ref: '#/components/schemas/ModuleKeyEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        workflow_key:
+          type: string
+          maxLength: 80
+        tags: {}
+        status:
+          $ref: '#/components/schemas/Status399Enum'
+        content_scope:
+          $ref: '#/components/schemas/ContentScopeEnum'
+        sort_order:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        published_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        created_by_username:
+          type: string
+          readOnly: true
+        updated_by_username:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - body
+      - category_name
+      - created_at
+      - created_by_username
+      - id
+      - published_at
+      - slug
+      - title
+      - updated_at
+      - updated_by_username
+    KnowledgeArticleDetailRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 220
+        slug:
+          type: string
+          minLength: 1
+          maxLength: 240
+          pattern: ^[-a-zA-Z0-9_]+$
+        summary:
+          type: string
+        body:
+          type: string
+          minLength: 1
+        category:
+          type: integer
+          nullable: true
+        module_key:
+          oneOf:
+          - $ref: '#/components/schemas/ModuleKeyEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        workflow_key:
+          type: string
+          maxLength: 80
+        tags: {}
+        status:
+          $ref: '#/components/schemas/Status399Enum'
+        content_scope:
+          $ref: '#/components/schemas/ContentScopeEnum'
+        sort_order:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+      required:
+      - body
+      - slug
+      - title
+    KnowledgeArticleList:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          maxLength: 220
+        slug:
+          type: string
+          maxLength: 240
+          pattern: ^[-a-zA-Z0-9_]+$
+        summary:
+          type: string
+        category:
+          type: integer
+          nullable: true
+        category_name:
+          type: string
+          readOnly: true
+        module_key:
+          oneOf:
+          - $ref: '#/components/schemas/ModuleKeyEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        workflow_key:
+          type: string
+          maxLength: 80
+        tags: {}
+        status:
+          $ref: '#/components/schemas/Status399Enum'
+        content_scope:
+          $ref: '#/components/schemas/ContentScopeEnum'
+        sort_order:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        published_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - category_name
+      - id
+      - published_at
+      - slug
+      - title
+      - updated_at
+    KnowledgeCategory:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 120
+        slug:
+          type: string
+          maxLength: 140
+          pattern: ^[-a-zA-Z0-9_]+$
+        description:
+          type: string
+        module_key:
+          oneOf:
+          - $ref: '#/components/schemas/ModuleKeyEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        sort_order:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        is_active:
+          type: boolean
+        article_count:
+          type: integer
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - article_count
+      - created_at
+      - id
+      - name
+      - slug
+      - updated_at
+    KnowledgeCategoryRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        slug:
+          type: string
+          minLength: 1
+          maxLength: 140
+          pattern: ^[-a-zA-Z0-9_]+$
+        description:
+          type: string
+        module_key:
+          oneOf:
+          - $ref: '#/components/schemas/ModuleKeyEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        sort_order:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        is_active:
+          type: boolean
+      required:
+      - name
+      - slug
     LastTestResultEnum:
       enum:
       - not_effective
@@ -6015,6 +14775,34 @@ components:
         * `partially_effective` - Partially Effective
         * `largely_effective` - Largely Effective
         * `fully_effective` - Fully Effective
+    LifecycleStateEnum:
+      enum:
+      - template
+      - draft
+      - client_modified
+      - approved
+      - final
+      type: string
+      description: |-
+        * `template` - Template
+        * `draft` - Draft
+        * `client_modified` - Client Modified
+        * `approved` - Approved
+        * `final` - Final
+    LifecycleStatusEnum:
+      enum:
+      - planned
+      - active
+      - maintenance
+      - retired
+      - disposed
+      type: string
+      description: |-
+        * `planned` - Planned
+        * `active` - Active
+        * `maintenance` - Maintenance
+        * `retired` - Retired
+        * `disposed` - Disposed
     LimitOverrideCreate:
       type: object
       description: Serializer for creating new limit override requests.
@@ -6113,7 +14901,7 @@ components:
           nullable: true
           description: When should temporary limits expire?
         status:
-          $ref: '#/components/schemas/Status7d3Enum'
+          $ref: '#/components/schemas/Status1bdEnum'
         status_display:
           type: string
           readOnly: true
@@ -6243,7 +15031,7 @@ components:
           nullable: true
           description: When should temporary limits expire?
         status:
-          $ref: '#/components/schemas/Status7d3Enum'
+          $ref: '#/components/schemas/Status1bdEnum'
         first_approval_notes:
           type: string
         second_approval_notes:
@@ -6279,6 +15067,165 @@ components:
       required:
       - password
       - username
+    ManagementReview:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        review_id:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          maxLength: 255
+        status:
+          $ref: '#/components/schemas/ManagementReviewStatusEnum'
+        meeting_date:
+          type: string
+          format: date
+        period_start:
+          type: string
+          format: date
+          nullable: true
+        period_end:
+          type: string
+          format: date
+          nullable: true
+        chair:
+          type: integer
+          nullable: true
+        chair_username:
+          type: string
+          readOnly: true
+        attendees:
+          type: array
+          items:
+            type: integer
+        agenda:
+          type: string
+        minutes:
+          type: string
+        decisions:
+          type: string
+        actions_summary:
+          type: string
+        inputs: {}
+        outputs: {}
+        linked_requirements:
+          type: array
+          items:
+            type: integer
+        linked_nonconformities:
+          type: array
+          items:
+            type: integer
+        linked_artefacts:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+        created_by_username:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - chair_username
+      - created_at
+      - created_by_username
+      - id
+      - meeting_date
+      - review_id
+      - title
+      - updated_at
+    ManagementReviewRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        status:
+          $ref: '#/components/schemas/ManagementReviewStatusEnum'
+        meeting_date:
+          type: string
+          format: date
+        period_start:
+          type: string
+          format: date
+          nullable: true
+        period_end:
+          type: string
+          format: date
+          nullable: true
+        chair:
+          type: integer
+          nullable: true
+        attendees:
+          type: array
+          items:
+            type: integer
+        agenda:
+          type: string
+        minutes:
+          type: string
+        decisions:
+          type: string
+        actions_summary:
+          type: string
+        inputs: {}
+        outputs: {}
+        linked_requirements:
+          type: array
+          items:
+            type: integer
+        linked_nonconformities:
+          type: array
+          items:
+            type: integer
+        linked_artefacts:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+      required:
+      - meeting_date
+      - title
+    ManagementReviewStatusEnum:
+      enum:
+      - planned
+      - held
+      - actions_open
+      - closed
+      - cancelled
+      type: string
+      description: |-
+        * `planned` - Planned
+        * `held` - Held
+        * `actions_open` - Actions Open
+        * `closed` - Closed
+        * `cancelled` - Cancelled
     MappingTypeEnum:
       enum:
       - equivalent
@@ -6305,6 +15252,411 @@ components:
         * `defined` - Defined
         * `managed` - Managed
         * `optimized` - Optimized
+    ModuleEnum:
+      enum:
+      - policy
+      - standard
+      - procedure
+      - iso_mandatory
+      - pci
+      - risk
+      - asset
+      - other
+      type: string
+      description: |-
+        * `policy` - Policy
+        * `standard` - Standard
+        * `procedure` - Procedure
+        * `iso_mandatory` - ISO Mandatory Document
+        * `pci` - PCI
+        * `risk` - Risk
+        * `asset` - Asset
+        * `other` - Other
+    ModuleKeyEnum:
+      enum:
+      - dashboard
+      - frameworks
+      - risk
+      - assets
+      - vendors
+      - policies
+      - training
+      - analytics
+      - vulnerability_scanning
+      - exports
+      - administration
+      type: string
+      description: |-
+        * `dashboard` - Dashboard
+        * `frameworks` - Frameworks and assessments
+        * `risk` - Risk
+        * `assets` - Assets
+        * `vendors` - Vendors
+        * `policies` - Policies
+        * `training` - Training
+        * `analytics` - Analytics
+        * `vulnerability_scanning` - Vulnerability scanning
+        * `exports` - Exports
+        * `administration` - Administration
+    NonConformity:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        nonconformity_id:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        severity:
+          $ref: '#/components/schemas/NonConformitySeverityEnum'
+        status:
+          $ref: '#/components/schemas/NonConformityStatusEnum'
+        source_type:
+          $ref: '#/components/schemas/NonConformitySourceTypeEnum'
+        detected_on:
+          type: string
+          format: date
+        due_date:
+          type: string
+          format: date
+          nullable: true
+        closed_on:
+          type: string
+          format: date
+          readOnly: true
+          nullable: true
+        owner:
+          type: integer
+          nullable: true
+        owner_username:
+          type: string
+          readOnly: true
+        raised_by_username:
+          type: string
+          readOnly: true
+        regulatory_requirement:
+          type: integer
+          nullable: true
+        root_cause:
+          type: string
+        corrective_action:
+          type: string
+        preventive_action:
+          type: string
+        verification_notes:
+          type: string
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_risks:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+        metadata: {}
+        is_overdue:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - closed_on
+      - created_at
+      - description
+      - id
+      - is_overdue
+      - nonconformity_id
+      - owner_username
+      - raised_by_username
+      - title
+      - updated_at
+    NonConformityRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+          minLength: 1
+        severity:
+          $ref: '#/components/schemas/NonConformitySeverityEnum'
+        status:
+          $ref: '#/components/schemas/NonConformityStatusEnum'
+        source_type:
+          $ref: '#/components/schemas/NonConformitySourceTypeEnum'
+        detected_on:
+          type: string
+          format: date
+        due_date:
+          type: string
+          format: date
+          nullable: true
+        owner:
+          type: integer
+          nullable: true
+        regulatory_requirement:
+          type: integer
+          nullable: true
+        root_cause:
+          type: string
+        corrective_action:
+          type: string
+        preventive_action:
+          type: string
+        verification_notes:
+          type: string
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_risks:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+        metadata: {}
+      required:
+      - description
+      - title
+    NonConformitySeverityEnum:
+      enum:
+      - minor
+      - major
+      - critical
+      type: string
+      description: |-
+        * `minor` - Minor
+        * `major` - Major
+        * `critical` - Critical
+    NonConformitySourceTypeEnum:
+      enum:
+      - internal_audit
+      - external_audit
+      - assessment
+      - incident
+      - management_review
+      - vendor_review
+      - other
+      type: string
+      description: |-
+        * `internal_audit` - Internal Audit
+        * `external_audit` - External Audit
+        * `assessment` - Assessment
+        * `incident` - Incident
+        * `management_review` - Management Review
+        * `vendor_review` - Vendor Review
+        * `other` - Other
+    NonConformityStatusEnum:
+      enum:
+      - open
+      - root_cause_review
+      - corrective_action
+      - verification
+      - closed
+      - accepted
+      type: string
+      description: |-
+        * `open` - Open
+        * `root_cause_review` - Root Cause Review
+        * `corrective_action` - Corrective Action
+        * `verification` - Verification
+        * `closed` - Closed
+        * `accepted` - Accepted
+    NoteTypeE6aEnum:
+      enum:
+      - progress
+      - issue
+      - completion
+      - status_change
+      - general
+      type: string
+      description: |-
+        * `progress` - Progress Update
+        * `issue` - Issue/Blocker
+        * `completion` - Completion
+        * `status_change` - Status Change
+        * `general` - General
+    PaginatedAssetListList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssetList'
+    PaginatedGovernanceArtefactList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/GovernanceArtefact'
+    PaginatedKnowledgeArticleListList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/KnowledgeArticleList'
+    PaginatedKnowledgeCategoryList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/KnowledgeCategory'
+    PaginatedManagementReviewList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ManagementReview'
+    PaginatedNonConformityList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/NonConformity'
+    PaginatedRegulatoryRequirementList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegulatoryRequirement'
     PatchedAssessmentEvidenceRequest:
       type: object
       description: Serializer for assessment evidence links.
@@ -6344,6 +15696,119 @@ components:
           type: boolean
         include_charts:
           type: boolean
+    PatchedAssetDetailRequest:
+      type: object
+      properties:
+        asset_id:
+          type: string
+          minLength: 1
+          maxLength: 80
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        asset_type:
+          $ref: '#/components/schemas/AssetTypeEnum'
+        description:
+          type: string
+        classification:
+          $ref: '#/components/schemas/ClassificationEnum'
+        criticality:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        lifecycle_status:
+          $ref: '#/components/schemas/LifecycleStatusEnum'
+        owner:
+          type: integer
+          nullable: true
+        owner_name:
+          type: string
+          maxLength: 255
+        custodian:
+          type: string
+          maxLength: 255
+        location:
+          type: string
+          maxLength: 255
+        domain:
+          type: string
+          maxLength: 255
+        ip_address:
+          type: string
+          nullable: true
+          minLength: 1
+        mac_address:
+          type: string
+          maxLength: 64
+        serial_number:
+          type: string
+          maxLength: 128
+        manufacturer:
+          type: string
+          maxLength: 255
+        model:
+          type: string
+          maxLength: 255
+        operating_system:
+          type: string
+          maxLength: 255
+        version:
+          type: string
+          maxLength: 100
+        acquisition_date:
+          type: string
+          format: date
+          nullable: true
+        last_seen_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_reviewed_at:
+          type: string
+          format: date-time
+          nullable: true
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        disposal_date:
+          type: string
+          format: date
+          nullable: true
+        linked_risks:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+    PatchedCalendarEventRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+        event_type:
+          $ref: '#/components/schemas/EventTypeEnum'
+        due_date:
+          type: string
+          format: date
+        owner:
+          type: integer
+          nullable: true
+        status:
+          $ref: '#/components/schemas/CalendarEventStatusEnum'
+        source_url:
+          type: string
+          maxLength: 500
+        metadata: {}
     PatchedClauseDetailRequest:
       type: object
       description: Detailed clause serializer with full information.
@@ -6376,7 +15841,7 @@ components:
         clause_type:
           $ref: '#/components/schemas/ClauseTypeEnum'
         criticality:
-          $ref: '#/components/schemas/UrgencyEnum'
+          $ref: '#/components/schemas/RiskLevelEnum'
         is_testable:
           type: boolean
           description: Whether this clause can be tested/audited
@@ -6387,8 +15852,6 @@ components:
           type: string
           description: Procedures for testing compliance with this clause
         external_references:
-          type: object
-          additionalProperties: {}
           description: References to other standards, regulations, or frameworks
     PatchedControlAssessmentCreateUpdateRequest:
       type: object
@@ -6397,6 +15860,10 @@ components:
         control:
           type: integer
           description: The control being assessed
+        framework:
+          type: integer
+          nullable: true
+          description: Framework version this assessment was created against
         applicability:
           allOf:
           - $ref: '#/components/schemas/ApplicabilityEnum'
@@ -6478,7 +15945,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -6533,7 +16000,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status9ffEnum'
+          $ref: '#/components/schemas/Status98bEnum'
         control_owner:
           type: integer
           nullable: true
@@ -6573,8 +16040,6 @@ components:
           type: string
           description: What evidence is needed to demonstrate this control's effectiveness
         documentation_links:
-          type: object
-          additionalProperties: {}
           description: Links to related policies, procedures, and documentation
         risk_rating:
           description: |-
@@ -6585,7 +16050,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/UrgencyEnum'
+          - $ref: '#/components/schemas/RiskLevelEnum'
           - $ref: '#/components/schemas/BlankEnum'
         remediation_plan:
           type: string
@@ -6707,7 +16172,7 @@ components:
           nullable: true
           description: Date when this version expires
         status:
-          $ref: '#/components/schemas/StatusB25Enum'
+          $ref: '#/components/schemas/Status4daEnum'
         is_mandatory:
           type: boolean
           description: Whether compliance with this framework is mandatory for the
@@ -6730,6 +16195,110 @@ components:
           maximum: 2147483647
           minimum: -2147483648
           description: Confidence percentage (0-100) in this mapping
+    PatchedGovernanceArtefactRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        artefact_type:
+          $ref: '#/components/schemas/ArtefactTypeEnum'
+        description:
+          type: string
+        status:
+          $ref: '#/components/schemas/GovernanceArtefactStatusEnum'
+        version:
+          type: string
+          minLength: 1
+          maxLength: 30
+        owner:
+          type: integer
+          nullable: true
+        effective_date:
+          type: string
+          format: date
+          nullable: true
+        review_due_date:
+          type: string
+          format: date
+          nullable: true
+        linked_frameworks:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+        source_template:
+          type: integer
+          nullable: true
+        metadata: {}
+    PatchedKnowledgeArticleDetailRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 220
+        slug:
+          type: string
+          minLength: 1
+          maxLength: 240
+          pattern: ^[-a-zA-Z0-9_]+$
+        summary:
+          type: string
+        body:
+          type: string
+          minLength: 1
+        category:
+          type: integer
+          nullable: true
+        module_key:
+          oneOf:
+          - $ref: '#/components/schemas/ModuleKeyEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        workflow_key:
+          type: string
+          maxLength: 80
+        tags: {}
+        status:
+          $ref: '#/components/schemas/Status399Enum'
+        content_scope:
+          $ref: '#/components/schemas/ContentScopeEnum'
+        sort_order:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+    PatchedKnowledgeCategoryRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        slug:
+          type: string
+          minLength: 1
+          maxLength: 140
+          pattern: ^[-a-zA-Z0-9_]+$
+        description:
+          type: string
+        module_key:
+          oneOf:
+          - $ref: '#/components/schemas/ModuleKeyEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        sort_order:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        is_active:
+          type: boolean
     PatchedLimitOverrideRequestRequest:
       type: object
       description: Serializer for viewing limit override requests.
@@ -6759,13 +16328,614 @@ components:
           nullable: true
           description: When should temporary limits expire?
         status:
-          $ref: '#/components/schemas/Status7d3Enum'
+          $ref: '#/components/schemas/Status1bdEnum'
         first_approval_notes:
           type: string
         second_approval_notes:
           type: string
         rejection_reason:
           type: string
+    PatchedManagementReviewRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        status:
+          $ref: '#/components/schemas/ManagementReviewStatusEnum'
+        meeting_date:
+          type: string
+          format: date
+        period_start:
+          type: string
+          format: date
+          nullable: true
+        period_end:
+          type: string
+          format: date
+          nullable: true
+        chair:
+          type: integer
+          nullable: true
+        attendees:
+          type: array
+          items:
+            type: integer
+        agenda:
+          type: string
+        minutes:
+          type: string
+        decisions:
+          type: string
+        actions_summary:
+          type: string
+        inputs: {}
+        outputs: {}
+        linked_requirements:
+          type: array
+          items:
+            type: integer
+        linked_nonconformities:
+          type: array
+          items:
+            type: integer
+        linked_artefacts:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+    PatchedNonConformityRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+          minLength: 1
+        severity:
+          $ref: '#/components/schemas/NonConformitySeverityEnum'
+        status:
+          $ref: '#/components/schemas/NonConformityStatusEnum'
+        source_type:
+          $ref: '#/components/schemas/NonConformitySourceTypeEnum'
+        detected_on:
+          type: string
+          format: date
+        due_date:
+          type: string
+          format: date
+          nullable: true
+        owner:
+          type: integer
+          nullable: true
+        regulatory_requirement:
+          type: integer
+          nullable: true
+        root_cause:
+          type: string
+        corrective_action:
+          type: string
+        preventive_action:
+          type: string
+        verification_notes:
+          type: string
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_risks:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+        metadata: {}
+    PatchedPolicyCategoryRequest:
+      type: object
+      description: Serializer for policy categories.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Category name (e.g., Security, HR, Legal, IT)
+          maxLength: 100
+        description:
+          type: string
+          description: Description of this policy category
+        color:
+          type: string
+          minLength: 1
+          description: Hex color code for visual identification
+          maxLength: 7
+    PatchedPolicyCreateUpdateRequest:
+      type: object
+      description: Serializer for creating/updating policies.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          description: Policy title
+          maxLength: 200
+        category:
+          type: string
+          format: uuid
+        policy_type:
+          $ref: '#/components/schemas/PolicyTypeEnum'
+        owner:
+          type: integer
+          description: Policy owner/manager responsible for this policy
+        approver:
+          type: integer
+          nullable: true
+          description: User who approved this policy
+        review_frequency_months:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How often this policy should be reviewed (in months)
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this policy is due for review
+        requires_acknowledgment:
+          type: boolean
+          description: Whether users must acknowledge reading this policy
+        acknowledgment_validity_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How long acknowledgments remain valid (days)
+    PatchedPolicyVersionDetailRequest:
+      type: object
+      description: Detailed serializer for policy versions.
+      properties:
+        policy:
+          type: string
+          format: uuid
+        version_number:
+          type: string
+          minLength: 1
+          description: Version number (e.g., 1.0, 1.1, 2.0)
+          maxLength: 10
+        document:
+          type: string
+          format: binary
+          description: Policy document (PDF, DOCX, or DOC)
+          pattern: (?:pdf|docx|doc)$
+        summary:
+          type: string
+          description: Summary of changes in this version
+        lifecycle_state:
+          allOf:
+          - $ref: '#/components/schemas/LifecycleStateEnum'
+          description: |-
+            Document lifecycle state from template through final PDF
+
+            * `template` - Template
+            * `draft` - Draft
+            * `client_modified` - Client Modified
+            * `approved` - Approved
+            * `final` - Final
+        is_active:
+          type: boolean
+          description: Whether this is the current active version
+        is_published:
+          type: boolean
+          description: Whether this version is published and available to users
+        approved_at:
+          type: string
+          format: date-time
+          nullable: true
+        effective_date:
+          type: string
+          format: date
+          description: When this version becomes effective
+        expiry_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this version expires (optional)
+    PatchedRegulatoryRequirementRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        source_type:
+          $ref: '#/components/schemas/RegulatoryRequirementSourceTypeEnum'
+        issuing_body:
+          type: string
+          maxLength: 255
+        jurisdiction:
+          type: string
+          maxLength: 120
+        reference:
+          type: string
+          maxLength: 120
+        description:
+          type: string
+        applicability_status:
+          $ref: '#/components/schemas/ApplicabilityStatusEnum'
+        compliance_status:
+          $ref: '#/components/schemas/ComplianceStatusEnum'
+        priority:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        owner:
+          type: integer
+          nullable: true
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        linked_frameworks:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_risks:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+        linked_artefacts:
+          type: array
+          items:
+            type: integer
+        metadata: {}
+    PatchedRiskActionCreateUpdateRequest:
+      type: object
+      description: Serializer for creating and updating risk actions.
+      properties:
+        risk:
+          type: integer
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+          minLength: 1
+        action_type:
+          $ref: '#/components/schemas/ActionTypeEnum'
+        assigned_to:
+          type: integer
+          nullable: true
+          description: Person responsible for completing this action
+        priority:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        due_date:
+          type: string
+          format: date
+          description: Date when this action must be completed
+        progress_percentage:
+          type: integer
+          maximum: 100
+          minimum: 0
+          description: Completion percentage (0-100)
+        estimated_cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Estimated cost to complete this action
+        actual_cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Actual cost incurred for this action
+        estimated_effort_hours:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+          description: Estimated effort in hours
+        success_criteria:
+          type: string
+          description: Specific criteria that define successful completion
+        dependencies:
+          type: string
+          description: Dependencies or prerequisites for this action
+    PatchedRiskActionReminderConfigurationRequest:
+      type: object
+      description: Serializer for risk action reminder configuration.
+      properties:
+        enable_reminders:
+          type: boolean
+          description: Whether to send automated reminders to this user
+        advance_warning_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: Days before due date to send advance warning
+        reminder_frequency:
+          allOf:
+          - $ref: '#/components/schemas/ReminderFrequencyEnum'
+          description: |-
+            How frequently to send reminders
+
+            * `daily` - Daily
+            * `weekly` - Weekly
+            * `custom` - Custom Days
+        custom_reminder_days:
+          description: Custom reminder days pattern [1, 3, 7, 14] - only used when
+            frequency is 'custom'
+        email_notifications:
+          type: boolean
+          description: Send email notifications
+        overdue_reminders:
+          type: boolean
+          description: Send reminders for overdue actions
+        weekly_digest_enabled:
+          type: boolean
+          description: Send weekly summary digest
+        weekly_digest_day:
+          type: integer
+          maximum: 6
+          minimum: 0
+          description: Day of week for digest (0=Monday, 6=Sunday)
+        silence_completed:
+          type: boolean
+          description: Stop sending reminders for completed actions
+        silence_cancelled:
+          type: boolean
+          description: Stop sending reminders for cancelled actions
+    PatchedRiskCategoryRequest:
+      type: object
+      description: Serializer for Risk Categories.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        description:
+          type: string
+        color:
+          type: string
+          minLength: 1
+          description: Hex color code for UI display
+          maxLength: 7
+    PatchedRiskCreateUpdateRequest:
+      type: object
+      description: Serializer for creating and updating risks.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+          minLength: 1
+        category:
+          type: integer
+          nullable: true
+        impact:
+          type: integer
+          maximum: 5
+          minimum: 1
+          description: Impact level (1=Very Low, 5=Very High)
+        likelihood:
+          type: integer
+          maximum: 5
+          minimum: 1
+          description: Likelihood level (1=Very Low, 5=Very High)
+        status:
+          $ref: '#/components/schemas/Status7b5Enum'
+        treatment_strategy:
+          oneOf:
+          - $ref: '#/components/schemas/TreatmentStrategyEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        treatment_description:
+          type: string
+          description: Description of the treatment approach
+        risk_owner:
+          type: integer
+          nullable: true
+          description: Person responsible for managing this risk
+        risk_matrix:
+          type: integer
+          nullable: true
+        identified_date:
+          type: string
+          format: date
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        potential_impact_description:
+          type: string
+          description: Detailed description of potential impact
+        current_controls:
+          type: string
+          description: Existing controls or mitigations in place
+    PatchedRiskMatrixRequest:
+      type: object
+      description: Serializer for Risk Matrix configurations.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        description:
+          type: string
+        is_default:
+          type: boolean
+        impact_levels:
+          type: integer
+          maximum: 7
+          minimum: 3
+        likelihood_levels:
+          type: integer
+          maximum: 7
+          minimum: 3
+        matrix_config:
+          description: Matrix configuration mapping impact x likelihood to risk levels
+    PatchedScanScheduleRequest:
+      type: object
+      properties:
+        target:
+          type: string
+          format: uuid
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        frequency:
+          $ref: '#/components/schemas/FrequencyEnum'
+        is_active:
+          type: boolean
+        next_run_at:
+          type: string
+          format: date-time
+          nullable: true
+    PatchedScanTargetRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        target_type:
+          $ref: '#/components/schemas/TargetTypeEnum'
+        address:
+          type: string
+          minLength: 1
+          maxLength: 500
+        status:
+          $ref: '#/components/schemas/ScanTargetStatusEnum'
+        owner:
+          type: integer
+          nullable: true
+        tags: {}
+        metadata: {}
+    PatchedSecurityAwarenessCampaignDetailRequest:
+      type: object
+      description: Serializer for campaign detail view.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+        subject_line:
+          type: string
+          minLength: 1
+          maxLength: 200
+        email_content:
+          type: string
+          minLength: 1
+          description: HTML content for the email. Use {{user.first_name}} for personalization.
+        is_active:
+          type: boolean
+        send_frequency:
+          $ref: '#/components/schemas/SendFrequencyEnum'
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        next_send_date:
+          type: string
+          format: date-time
+        send_to_all_users:
+          type: boolean
+          description: If False, only send to specific users or groups
+        target_users:
+          type: array
+          items:
+            type: integer
+          description: Specific users to receive this campaign (if not sending to
+            all)
+    PatchedTrainingCategoryRequest:
+      type: object
+      description: Serializer for training categories.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        description:
+          type: string
+        color:
+          type: string
+          minLength: 1
+          description: Hex color code for category display
+          maxLength: 7
+        is_active:
+          type: boolean
+    PatchedTrainingVideoDetailRequest:
+      type: object
+      description: Serializer for training video detail view.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+        category:
+          type: string
+          format: uuid
+        video_provider:
+          $ref: '#/components/schemas/VideoProviderEnum'
+        video_url:
+          type: string
+          format: uri
+          minLength: 1
+          description: Full URL to the video or embed URL
+          maxLength: 200
+        video_id:
+          type: string
+          description: Provider-specific video ID
+          maxLength: 100
+        duration_minutes:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+          description: Video duration in minutes
+        difficulty_level:
+          $ref: '#/components/schemas/DifficultyLevelEnum'
+        is_published:
+          type: boolean
+    PatchedVulnerabilityFindingRequest:
+      type: object
+      properties:
+        target:
+          type: string
+          format: uuid
+        job:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/VulnerabilityFindingStatusEnum'
     Plan:
       type: object
       description: Serializer for subscription plans.
@@ -6804,10 +16974,905 @@ components:
           type: boolean
         has_priority_support:
           type: boolean
+        included_modules: {}
+        module_catalog:
+          type: string
+          readOnly: true
       required:
       - id
+      - module_catalog
       - name
       - slug
+    PolicyAcknowledgment:
+      type: object
+      description: Serializer for policy acknowledgments.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        user:
+          type: integer
+        user_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+        policy_version:
+          type: string
+          format: uuid
+        policy_version_details:
+          allOf:
+          - $ref: '#/components/schemas/PolicyVersionList'
+          readOnly: true
+        policy_title:
+          type: string
+          readOnly: true
+        policy_code:
+          type: string
+          readOnly: true
+        acknowledged_at:
+          type: string
+          format: date-time
+          readOnly: true
+        expires_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+          description: When this acknowledgment expires
+        ip_address:
+          type: string
+          nullable: true
+          description: IP address when acknowledgment was made
+        user_agent:
+          type: string
+          description: Browser user agent string
+        is_expired:
+          type: boolean
+          readOnly: true
+        is_valid:
+          type: boolean
+          readOnly: true
+      required:
+      - acknowledged_at
+      - expires_at
+      - id
+      - is_expired
+      - is_valid
+      - policy_code
+      - policy_title
+      - policy_version
+      - policy_version_details
+      - user
+      - user_details
+    PolicyCategory:
+      type: object
+      description: Serializer for policy categories.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          description: Category name (e.g., Security, HR, Legal, IT)
+          maxLength: 100
+        description:
+          type: string
+          description: Description of this policy category
+        color:
+          type: string
+          description: Hex color code for visual identification
+          maxLength: 7
+        policies_count:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - id
+      - name
+      - policies_count
+      - updated_at
+    PolicyCategoryRequest:
+      type: object
+      description: Serializer for policy categories.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Category name (e.g., Security, HR, Legal, IT)
+          maxLength: 100
+        description:
+          type: string
+          description: Description of this policy category
+        color:
+          type: string
+          minLength: 1
+          description: Hex color code for visual identification
+          maxLength: 7
+      required:
+      - name
+    PolicyCreateUpdate:
+      type: object
+      description: Serializer for creating/updating policies.
+      properties:
+        title:
+          type: string
+          description: Policy title
+          maxLength: 200
+        category:
+          type: string
+          format: uuid
+        policy_type:
+          $ref: '#/components/schemas/PolicyTypeEnum'
+        owner:
+          type: integer
+          description: Policy owner/manager responsible for this policy
+        approver:
+          type: integer
+          nullable: true
+          description: User who approved this policy
+        review_frequency_months:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How often this policy should be reviewed (in months)
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this policy is due for review
+        requires_acknowledgment:
+          type: boolean
+          description: Whether users must acknowledge reading this policy
+        acknowledgment_validity_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How long acknowledgments remain valid (days)
+      required:
+      - category
+      - owner
+      - title
+    PolicyCreateUpdateRequest:
+      type: object
+      description: Serializer for creating/updating policies.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          description: Policy title
+          maxLength: 200
+        category:
+          type: string
+          format: uuid
+        policy_type:
+          $ref: '#/components/schemas/PolicyTypeEnum'
+        owner:
+          type: integer
+          description: Policy owner/manager responsible for this policy
+        approver:
+          type: integer
+          nullable: true
+          description: User who approved this policy
+        review_frequency_months:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How often this policy should be reviewed (in months)
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this policy is due for review
+        requires_acknowledgment:
+          type: boolean
+          description: Whether users must acknowledge reading this policy
+        acknowledgment_validity_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How long acknowledgments remain valid (days)
+      required:
+      - category
+      - owner
+      - title
+    PolicyDetail:
+      type: object
+      description: Detailed serializer for policies.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        policy_code:
+          type: string
+          readOnly: true
+          description: Unique policy code (e.g., POL-SEC-001)
+        title:
+          type: string
+          description: Policy title
+          maxLength: 200
+        category:
+          type: string
+          format: uuid
+        category_details:
+          allOf:
+          - $ref: '#/components/schemas/PolicyCategory'
+          readOnly: true
+        policy_type:
+          $ref: '#/components/schemas/PolicyTypeEnum'
+        status:
+          $ref: '#/components/schemas/Status019Enum'
+        owner:
+          type: integer
+          description: Policy owner/manager responsible for this policy
+        owner_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+        approver:
+          type: integer
+          nullable: true
+          description: User who approved this policy
+        approver_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+        review_frequency_months:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How often this policy should be reviewed (in months)
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this policy is due for review
+        requires_acknowledgment:
+          type: boolean
+          description: Whether users must acknowledge reading this policy
+        acknowledgment_validity_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How long acknowledgments remain valid (days)
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PolicyVersionList'
+          readOnly: true
+        current_version:
+          allOf:
+          - $ref: '#/components/schemas/PolicyVersionList'
+          readOnly: true
+        latest_version:
+          allOf:
+          - $ref: '#/components/schemas/PolicyVersionList'
+          readOnly: true
+        is_due_for_review:
+          type: boolean
+          readOnly: true
+        acknowledgment_stats:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        created_by_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+      required:
+      - acknowledgment_stats
+      - approver_details
+      - category
+      - category_details
+      - created_at
+      - created_by_details
+      - current_version
+      - id
+      - is_due_for_review
+      - latest_version
+      - owner
+      - owner_details
+      - policy_code
+      - title
+      - updated_at
+      - versions
+    PolicyDetailRequest:
+      type: object
+      description: Detailed serializer for policies.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          description: Policy title
+          maxLength: 200
+        category:
+          type: string
+          format: uuid
+        policy_type:
+          $ref: '#/components/schemas/PolicyTypeEnum'
+        status:
+          $ref: '#/components/schemas/Status019Enum'
+        owner:
+          type: integer
+          description: Policy owner/manager responsible for this policy
+        approver:
+          type: integer
+          nullable: true
+          description: User who approved this policy
+        review_frequency_months:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How often this policy should be reviewed (in months)
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this policy is due for review
+        requires_acknowledgment:
+          type: boolean
+          description: Whether users must acknowledge reading this policy
+        acknowledgment_validity_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How long acknowledgments remain valid (days)
+      required:
+      - category
+      - owner
+      - title
+    PolicyDistribution:
+      type: object
+      description: Serializer for policy distributions.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        policy_version:
+          type: string
+          format: uuid
+        policy_version_details:
+          allOf:
+          - $ref: '#/components/schemas/PolicyVersionList'
+          readOnly: true
+        policy_title:
+          type: string
+          readOnly: true
+        policy_code:
+          type: string
+          readOnly: true
+        distributed_to:
+          type: integer
+        distributed_to_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+        distributed_by:
+          type: integer
+          nullable: true
+        distributed_by_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+        distributed_at:
+          type: string
+          format: date-time
+          readOnly: true
+        notification_sent:
+          type: boolean
+        notification_sent_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        reminder_count:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        last_reminder_sent:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        acknowledged:
+          type: boolean
+        acknowledged_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        is_overdue:
+          type: boolean
+          readOnly: true
+      required:
+      - acknowledged_at
+      - distributed_at
+      - distributed_by_details
+      - distributed_to
+      - distributed_to_details
+      - id
+      - is_overdue
+      - last_reminder_sent
+      - notification_sent_at
+      - policy_code
+      - policy_title
+      - policy_version
+      - policy_version_details
+    PolicyList:
+      type: object
+      description: List serializer for policies.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        policy_code:
+          type: string
+          readOnly: true
+          description: Unique policy code (e.g., POL-SEC-001)
+        title:
+          type: string
+          description: Policy title
+          maxLength: 200
+        policy_type:
+          $ref: '#/components/schemas/PolicyTypeEnum'
+        status:
+          $ref: '#/components/schemas/Status019Enum'
+        category_name:
+          type: string
+          readOnly: true
+        category_color:
+          type: string
+          readOnly: true
+        owner_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+        current_version:
+          allOf:
+          - $ref: '#/components/schemas/PolicyVersionList'
+          readOnly: true
+        review_frequency_months:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How often this policy should be reviewed (in months)
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this policy is due for review
+        requires_acknowledgment:
+          type: boolean
+          description: Whether users must acknowledge reading this policy
+        acknowledgment_validity_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How long acknowledgments remain valid (days)
+        versions_count:
+          type: string
+          readOnly: true
+        acknowledgment_count:
+          type: string
+          readOnly: true
+        is_due_for_review:
+          type: boolean
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - acknowledgment_count
+      - category_color
+      - category_name
+      - created_at
+      - current_version
+      - id
+      - is_due_for_review
+      - owner_details
+      - policy_code
+      - title
+      - updated_at
+      - versions_count
+    PolicyListRequest:
+      type: object
+      description: List serializer for policies.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          description: Policy title
+          maxLength: 200
+        policy_type:
+          $ref: '#/components/schemas/PolicyTypeEnum'
+        status:
+          $ref: '#/components/schemas/Status019Enum'
+        review_frequency_months:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How often this policy should be reviewed (in months)
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this policy is due for review
+        requires_acknowledgment:
+          type: boolean
+          description: Whether users must acknowledge reading this policy
+        acknowledgment_validity_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: How long acknowledgments remain valid (days)
+      required:
+      - title
+    PolicyTypeEnum:
+      enum:
+      - procedure
+      - policy
+      - standard
+      - guideline
+      - framework
+      type: string
+      description: |-
+        * `procedure` - Procedure
+        * `policy` - Policy
+        * `standard` - Standard
+        * `guideline` - Guideline
+        * `framework` - Framework
+    PolicyVersionDetail:
+      type: object
+      description: Detailed serializer for policy versions.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        policy:
+          type: string
+          format: uuid
+        policy_details:
+          allOf:
+          - $ref: '#/components/schemas/PolicyList'
+          readOnly: true
+        version_number:
+          type: string
+          description: Version number (e.g., 1.0, 1.1, 2.0)
+          maxLength: 10
+        document:
+          type: string
+          format: uri
+          description: Policy document (PDF, DOCX, or DOC)
+          pattern: (?:pdf|docx|doc)$
+        document_size:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: Document size in bytes
+        final_pdf:
+          type: string
+          format: uri
+          readOnly: true
+          nullable: true
+          description: Final PDF generated from the approved editable source
+        final_pdf_size:
+          type: integer
+          readOnly: true
+          nullable: true
+        file_name:
+          type: string
+          readOnly: true
+        file_extension:
+          type: string
+          readOnly: true
+        summary:
+          type: string
+          description: Summary of changes in this version
+        lifecycle_state:
+          allOf:
+          - $ref: '#/components/schemas/LifecycleStateEnum'
+          description: |-
+            Document lifecycle state from template through final PDF
+
+            * `template` - Template
+            * `draft` - Draft
+            * `client_modified` - Client Modified
+            * `approved` - Approved
+            * `final` - Final
+        is_active:
+          type: boolean
+          description: Whether this is the current active version
+        is_published:
+          type: boolean
+          description: Whether this version is published and available to users
+        is_current:
+          type: boolean
+          readOnly: true
+        is_expired:
+          type: boolean
+          readOnly: true
+        approved_at:
+          type: string
+          format: date-time
+          nullable: true
+        effective_date:
+          type: string
+          format: date
+          description: When this version becomes effective
+        expiry_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this version expires (optional)
+        finalized_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        acknowledgments_count:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        created_by_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+        approved_by_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+        finalized_by_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+      required:
+      - acknowledgments_count
+      - approved_by_details
+      - created_at
+      - created_by_details
+      - document
+      - document_size
+      - file_extension
+      - file_name
+      - final_pdf
+      - final_pdf_size
+      - finalized_at
+      - finalized_by_details
+      - id
+      - is_current
+      - is_expired
+      - policy
+      - policy_details
+      - version_number
+    PolicyVersionDetailRequest:
+      type: object
+      description: Detailed serializer for policy versions.
+      properties:
+        policy:
+          type: string
+          format: uuid
+        version_number:
+          type: string
+          minLength: 1
+          description: Version number (e.g., 1.0, 1.1, 2.0)
+          maxLength: 10
+        document:
+          type: string
+          format: binary
+          description: Policy document (PDF, DOCX, or DOC)
+          pattern: (?:pdf|docx|doc)$
+        summary:
+          type: string
+          description: Summary of changes in this version
+        lifecycle_state:
+          allOf:
+          - $ref: '#/components/schemas/LifecycleStateEnum'
+          description: |-
+            Document lifecycle state from template through final PDF
+
+            * `template` - Template
+            * `draft` - Draft
+            * `client_modified` - Client Modified
+            * `approved` - Approved
+            * `final` - Final
+        is_active:
+          type: boolean
+          description: Whether this is the current active version
+        is_published:
+          type: boolean
+          description: Whether this version is published and available to users
+        approved_at:
+          type: string
+          format: date-time
+          nullable: true
+        effective_date:
+          type: string
+          format: date
+          description: When this version becomes effective
+        expiry_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this version expires (optional)
+      required:
+      - document
+      - policy
+      - version_number
+    PolicyVersionList:
+      type: object
+      description: List serializer for policy versions.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        version_number:
+          type: string
+          description: Version number (e.g., 1.0, 1.1, 2.0)
+          maxLength: 10
+        summary:
+          type: string
+          description: Summary of changes in this version
+        is_active:
+          type: boolean
+          description: Whether this is the current active version
+        is_published:
+          type: boolean
+          description: Whether this version is published and available to users
+        lifecycle_state:
+          allOf:
+          - $ref: '#/components/schemas/LifecycleStateEnum'
+          description: |-
+            Document lifecycle state from template through final PDF
+
+            * `template` - Template
+            * `draft` - Draft
+            * `client_modified` - Client Modified
+            * `approved` - Approved
+            * `final` - Final
+        document_size:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: Document size in bytes
+        final_pdf_size:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+        file_name:
+          type: string
+          readOnly: true
+        file_extension:
+          type: string
+          readOnly: true
+        is_current:
+          type: boolean
+          readOnly: true
+        is_expired:
+          type: boolean
+          readOnly: true
+        effective_date:
+          type: string
+          format: date
+          description: When this version becomes effective
+        expiry_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this version expires (optional)
+        approved_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        finalized_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_by_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+        approved_by_details:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+      required:
+      - approved_by_details
+      - created_at
+      - created_by_details
+      - document_size
+      - file_extension
+      - file_name
+      - id
+      - is_current
+      - is_expired
+      - version_number
+    PolicyVersionListRequest:
+      type: object
+      description: List serializer for policy versions.
+      properties:
+        version_number:
+          type: string
+          minLength: 1
+          description: Version number (e.g., 1.0, 1.1, 2.0)
+          maxLength: 10
+        summary:
+          type: string
+          description: Summary of changes in this version
+        is_active:
+          type: boolean
+          description: Whether this is the current active version
+        is_published:
+          type: boolean
+          description: Whether this version is published and available to users
+        lifecycle_state:
+          allOf:
+          - $ref: '#/components/schemas/LifecycleStateEnum'
+          description: |-
+            Document lifecycle state from template through final PDF
+
+            * `template` - Template
+            * `draft` - Draft
+            * `client_modified` - Client Modified
+            * `approved` - Approved
+            * `final` - Final
+        final_pdf_size:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+        effective_date:
+          type: string
+          format: date
+          description: When this version becomes effective
+        expiry_date:
+          type: string
+          format: date
+          nullable: true
+          description: When this version expires (optional)
+        approved_at:
+          type: string
+          format: date-time
+          nullable: true
+        finalized_at:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - version_number
     RegisterRequest:
       type: object
       properties:
@@ -6841,19 +17906,2055 @@ components:
       - password
       - password_confirm
       - username
+    RegulatoryRequirement:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        requirement_id:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          maxLength: 255
+        source_type:
+          $ref: '#/components/schemas/RegulatoryRequirementSourceTypeEnum'
+        issuing_body:
+          type: string
+          maxLength: 255
+        jurisdiction:
+          type: string
+          maxLength: 120
+        reference:
+          type: string
+          maxLength: 120
+        description:
+          type: string
+        applicability_status:
+          $ref: '#/components/schemas/ApplicabilityStatusEnum'
+        compliance_status:
+          $ref: '#/components/schemas/ComplianceStatusEnum'
+        priority:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        owner:
+          type: integer
+          nullable: true
+        owner_username:
+          type: string
+          readOnly: true
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        linked_frameworks:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_risks:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+        linked_artefacts:
+          type: array
+          items:
+            type: integer
+        metadata: {}
+        created_by_username:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - created_by_username
+      - id
+      - owner_username
+      - requirement_id
+      - source_type
+      - title
+      - updated_at
+    RegulatoryRequirementRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        source_type:
+          $ref: '#/components/schemas/RegulatoryRequirementSourceTypeEnum'
+        issuing_body:
+          type: string
+          maxLength: 255
+        jurisdiction:
+          type: string
+          maxLength: 120
+        reference:
+          type: string
+          maxLength: 120
+        description:
+          type: string
+        applicability_status:
+          $ref: '#/components/schemas/ApplicabilityStatusEnum'
+        compliance_status:
+          $ref: '#/components/schemas/ComplianceStatusEnum'
+        priority:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        owner:
+          type: integer
+          nullable: true
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        linked_frameworks:
+          type: array
+          items:
+            type: integer
+        linked_controls:
+          type: array
+          items:
+            type: integer
+        linked_risks:
+          type: array
+          items:
+            type: integer
+        linked_documents:
+          type: array
+          items:
+            type: integer
+        linked_artefacts:
+          type: array
+          items:
+            type: integer
+        metadata: {}
+      required:
+      - source_type
+      - title
+    RegulatoryRequirementSourceTypeEnum:
+      enum:
+      - regulation
+      - contract
+      - standard
+      - policy
+      - other
+      type: string
+      description: |-
+        * `regulation` - Regulation
+        * `contract` - Contract
+        * `standard` - Standard
+        * `policy` - Policy
+        * `other` - Other
+    ReminderFrequencyEnum:
+      enum:
+      - daily
+      - weekly
+      - custom
+      type: string
+      description: |-
+        * `daily` - Daily
+        * `weekly` - Weekly
+        * `custom` - Custom Days
     ReportTypeEnum:
       enum:
       - assessment_summary
       - detailed_assessment
       - evidence_portfolio
       - compliance_gap
+      - risk_analytics
       type: string
       description: |-
         * `assessment_summary` - Assessment Summary Report
         * `detailed_assessment` - Detailed Assessment Report
         * `evidence_portfolio` - Evidence Portfolio Report
         * `compliance_gap` - Compliance Gap Analysis
-    Status7d3Enum:
+        * `risk_analytics` - Risk Analytics & Integration Report
+    RiskActionBulkCreateRequest:
+      type: object
+      description: Serializer for bulk creating risk actions.
+      properties:
+        risk:
+          type: integer
+        assigned_to:
+          type: integer
+          nullable: true
+        default_priority:
+          allOf:
+          - $ref: '#/components/schemas/RiskLevelEnum'
+          default: medium
+        default_action_type:
+          allOf:
+          - $ref: '#/components/schemas/DefaultActionTypeEnum'
+          default: other
+        actions:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: List of action dictionaries with title, description, and optional
+            overrides
+          maxItems: 50
+          minItems: 1
+      required:
+      - actions
+      - risk
+    RiskActionCreateUpdate:
+      type: object
+      description: Serializer for creating and updating risk actions.
+      properties:
+        risk:
+          type: integer
+        title:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+        action_type:
+          $ref: '#/components/schemas/ActionTypeEnum'
+        assigned_to:
+          type: integer
+          nullable: true
+          description: Person responsible for completing this action
+        priority:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        due_date:
+          type: string
+          format: date
+          description: Date when this action must be completed
+        progress_percentage:
+          type: integer
+          maximum: 100
+          minimum: 0
+          description: Completion percentage (0-100)
+        estimated_cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Estimated cost to complete this action
+        actual_cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Actual cost incurred for this action
+        estimated_effort_hours:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+          description: Estimated effort in hours
+        success_criteria:
+          type: string
+          description: Specific criteria that define successful completion
+        dependencies:
+          type: string
+          description: Dependencies or prerequisites for this action
+      required:
+      - description
+      - due_date
+      - risk
+      - title
+    RiskActionCreateUpdateRequest:
+      type: object
+      description: Serializer for creating and updating risk actions.
+      properties:
+        risk:
+          type: integer
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+          minLength: 1
+        action_type:
+          $ref: '#/components/schemas/ActionTypeEnum'
+        assigned_to:
+          type: integer
+          nullable: true
+          description: Person responsible for completing this action
+        priority:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        due_date:
+          type: string
+          format: date
+          description: Date when this action must be completed
+        progress_percentage:
+          type: integer
+          maximum: 100
+          minimum: 0
+          description: Completion percentage (0-100)
+        estimated_cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Estimated cost to complete this action
+        actual_cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Actual cost incurred for this action
+        estimated_effort_hours:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+          description: Estimated effort in hours
+        success_criteria:
+          type: string
+          description: Specific criteria that define successful completion
+        dependencies:
+          type: string
+          description: Dependencies or prerequisites for this action
+      required:
+      - description
+      - due_date
+      - risk
+      - title
+    RiskActionDetail:
+      type: object
+      description: Detailed Risk Action serializer with all fields and related data.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        action_id:
+          type: string
+          readOnly: true
+          description: Unique action identifier
+        title:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+        action_type:
+          $ref: '#/components/schemas/ActionTypeEnum'
+        risk:
+          type: integer
+        risk_id:
+          type: string
+          readOnly: true
+        risk_title:
+          type: string
+          readOnly: true
+        risk_level:
+          type: string
+          readOnly: true
+        risk_level_display:
+          type: string
+          readOnly: true
+        risk_summary:
+          type: string
+          readOnly: true
+        assigned_to:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+        assigned_to_name:
+          type: string
+          readOnly: true
+        status:
+          $ref: '#/components/schemas/Status833Enum'
+        priority:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        priority_color:
+          type: string
+          readOnly: true
+        status_color:
+          type: string
+          readOnly: true
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        due_date:
+          type: string
+          format: date
+          description: Date when this action must be completed
+        completed_date:
+          type: string
+          format: date
+          readOnly: true
+          nullable: true
+        progress_percentage:
+          type: integer
+          maximum: 100
+          minimum: 0
+          description: Completion percentage (0-100)
+        estimated_cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Estimated cost to complete this action
+        actual_cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Actual cost incurred for this action
+        estimated_effort_hours:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+          description: Estimated effort in hours
+        success_criteria:
+          type: string
+          description: Specific criteria that define successful completion
+        dependencies:
+          type: string
+          description: Dependencies or prerequisites for this action
+        days_until_due:
+          type: integer
+          readOnly: true
+        is_overdue:
+          type: boolean
+          readOnly: true
+        is_due_soon:
+          type: boolean
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        created_by:
+          type: integer
+          readOnly: true
+          nullable: true
+        created_by_name:
+          type: string
+          readOnly: true
+        notes:
+          type: array
+          items:
+            $ref: '#/components/schemas/RiskActionNote'
+          readOnly: true
+        evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/RiskActionEvidence'
+          readOnly: true
+      required:
+      - action_id
+      - assigned_to
+      - assigned_to_name
+      - completed_date
+      - created_at
+      - created_by
+      - created_by_name
+      - days_until_due
+      - description
+      - due_date
+      - evidence
+      - id
+      - is_due_soon
+      - is_overdue
+      - notes
+      - priority_color
+      - risk
+      - risk_id
+      - risk_level
+      - risk_level_display
+      - risk_summary
+      - risk_title
+      - status_color
+      - title
+      - updated_at
+    RiskActionEvidence:
+      type: object
+      description: Serializer for Risk Action Evidence.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+        evidence_type:
+          $ref: '#/components/schemas/EvidenceTypeAe0Enum'
+        file:
+          type: string
+          format: uri
+          nullable: true
+        file_url:
+          type: string
+          readOnly: true
+        external_link:
+          type: string
+          format: uri
+          description: Link to external evidence or system
+          maxLength: 200
+        is_validated:
+          type: boolean
+          readOnly: true
+        validated_by:
+          type: integer
+          readOnly: true
+          nullable: true
+        validated_by_name:
+          type: string
+          readOnly: true
+        validated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        validation_notes:
+          type: string
+          readOnly: true
+        evidence_date:
+          type: string
+          format: date
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        uploaded_by:
+          type: integer
+          readOnly: true
+          nullable: true
+        uploaded_by_name:
+          type: string
+          readOnly: true
+      required:
+      - created_at
+      - file_url
+      - id
+      - is_validated
+      - title
+      - uploaded_by
+      - uploaded_by_name
+      - validated_at
+      - validated_by
+      - validated_by_name
+      - validation_notes
+    RiskActionEvidenceCreateUpdateRequest:
+      type: object
+      description: Serializer for creating and updating risk action evidence.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+        evidence_type:
+          $ref: '#/components/schemas/EvidenceTypeAe0Enum'
+        file:
+          type: string
+          format: binary
+          nullable: true
+        external_link:
+          type: string
+          format: uri
+          description: Link to external evidence or system
+          maxLength: 200
+        evidence_date:
+          type: string
+          format: date
+      required:
+      - title
+    RiskActionList:
+      type: object
+      description: Serializer for Risk Action list view with essential fields.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        action_id:
+          type: string
+          readOnly: true
+          description: Unique action identifier
+        title:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+        action_type:
+          $ref: '#/components/schemas/ActionTypeEnum'
+        risk:
+          type: integer
+        risk_id:
+          type: string
+          readOnly: true
+        risk_title:
+          type: string
+          readOnly: true
+        risk_level:
+          type: string
+          readOnly: true
+        risk_level_display:
+          type: string
+          readOnly: true
+        assigned_to:
+          type: integer
+          nullable: true
+          description: Person responsible for completing this action
+        assigned_to_name:
+          type: string
+          readOnly: true
+        status:
+          $ref: '#/components/schemas/Status833Enum'
+        priority:
+          $ref: '#/components/schemas/RiskLevelEnum'
+        priority_color:
+          type: string
+          readOnly: true
+        status_color:
+          type: string
+          readOnly: true
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        due_date:
+          type: string
+          format: date
+          description: Date when this action must be completed
+        completed_date:
+          type: string
+          format: date
+          readOnly: true
+          nullable: true
+        progress_percentage:
+          type: integer
+          maximum: 100
+          minimum: 0
+          description: Completion percentage (0-100)
+        days_until_due:
+          type: integer
+          readOnly: true
+        is_overdue:
+          type: boolean
+          readOnly: true
+        is_due_soon:
+          type: boolean
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - action_id
+      - assigned_to_name
+      - completed_date
+      - created_at
+      - days_until_due
+      - description
+      - due_date
+      - id
+      - is_due_soon
+      - is_overdue
+      - priority_color
+      - risk
+      - risk_id
+      - risk_level
+      - risk_level_display
+      - risk_title
+      - status_color
+      - title
+      - updated_at
+    RiskActionNote:
+      type: object
+      description: Serializer for Risk Action Notes.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        note:
+          type: string
+        note_type:
+          $ref: '#/components/schemas/NoteTypeE6aEnum'
+        progress_percentage:
+          type: integer
+          maximum: 100
+          minimum: 0
+          nullable: true
+          description: Progress percentage at time of note
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        created_by:
+          type: integer
+          readOnly: true
+          nullable: true
+        created_by_name:
+          type: string
+          readOnly: true
+      required:
+      - created_at
+      - created_by
+      - created_by_name
+      - id
+      - note
+    RiskActionNoteCreateRequest:
+      type: object
+      description: Serializer for creating risk action notes.
+      properties:
+        note:
+          type: string
+          minLength: 1
+        note_type:
+          $ref: '#/components/schemas/NoteTypeE6aEnum'
+        progress_percentage:
+          type: integer
+          maximum: 100
+          minimum: 0
+          nullable: true
+          description: Progress percentage at time of note
+      required:
+      - note
+    RiskActionReminderConfiguration:
+      type: object
+      description: Serializer for risk action reminder configuration.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        user:
+          type: integer
+          readOnly: true
+          description: User for whom risk action reminders are configured
+        user_name:
+          type: string
+          readOnly: true
+        enable_reminders:
+          type: boolean
+          description: Whether to send automated reminders to this user
+        advance_warning_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: Days before due date to send advance warning
+        reminder_frequency:
+          allOf:
+          - $ref: '#/components/schemas/ReminderFrequencyEnum'
+          description: |-
+            How frequently to send reminders
+
+            * `daily` - Daily
+            * `weekly` - Weekly
+            * `custom` - Custom Days
+        custom_reminder_days:
+          description: Custom reminder days pattern [1, 3, 7, 14] - only used when
+            frequency is 'custom'
+        email_notifications:
+          type: boolean
+          description: Send email notifications
+        overdue_reminders:
+          type: boolean
+          description: Send reminders for overdue actions
+        weekly_digest_enabled:
+          type: boolean
+          description: Send weekly summary digest
+        weekly_digest_day:
+          type: integer
+          maximum: 6
+          minimum: 0
+          description: Day of week for digest (0=Monday, 6=Sunday)
+        silence_completed:
+          type: boolean
+          description: Stop sending reminders for completed actions
+        silence_cancelled:
+          type: boolean
+          description: Stop sending reminders for cancelled actions
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - id
+      - updated_at
+      - user
+      - user_name
+    RiskActionReminderConfigurationRequest:
+      type: object
+      description: Serializer for risk action reminder configuration.
+      properties:
+        enable_reminders:
+          type: boolean
+          description: Whether to send automated reminders to this user
+        advance_warning_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: Days before due date to send advance warning
+        reminder_frequency:
+          allOf:
+          - $ref: '#/components/schemas/ReminderFrequencyEnum'
+          description: |-
+            How frequently to send reminders
+
+            * `daily` - Daily
+            * `weekly` - Weekly
+            * `custom` - Custom Days
+        custom_reminder_days:
+          description: Custom reminder days pattern [1, 3, 7, 14] - only used when
+            frequency is 'custom'
+        email_notifications:
+          type: boolean
+          description: Send email notifications
+        overdue_reminders:
+          type: boolean
+          description: Send reminders for overdue actions
+        weekly_digest_enabled:
+          type: boolean
+          description: Send weekly summary digest
+        weekly_digest_day:
+          type: integer
+          maximum: 6
+          minimum: 0
+          description: Day of week for digest (0=Monday, 6=Sunday)
+        silence_completed:
+          type: boolean
+          description: Stop sending reminders for completed actions
+        silence_cancelled:
+          type: boolean
+          description: Stop sending reminders for cancelled actions
+    RiskActionStatusUpdateRequest:
+      type: object
+      description: Serializer for updating risk action status with optional note.
+      properties:
+        status:
+          $ref: '#/components/schemas/Status833Enum'
+        progress_percentage:
+          type: integer
+          maximum: 100
+          minimum: 0
+        note:
+          type: string
+          maxLength: 1000
+      required:
+      - status
+    RiskActionSummary:
+      type: object
+      description: Serializer for risk action summary statistics.
+      properties:
+        total_actions:
+          type: integer
+        by_status:
+          type: object
+          additionalProperties: {}
+        by_priority:
+          type: object
+          additionalProperties: {}
+        overdue_count:
+          type: integer
+        due_this_week:
+          type: integer
+        high_priority_pending:
+          type: integer
+        completion_rate:
+          type: number
+          format: double
+        overdue_actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/RiskActionList'
+          readOnly: true
+        due_soon_actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/RiskActionList'
+          readOnly: true
+        high_priority_actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/RiskActionList'
+          readOnly: true
+      required:
+      - by_priority
+      - by_status
+      - completion_rate
+      - due_soon_actions
+      - due_this_week
+      - high_priority_actions
+      - high_priority_pending
+      - overdue_actions
+      - overdue_count
+      - total_actions
+    RiskCategory:
+      type: object
+      description: Serializer for Risk Categories.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+        color:
+          type: string
+          description: Hex color code for UI display
+          maxLength: 7
+        risk_count:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - id
+      - name
+      - risk_count
+      - updated_at
+    RiskCategoryRequest:
+      type: object
+      description: Serializer for Risk Categories.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        description:
+          type: string
+        color:
+          type: string
+          minLength: 1
+          description: Hex color code for UI display
+          maxLength: 7
+      required:
+      - name
+    RiskCreateUpdate:
+      type: object
+      description: Serializer for creating and updating risks.
+      properties:
+        title:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+        category:
+          type: integer
+          nullable: true
+        impact:
+          type: integer
+          maximum: 5
+          minimum: 1
+          description: Impact level (1=Very Low, 5=Very High)
+        likelihood:
+          type: integer
+          maximum: 5
+          minimum: 1
+          description: Likelihood level (1=Very Low, 5=Very High)
+        status:
+          $ref: '#/components/schemas/Status7b5Enum'
+        treatment_strategy:
+          oneOf:
+          - $ref: '#/components/schemas/TreatmentStrategyEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        treatment_description:
+          type: string
+          description: Description of the treatment approach
+        risk_owner:
+          type: integer
+          nullable: true
+          description: Person responsible for managing this risk
+        risk_matrix:
+          type: integer
+          nullable: true
+        identified_date:
+          type: string
+          format: date
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        potential_impact_description:
+          type: string
+          description: Detailed description of potential impact
+        current_controls:
+          type: string
+          description: Existing controls or mitigations in place
+      required:
+      - description
+      - impact
+      - likelihood
+      - title
+    RiskCreateUpdateRequest:
+      type: object
+      description: Serializer for creating and updating risks.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+          minLength: 1
+        category:
+          type: integer
+          nullable: true
+        impact:
+          type: integer
+          maximum: 5
+          minimum: 1
+          description: Impact level (1=Very Low, 5=Very High)
+        likelihood:
+          type: integer
+          maximum: 5
+          minimum: 1
+          description: Likelihood level (1=Very Low, 5=Very High)
+        status:
+          $ref: '#/components/schemas/Status7b5Enum'
+        treatment_strategy:
+          oneOf:
+          - $ref: '#/components/schemas/TreatmentStrategyEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        treatment_description:
+          type: string
+          description: Description of the treatment approach
+        risk_owner:
+          type: integer
+          nullable: true
+          description: Person responsible for managing this risk
+        risk_matrix:
+          type: integer
+          nullable: true
+        identified_date:
+          type: string
+          format: date
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        potential_impact_description:
+          type: string
+          description: Detailed description of potential impact
+        current_controls:
+          type: string
+          description: Existing controls or mitigations in place
+      required:
+      - description
+      - impact
+      - likelihood
+      - title
+    RiskDetail:
+      type: object
+      description: Detailed Risk serializer with all fields and related data.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        risk_id:
+          type: string
+          readOnly: true
+          description: Unique risk identifier
+        title:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+        impact:
+          type: integer
+          maximum: 5
+          minimum: 1
+          description: Impact level (1=Very Low, 5=Very High)
+        likelihood:
+          type: integer
+          maximum: 5
+          minimum: 1
+          description: Likelihood level (1=Very Low, 5=Very High)
+        risk_level:
+          allOf:
+          - $ref: '#/components/schemas/RiskLevelEnum'
+          readOnly: true
+          description: |-
+            Calculated risk level
+
+            * `low` - Low
+            * `medium` - Medium
+            * `high` - High
+            * `critical` - Critical
+        risk_level_display:
+          type: string
+          readOnly: true
+        risk_level_color:
+          type: string
+          readOnly: true
+        status:
+          $ref: '#/components/schemas/Status7b5Enum'
+        status_display:
+          type: string
+          readOnly: true
+        status_display_color:
+          type: string
+          readOnly: true
+        treatment_strategy:
+          oneOf:
+          - $ref: '#/components/schemas/TreatmentStrategyEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+        treatment_strategy_display:
+          type: string
+          readOnly: true
+        treatment_description:
+          type: string
+          description: Description of the treatment approach
+        category:
+          allOf:
+          - $ref: '#/components/schemas/RiskCategory'
+          readOnly: true
+        category_name:
+          type: string
+          readOnly: true
+        risk_owner:
+          allOf:
+          - $ref: '#/components/schemas/UserBasic'
+          readOnly: true
+        risk_owner_name:
+          type: string
+          readOnly: true
+        risk_matrix:
+          allOf:
+          - $ref: '#/components/schemas/RiskMatrix'
+          readOnly: true
+        risk_matrix_name:
+          type: string
+          readOnly: true
+        identified_date:
+          type: string
+          format: date
+        last_assessed_date:
+          type: string
+          format: date
+          nullable: true
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        closed_date:
+          type: string
+          format: date
+          readOnly: true
+          nullable: true
+        potential_impact_description:
+          type: string
+          description: Detailed description of potential impact
+        current_controls:
+          type: string
+          description: Existing controls or mitigations in place
+        risk_score:
+          type: integer
+          readOnly: true
+        is_overdue_for_review:
+          type: boolean
+          readOnly: true
+        days_until_review:
+          type: integer
+          readOnly: true
+        is_active:
+          type: boolean
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        created_by:
+          type: integer
+          readOnly: true
+          nullable: true
+        created_by_name:
+          type: string
+          readOnly: true
+        notes:
+          type: array
+          items:
+            $ref: '#/components/schemas/RiskNote'
+          readOnly: true
+      required:
+      - category
+      - category_name
+      - closed_date
+      - created_at
+      - created_by
+      - created_by_name
+      - days_until_review
+      - description
+      - id
+      - impact
+      - is_active
+      - is_overdue_for_review
+      - likelihood
+      - notes
+      - risk_id
+      - risk_level
+      - risk_level_color
+      - risk_level_display
+      - risk_matrix
+      - risk_matrix_name
+      - risk_owner
+      - risk_owner_name
+      - risk_score
+      - status_display
+      - status_display_color
+      - title
+      - treatment_strategy_display
+      - updated_at
+    RiskLevelEnum:
+      enum:
+      - low
+      - medium
+      - high
+      - critical
+      type: string
+      description: |-
+        * `low` - Low
+        * `medium` - Medium
+        * `high` - High
+        * `critical` - Critical
+    RiskList:
+      type: object
+      description: Serializer for Risk list view with essential fields.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        risk_id:
+          type: string
+          readOnly: true
+          description: Unique risk identifier
+        title:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+        impact:
+          type: integer
+          maximum: 5
+          minimum: 1
+          description: Impact level (1=Very Low, 5=Very High)
+        likelihood:
+          type: integer
+          maximum: 5
+          minimum: 1
+          description: Likelihood level (1=Very Low, 5=Very High)
+        risk_level:
+          allOf:
+          - $ref: '#/components/schemas/RiskLevelEnum'
+          readOnly: true
+          description: |-
+            Calculated risk level
+
+            * `low` - Low
+            * `medium` - Medium
+            * `high` - High
+            * `critical` - Critical
+        risk_level_display:
+          type: string
+          readOnly: true
+        risk_level_color:
+          type: string
+          readOnly: true
+        status:
+          $ref: '#/components/schemas/Status7b5Enum'
+        status_display:
+          type: string
+          readOnly: true
+        status_display_color:
+          type: string
+          readOnly: true
+        category:
+          type: integer
+          nullable: true
+        category_name:
+          type: string
+          readOnly: true
+        risk_owner:
+          type: integer
+          nullable: true
+          description: Person responsible for managing this risk
+        risk_owner_name:
+          type: string
+          readOnly: true
+        risk_score:
+          type: integer
+          readOnly: true
+        identified_date:
+          type: string
+          format: date
+        last_assessed_date:
+          type: string
+          format: date
+          nullable: true
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+        is_overdue_for_review:
+          type: boolean
+          readOnly: true
+        days_until_review:
+          type: integer
+          readOnly: true
+        is_active:
+          type: boolean
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - category_name
+      - created_at
+      - days_until_review
+      - description
+      - id
+      - impact
+      - is_active
+      - is_overdue_for_review
+      - likelihood
+      - risk_id
+      - risk_level
+      - risk_level_color
+      - risk_level_display
+      - risk_owner_name
+      - risk_score
+      - status_display
+      - status_display_color
+      - title
+      - updated_at
+    RiskMatrix:
+      type: object
+      description: Serializer for Risk Matrix configurations.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+        is_default:
+          type: boolean
+        impact_levels:
+          type: integer
+          maximum: 7
+          minimum: 3
+        likelihood_levels:
+          type: integer
+          maximum: 7
+          minimum: 3
+        matrix_config:
+          description: Matrix configuration mapping impact x likelihood to risk levels
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        created_by:
+          type: integer
+          readOnly: true
+          nullable: true
+        created_by_name:
+          type: string
+          readOnly: true
+      required:
+      - created_at
+      - created_by
+      - created_by_name
+      - id
+      - name
+      - updated_at
+    RiskMatrixRequest:
+      type: object
+      description: Serializer for Risk Matrix configurations.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        description:
+          type: string
+        is_default:
+          type: boolean
+        impact_levels:
+          type: integer
+          maximum: 7
+          minimum: 3
+        likelihood_levels:
+          type: integer
+          maximum: 7
+          minimum: 3
+        matrix_config:
+          description: Matrix configuration mapping impact x likelihood to risk levels
+      required:
+      - name
+    RiskNote:
+      type: object
+      description: Serializer for Risk Notes.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        note:
+          type: string
+        note_type:
+          $ref: '#/components/schemas/RiskNoteNoteTypeEnum'
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        created_by:
+          type: integer
+          readOnly: true
+          nullable: true
+        created_by_name:
+          type: string
+          readOnly: true
+      required:
+      - created_at
+      - created_by
+      - created_by_name
+      - id
+      - note
+    RiskNoteNoteTypeEnum:
+      enum:
+      - general
+      - assessment
+      - treatment
+      - review
+      - status_change
+      type: string
+      description: |-
+        * `general` - General
+        * `assessment` - Assessment
+        * `treatment` - Treatment
+        * `review` - Review
+        * `status_change` - Status Change
+    RiskStatusUpdateRequest:
+      type: object
+      description: Serializer for updating risk status with optional notes.
+      properties:
+        status:
+          $ref: '#/components/schemas/Status7b5Enum'
+        treatment_strategy:
+          $ref: '#/components/schemas/TreatmentStrategyEnum'
+        treatment_description:
+          type: string
+        note:
+          type: string
+        next_review_date:
+          type: string
+          format: date
+          nullable: true
+      required:
+      - status
+    RiskSummary:
+      type: object
+      description: Serializer for risk summary statistics.
+      properties:
+        total_risks:
+          type: integer
+        active_risks:
+          type: integer
+        overdue_reviews:
+          type: integer
+        by_risk_level:
+          type: object
+          additionalProperties: {}
+        by_status:
+          type: object
+          additionalProperties: {}
+        by_category:
+          type: object
+          additionalProperties: {}
+        by_treatment_strategy:
+          type: object
+          additionalProperties: {}
+        recent_risks:
+          type: array
+          items:
+            $ref: '#/components/schemas/RiskList'
+          readOnly: true
+        high_priority_risks:
+          type: array
+          items:
+            $ref: '#/components/schemas/RiskList'
+          readOnly: true
+        overdue_review_risks:
+          type: array
+          items:
+            $ref: '#/components/schemas/RiskList'
+          readOnly: true
+      required:
+      - active_risks
+      - by_category
+      - by_risk_level
+      - by_status
+      - by_treatment_strategy
+      - high_priority_risks
+      - overdue_review_risks
+      - overdue_reviews
+      - recent_risks
+      - total_risks
+    ScanJob:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        target:
+          type: string
+          format: uuid
+        target_name:
+          type: string
+          readOnly: true
+        target_address:
+          type: string
+          readOnly: true
+        schedule:
+          type: string
+          format: uuid
+          nullable: true
+        scanner:
+          $ref: '#/components/schemas/ScannerEnum'
+        status:
+          $ref: '#/components/schemas/ScanJobStatusEnum'
+        requested_by:
+          type: integer
+          readOnly: true
+          nullable: true
+        started_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        finished_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        error_message:
+          type: string
+          readOnly: true
+        findings_count:
+          type: integer
+          readOnly: true
+        scan_config: {}
+        raw_summary:
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - error_message
+      - findings_count
+      - finished_at
+      - id
+      - raw_summary
+      - requested_by
+      - started_at
+      - target
+      - target_address
+      - target_name
+      - updated_at
+    ScanJobRequest:
+      type: object
+      properties:
+        target:
+          type: string
+          format: uuid
+        schedule:
+          type: string
+          format: uuid
+          nullable: true
+        scanner:
+          $ref: '#/components/schemas/ScannerEnum'
+        status:
+          $ref: '#/components/schemas/ScanJobStatusEnum'
+        scan_config: {}
+      required:
+      - target
+    ScanJobStatusEnum:
+      enum:
+      - queued
+      - running
+      - succeeded
+      - failed
+      - cancelled
+      type: string
+      description: |-
+        * `queued` - Queued
+        * `running` - Running
+        * `succeeded` - Succeeded
+        * `failed` - Failed
+        * `cancelled` - Cancelled
+    ScanSchedule:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        target:
+          type: string
+          format: uuid
+        target_name:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          maxLength: 255
+        frequency:
+          $ref: '#/components/schemas/FrequencyEnum'
+        is_active:
+          type: boolean
+        next_run_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_run_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        created_by:
+          type: integer
+          readOnly: true
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - created_by
+      - id
+      - last_run_at
+      - name
+      - target
+      - target_name
+      - updated_at
+    ScanScheduleRequest:
+      type: object
+      properties:
+        target:
+          type: string
+          format: uuid
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        frequency:
+          $ref: '#/components/schemas/FrequencyEnum'
+        is_active:
+          type: boolean
+        next_run_at:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - name
+      - target
+    ScanTarget:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          maxLength: 255
+        target_type:
+          $ref: '#/components/schemas/TargetTypeEnum'
+        address:
+          type: string
+          maxLength: 500
+        status:
+          $ref: '#/components/schemas/ScanTargetStatusEnum'
+        owner:
+          type: integer
+          nullable: true
+        owner_email:
+          type: string
+          format: email
+          readOnly: true
+        tags: {}
+        metadata: {}
+        created_by:
+          type: integer
+          readOnly: true
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - address
+      - created_at
+      - created_by
+      - id
+      - name
+      - owner_email
+      - updated_at
+    ScanTargetRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        target_type:
+          $ref: '#/components/schemas/TargetTypeEnum'
+        address:
+          type: string
+          minLength: 1
+          maxLength: 500
+        status:
+          $ref: '#/components/schemas/ScanTargetStatusEnum'
+        owner:
+          type: integer
+          nullable: true
+        tags: {}
+        metadata: {}
+      required:
+      - address
+      - name
+    ScanTargetStatusEnum:
+      enum:
+      - pending_approval
+      - approved
+      - disabled
+      type: string
+      description: |-
+        * `pending_approval` - Pending approval
+        * `approved` - Approved
+        * `disabled` - Disabled
+    ScannerEnum:
+      enum:
+      - nuclei
+      type: string
+      description: '* `nuclei` - Nuclei'
+    SecurityAwarenessCampaignDetail:
+      type: object
+      description: Serializer for campaign detail view.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+        subject_line:
+          type: string
+          maxLength: 200
+        email_content:
+          type: string
+          description: HTML content for the email. Use {{user.first_name}} for personalization.
+        is_active:
+          type: boolean
+        send_frequency:
+          $ref: '#/components/schemas/SendFrequencyEnum'
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        next_send_date:
+          type: string
+          format: date-time
+        send_to_all_users:
+          type: boolean
+          description: If False, only send to specific users or groups
+        target_users:
+          type: array
+          items:
+            type: integer
+          description: Specific users to receive this campaign (if not sending to
+            all)
+        created_by:
+          type: integer
+          readOnly: true
+        created_by_details:
+          type: string
+          readOnly: true
+        target_users_details:
+          type: string
+          readOnly: true
+        total_sent:
+          type: integer
+          readOnly: true
+        total_opened:
+          type: integer
+          readOnly: true
+        total_clicked:
+          type: integer
+          readOnly: true
+        open_rate:
+          type: string
+          readOnly: true
+        click_rate:
+          type: string
+          readOnly: true
+        recent_deliveries:
+          type: string
+          readOnly: true
+        analytics:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - analytics
+      - click_rate
+      - created_at
+      - created_by
+      - created_by_details
+      - email_content
+      - id
+      - name
+      - next_send_date
+      - open_rate
+      - recent_deliveries
+      - start_date
+      - subject_line
+      - target_users_details
+      - total_clicked
+      - total_opened
+      - total_sent
+      - updated_at
+    SecurityAwarenessCampaignDetailRequest:
+      type: object
+      description: Serializer for campaign detail view.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+        subject_line:
+          type: string
+          minLength: 1
+          maxLength: 200
+        email_content:
+          type: string
+          minLength: 1
+          description: HTML content for the email. Use {{user.first_name}} for personalization.
+        is_active:
+          type: boolean
+        send_frequency:
+          $ref: '#/components/schemas/SendFrequencyEnum'
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        next_send_date:
+          type: string
+          format: date-time
+        send_to_all_users:
+          type: boolean
+          description: If False, only send to specific users or groups
+        target_users:
+          type: array
+          items:
+            type: integer
+          description: Specific users to receive this campaign (if not sending to
+            all)
+      required:
+      - email_content
+      - name
+      - next_send_date
+      - start_date
+      - subject_line
+    SecurityAwarenessCampaignList:
+      type: object
+      description: Serializer for campaign list view.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+        subject_line:
+          type: string
+          maxLength: 200
+        is_active:
+          type: boolean
+        send_frequency:
+          $ref: '#/components/schemas/SendFrequencyEnum'
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        next_send_date:
+          type: string
+          format: date-time
+        send_to_all_users:
+          type: boolean
+          description: If False, only send to specific users or groups
+        target_users_count:
+          type: string
+          readOnly: true
+        created_by_name:
+          type: string
+          readOnly: true
+        total_sent:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        total_opened:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        total_clicked:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        open_rate:
+          type: string
+          readOnly: true
+        click_rate:
+          type: string
+          readOnly: true
+        status:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - click_rate
+      - created_at
+      - created_by_name
+      - id
+      - name
+      - next_send_date
+      - open_rate
+      - start_date
+      - status
+      - subject_line
+      - target_users_count
+      - updated_at
+    SendFrequencyEnum:
+      enum:
+      - weekly
+      - biweekly
+      - monthly
+      - quarterly
+      type: string
+      description: |-
+        * `weekly` - Weekly
+        * `biweekly` - Bi-weekly
+        * `monthly` - Monthly
+        * `quarterly` - Quarterly
+    Status019Enum:
+      enum:
+      - draft
+      - under_review
+      - approved
+      - archived
+      type: string
+      description: |-
+        * `draft` - Draft
+        * `under_review` - Under Review
+        * `approved` - Approved
+        * `archived` - Archived
+    Status1bdEnum:
       enum:
       - pending
       - approved
@@ -6867,7 +19968,63 @@ components:
         * `rejected` - Rejected
         * `applied` - Applied
         * `expired` - Expired
-    Status9ffEnum:
+    Status399Enum:
+      enum:
+      - draft
+      - published
+      - archived
+      type: string
+      description: |-
+        * `draft` - Draft
+        * `published` - Published
+        * `archived` - Archived
+    Status4daEnum:
+      enum:
+      - draft
+      - active
+      - deprecated
+      - archived
+      type: string
+      description: |-
+        * `draft` - Draft
+        * `active` - Active
+        * `deprecated` - Deprecated
+        * `archived` - Archived
+    Status7b5Enum:
+      enum:
+      - identified
+      - assessed
+      - treatment_planned
+      - treatment_in_progress
+      - mitigated
+      - accepted
+      - transferred
+      - closed
+      type: string
+      description: |-
+        * `identified` - Identified
+        * `assessed` - Assessed
+        * `treatment_planned` - Treatment Planned
+        * `treatment_in_progress` - Treatment in Progress
+        * `mitigated` - Mitigated
+        * `accepted` - Accepted
+        * `transferred` - Transferred
+        * `closed` - Closed
+    Status833Enum:
+      enum:
+      - pending
+      - in_progress
+      - completed
+      - cancelled
+      - deferred
+      type: string
+      description: |-
+        * `pending` - Pending
+        * `in_progress` - In Progress
+        * `completed` - Completed
+        * `cancelled` - Cancelled
+        * `deferred` - Deferred
+    Status98bEnum:
       enum:
       - planned
       - in_progress
@@ -6887,18 +20044,18 @@ components:
         * `remediation` - Needs Remediation
         * `disabled` - Disabled
         * `retired` - Retired
-    StatusB25Enum:
+    StatusA39Enum:
       enum:
-      - draft
-      - active
-      - deprecated
-      - archived
+      - pending
+      - processing
+      - completed
+      - failed
       type: string
       description: |-
-        * `draft` - Draft
-        * `active` - Active
-        * `deprecated` - Deprecated
-        * `archived` - Archived
+        * `pending` - Pending Generation
+        * `processing` - Processing
+        * `completed` - Completed
+        * `failed` - Failed
     StatusEnum:
       enum:
       - not_started
@@ -6938,6 +20095,21 @@ components:
         is_active:
           type: boolean
           readOnly: true
+        is_trial_active:
+          type: boolean
+          readOnly: true
+        enabled_modules:
+          description: Explicit module grants for this subscription
+        enabled_module_keys:
+          type: string
+          readOnly: true
+        trial_module:
+          type: string
+          description: Single module selected for a trial subscription
+          maxLength: 40
+        module_catalog:
+          type: string
+          readOnly: true
         current_period_start:
           type: string
           format: date-time
@@ -6971,8 +20143,11 @@ components:
       required:
       - created_at
       - effective_price
+      - enabled_module_keys
       - id
       - is_active
+      - is_trial_active
+      - module_catalog
       - plan
       - updated_at
     SubscriptionStatusEnum:
@@ -6991,6 +20166,574 @@ components:
         * `unpaid` - Unpaid
         * `trialing` - Trialing
         * `incomplete` - Incomplete
+    TargetTypeEnum:
+      enum:
+      - web
+      - host
+      - api
+      type: string
+      description: |-
+        * `web` - Web application
+        * `host` - Host
+        * `api` - API endpoint
+    TemplateDocument:
+      type: object
+      description: Serializer for imported template and sample documents.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          maxLength: 255
+        module:
+          $ref: '#/components/schemas/ModuleEnum'
+        document_type:
+          $ref: '#/components/schemas/DocumentTypeEnum'
+        document_code:
+          type: string
+          maxLength: 80
+        version:
+          type: string
+          maxLength: 50
+        document:
+          type: integer
+        document_url:
+          type: string
+          readOnly: true
+        document_name:
+          type: string
+          readOnly: true
+        document_size:
+          type: integer
+          readOnly: true
+        framework:
+          type: integer
+          nullable: true
+        framework_name:
+          type: string
+          readOnly: true
+        framework_version:
+          type: string
+          readOnly: true
+        clause:
+          type: integer
+          nullable: true
+        clause_identifier:
+          type: string
+          readOnly: true
+        control:
+          type: integer
+          nullable: true
+        control_identifier:
+          type: string
+          readOnly: true
+        source_path:
+          type: string
+          maxLength: 500
+        source_filename:
+          type: string
+          maxLength: 255
+        source_checksum:
+          type: string
+          maxLength: 64
+        source_modified_at:
+          type: string
+          format: date-time
+          nullable: true
+        metadata: {}
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - clause_identifier
+      - control_identifier
+      - created_at
+      - document
+      - document_name
+      - document_size
+      - document_type
+      - document_url
+      - framework_name
+      - framework_version
+      - id
+      - module
+      - source_checksum
+      - source_filename
+      - source_path
+      - title
+      - updated_at
+    TemplateDocumentRequest:
+      type: object
+      description: Serializer for imported template and sample documents.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        module:
+          $ref: '#/components/schemas/ModuleEnum'
+        document_type:
+          $ref: '#/components/schemas/DocumentTypeEnum'
+        document_code:
+          type: string
+          maxLength: 80
+        version:
+          type: string
+          maxLength: 50
+        document:
+          type: integer
+        framework:
+          type: integer
+          nullable: true
+        clause:
+          type: integer
+          nullable: true
+        control:
+          type: integer
+          nullable: true
+        source_path:
+          type: string
+          minLength: 1
+          maxLength: 500
+        source_filename:
+          type: string
+          minLength: 1
+          maxLength: 255
+        source_checksum:
+          type: string
+          minLength: 1
+          maxLength: 64
+        source_modified_at:
+          type: string
+          format: date-time
+          nullable: true
+        metadata: {}
+      required:
+      - document
+      - document_type
+      - module
+      - source_checksum
+      - source_filename
+      - source_path
+      - title
+    TemplateDocumentSummary:
+      type: object
+      description: Compact template document serializer for linked catalogue objects.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          maxLength: 255
+        module:
+          $ref: '#/components/schemas/ModuleEnum'
+        document_type:
+          $ref: '#/components/schemas/DocumentTypeEnum'
+        document_code:
+          type: string
+          maxLength: 80
+        version:
+          type: string
+          maxLength: 50
+        document_url:
+          type: string
+          readOnly: true
+        document_name:
+          type: string
+          readOnly: true
+        framework_name:
+          type: string
+          readOnly: true
+        clause_identifier:
+          type: string
+          readOnly: true
+        control_identifier:
+          type: string
+          readOnly: true
+      required:
+      - clause_identifier
+      - control_identifier
+      - document_name
+      - document_type
+      - document_url
+      - framework_name
+      - id
+      - module
+      - title
+    TemplateDocumentSummaryRequest:
+      type: object
+      description: Compact template document serializer for linked catalogue objects.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        module:
+          $ref: '#/components/schemas/ModuleEnum'
+        document_type:
+          $ref: '#/components/schemas/DocumentTypeEnum'
+        document_code:
+          type: string
+          maxLength: 80
+        version:
+          type: string
+          maxLength: 50
+      required:
+      - document_type
+      - module
+      - title
+    TenantDataExport:
+      type: object
+      description: Serializer for tenant data export jobs.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          maxLength: 200
+        export_format:
+          $ref: '#/components/schemas/ExportFormatEnum'
+        selected_modules: {}
+        requested_by:
+          type: integer
+          readOnly: true
+        requested_by_name:
+          type: string
+          readOnly: true
+        requested_at:
+          type: string
+          format: date-time
+          readOnly: true
+        status:
+          allOf:
+          - $ref: '#/components/schemas/StatusA39Enum'
+          readOnly: true
+        generated_file:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: Generated spreadsheet or CSV archive
+        generated_file_details:
+          allOf:
+          - $ref: '#/components/schemas/Document'
+          readOnly: true
+        download_url:
+          type: string
+          readOnly: true
+        generation_started_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        generation_completed_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        error_message:
+          type: string
+          readOnly: true
+        record_counts:
+          readOnly: true
+        coverage_manifest:
+          readOnly: true
+      required:
+      - coverage_manifest
+      - download_url
+      - error_message
+      - generated_file
+      - generated_file_details
+      - generation_completed_at
+      - generation_started_at
+      - id
+      - record_counts
+      - requested_at
+      - requested_by
+      - requested_by_name
+      - status
+    TenantDataExportCreate:
+      type: object
+      description: Serializer for creating tenant data exports.
+      properties:
+        title:
+          type: string
+          maxLength: 200
+        export_format:
+          $ref: '#/components/schemas/ExportFormatEnum'
+        selected_modules: {}
+    TenantDataExportCreateRequest:
+      type: object
+      description: Serializer for creating tenant data exports.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+        export_format:
+          $ref: '#/components/schemas/ExportFormatEnum'
+        selected_modules: {}
+    TenantDataExportRequest:
+      type: object
+      description: Serializer for tenant data export jobs.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+        export_format:
+          $ref: '#/components/schemas/ExportFormatEnum'
+        selected_modules: {}
+    TrainingCategory:
+      type: object
+      description: Serializer for training categories.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+        color:
+          type: string
+          description: Hex color code for category display
+          maxLength: 7
+        is_active:
+          type: boolean
+        videos_count:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - id
+      - name
+      - updated_at
+      - videos_count
+    TrainingCategoryRequest:
+      type: object
+      description: Serializer for training categories.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        description:
+          type: string
+        color:
+          type: string
+          minLength: 1
+          description: Hex color code for category display
+          maxLength: 7
+        is_active:
+          type: boolean
+      required:
+      - name
+    TrainingVideoDetail:
+      type: object
+      description: Serializer for training video detail view.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        title:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+        category:
+          type: string
+          format: uuid
+        category_details:
+          allOf:
+          - $ref: '#/components/schemas/TrainingCategory'
+          readOnly: true
+        video_provider:
+          $ref: '#/components/schemas/VideoProviderEnum'
+        video_url:
+          type: string
+          format: uri
+          description: Full URL to the video or embed URL
+          maxLength: 200
+        video_id:
+          type: string
+          description: Provider-specific video ID
+          maxLength: 100
+        embed_url:
+          type: string
+          readOnly: true
+        duration_minutes:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+          description: Video duration in minutes
+        difficulty_level:
+          $ref: '#/components/schemas/DifficultyLevelEnum'
+        is_published:
+          type: boolean
+        published_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        created_by:
+          type: integer
+          readOnly: true
+        created_by_details:
+          type: string
+          readOnly: true
+        view_count:
+          type: integer
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - category
+      - category_details
+      - created_at
+      - created_by
+      - created_by_details
+      - embed_url
+      - id
+      - published_at
+      - title
+      - updated_at
+      - video_url
+      - view_count
+    TrainingVideoDetailRequest:
+      type: object
+      description: Serializer for training video detail view.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+        category:
+          type: string
+          format: uuid
+        video_provider:
+          $ref: '#/components/schemas/VideoProviderEnum'
+        video_url:
+          type: string
+          format: uri
+          minLength: 1
+          description: Full URL to the video or embed URL
+          maxLength: 200
+        video_id:
+          type: string
+          description: Provider-specific video ID
+          maxLength: 100
+        duration_minutes:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+          description: Video duration in minutes
+        difficulty_level:
+          $ref: '#/components/schemas/DifficultyLevelEnum'
+        is_published:
+          type: boolean
+      required:
+      - category
+      - title
+      - video_url
+    TrainingVideoList:
+      type: object
+      description: Serializer for training video list view.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        title:
+          type: string
+          maxLength: 200
+        description:
+          type: string
+        category_name:
+          type: string
+          readOnly: true
+        category_color:
+          type: string
+          readOnly: true
+        video_provider:
+          $ref: '#/components/schemas/VideoProviderEnum'
+        duration_minutes:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          nullable: true
+          description: Video duration in minutes
+        difficulty_level:
+          $ref: '#/components/schemas/DifficultyLevelEnum'
+        is_published:
+          type: boolean
+        published_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_by_name:
+          type: string
+          readOnly: true
+        view_count:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - category_color
+      - category_name
+      - created_at
+      - created_by_name
+      - id
+      - title
+      - updated_at
+    TreatmentStrategyEnum:
+      enum:
+      - mitigate
+      - accept
+      - transfer
+      - avoid
+      type: string
+      description: |-
+        * `mitigate` - Mitigate
+        * `accept` - Accept
+        * `transfer` - Transfer
+        * `avoid` - Avoid
     UrgencyEnum:
       enum:
       - low
@@ -6999,10 +20742,43 @@ components:
       - critical
       type: string
       description: |-
-        * `low` - Low
-        * `medium` - Medium
-        * `high` - High
-        * `critical` - Critical
+        * `low` - Low - Standard Review
+        * `medium` - Medium - 24 Hour Review
+        * `high` - High - Same Day Review
+        * `critical` - Critical - Immediate Review
+    UserBasic:
+      type: object
+      description: Basic user serializer for risk ownership.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        username:
+          type: string
+          readOnly: true
+          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+            only.
+        email:
+          type: string
+          format: email
+          readOnly: true
+          title: Email address
+        first_name:
+          type: string
+          readOnly: true
+        last_name:
+          type: string
+          readOnly: true
+        full_name:
+          type: string
+          readOnly: true
+      required:
+      - email
+      - first_name
+      - full_name
+      - id
+      - last_name
+      - username
     UserProfile:
       type: object
       properties:
@@ -7046,6 +20822,219 @@ components:
       required:
       - otp_code
       - username
+    VideoProviderEnum:
+      enum:
+      - synthesia
+      - youtube
+      - vimeo
+      - custom
+      type: string
+      description: |-
+        * `synthesia` - Synthesia.io
+        * `youtube` - YouTube
+        * `vimeo` - Vimeo
+        * `custom` - Custom URL
+    VideoView:
+      type: object
+      description: Serializer for video view tracking.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        video:
+          type: string
+          format: uuid
+        video_title:
+          type: string
+          readOnly: true
+        user:
+          type: integer
+        user_email:
+          type: string
+          readOnly: true
+        started_at:
+          type: string
+          format: date-time
+          readOnly: true
+        duration_watched:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: Duration watched in seconds
+        completed:
+          type: boolean
+          description: Whether the user watched the full video
+        completion_percentage:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+          description: Percentage of video watched
+      required:
+      - id
+      - started_at
+      - user
+      - user_email
+      - video
+      - video_title
+    VulnerabilityFinding:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        target:
+          type: string
+          format: uuid
+        target_name:
+          type: string
+          readOnly: true
+        job:
+          type: string
+          format: uuid
+        fingerprint:
+          type: string
+          readOnly: true
+        scanner_name:
+          type: string
+          readOnly: true
+        scanner_finding_id:
+          type: string
+          readOnly: true
+        template_id:
+          type: string
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+        severity:
+          allOf:
+          - $ref: '#/components/schemas/VulnerabilityFindingSeverityEnum'
+          readOnly: true
+        description:
+          type: string
+          readOnly: true
+        remediation:
+          type: string
+          readOnly: true
+        matched_at:
+          type: string
+          readOnly: true
+        cve:
+          type: string
+          readOnly: true
+        cvss_score:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,3}(?:\.\d{0,1})?$
+          readOnly: true
+          nullable: true
+        evidence:
+          readOnly: true
+        status:
+          $ref: '#/components/schemas/VulnerabilityFindingStatusEnum'
+        risk:
+          type: integer
+          readOnly: true
+          nullable: true
+        risk_id:
+          type: string
+          readOnly: true
+        risk_action:
+          type: integer
+          readOnly: true
+          nullable: true
+        risk_action_id:
+          type: string
+          readOnly: true
+        first_seen_at:
+          type: string
+          format: date-time
+          readOnly: true
+        last_seen_at:
+          type: string
+          format: date-time
+          readOnly: true
+        resolved_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - cve
+      - cvss_score
+      - description
+      - evidence
+      - fingerprint
+      - first_seen_at
+      - id
+      - job
+      - last_seen_at
+      - matched_at
+      - remediation
+      - resolved_at
+      - risk
+      - risk_action
+      - risk_action_id
+      - risk_id
+      - scanner_finding_id
+      - scanner_name
+      - severity
+      - target
+      - target_name
+      - template_id
+      - title
+      - updated_at
+    VulnerabilityFindingRequest:
+      type: object
+      properties:
+        target:
+          type: string
+          format: uuid
+        job:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/VulnerabilityFindingStatusEnum'
+      required:
+      - job
+      - target
+    VulnerabilityFindingSeverityEnum:
+      enum:
+      - critical
+      - high
+      - medium
+      - low
+      - info
+      type: string
+      description: |-
+        * `critical` - Critical
+        * `high` - High
+        * `medium` - Medium
+        * `low` - Low
+        * `info` - Info
+    VulnerabilityFindingStatusEnum:
+      enum:
+      - open
+      - accepted_risk
+      - remediated
+      - false_positive
+      type: string
+      description: |-
+        * `open` - Open
+        * `accepted_risk` - Accepted risk
+        * `remediated` - Remediated
+        * `false_positive` - False positive
   securitySchemes:
     SessionAuth:
       type: apiKey


### PR DESCRIPTION
Closes #155\n\n## Summary\n- refresh the committed app/schema.yml from the current drf-spectacular output\n- add an OpenAPI schema freshness check to backend CI\n- baseline current drf-spectacular diagnostics so new warnings/errors fail CI while future cleanup can lower the ceiling\n\n## Notes\n- The schema check compares parsed YAML objects rather than raw bytes because drf-spectacular can reorder HTTP methods between runs without changing the contract.\n- Current diagnostics are explicitly capped at 191 warnings and 167 errors. This PR stops the count from growing but does not claim the schema is fully clean.\n\n## Verification\n- bash .github/scripts/check-openapi-schema.sh\n- python manage.py check\n- bash -n .github/scripts/check-openapi-schema.sh\n- git diff --check