### PR TITLE
test: add authenticated frontend e2e flow

### DIFF
--- a/frontend/e2e/authenticated-risk.smoke.spec.ts
+++ b/frontend/e2e/authenticated-risk.smoke.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+import { mockAuthenticatedGrcApi } from "./helpers/api";
+
+test("authenticated users can open the risk register with tenant-scoped API requests", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+
+  let riskRequestHeaders: Record<string, string> | null = null;
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/api/risk/risks/") {
+      riskRequestHeaders = request.headers();
+    }
+  });
+
+  await page.goto("/login?tenant=demo");
+  await page.getByLabel("Email").fill("user@example.com");
+  await page.getByLabel("Password").fill("E2ePassw0rd!");
+  await page.getByRole("button", { name: "Login" }).click();
+
+  await expect(page).toHaveURL(/\/$/);
+
+  await page.goto("/risk?tenant=demo");
+
+  await expect(page.getByRole("heading", { name: "Risk Management" })).toBeVisible();
+  await expect(page.getByText("Active Risk Register")).toBeVisible();
+  await expect(page.getByRole("cell", { name: "Supplier access review overdue" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "Ada Lovelace" })).toBeVisible();
+
+  expect(riskRequestHeaders).toMatchObject({
+    authorization: "Bearer test-access-token",
+    "x-tenancy-mode": "header",
+    "x-tenant-id": "demo",
+  });
+});

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -1,0 +1,146 @@
+import type { Page, Route } from "@playwright/test";
+
+const risk = {
+  id: 1,
+  risk_id: "RISK-001",
+  title: "Supplier access review overdue",
+  description: "Privileged supplier access has not been reviewed this quarter.",
+  category: {
+    id: 1,
+    name: "Vendor Risk",
+    description: "Third-party risk",
+    color: "#E5484D",
+  },
+  impact: 4,
+  likelihood: 3,
+  risk_level: "high",
+  status: "identified",
+  risk_owner: {
+    id: 1,
+    username: "owner",
+    first_name: "Ada",
+    last_name: "Lovelace",
+    email: "ada@example.com",
+  },
+  identified_date: "2026-07-01",
+  next_review_date: "2026-07-31",
+  risk_matrix: null,
+  created_at: "2026-07-01T09:00:00Z",
+  updated_at: "2026-07-01T09:00:00Z",
+  created_by: {
+    id: 1,
+    username: "admin",
+    first_name: "Grace",
+    last_name: "Hopper",
+  },
+  risk_score: 12,
+  is_overdue_for_review: false,
+  days_until_review: 14,
+  is_active: true,
+};
+
+const analytics = {
+  totalRisks: 1,
+  highRiskItems: 1,
+  overdueActions: 0,
+  avgRiskScore: 12,
+  riskTrend: -1,
+};
+
+const executiveDashboard = {
+  summary_metrics: {
+    total_risks: { title: "Total Risks", value: 1 },
+    high_priority_risks: { title: "High Priority", value: 1 },
+    policy_compliance: { title: "Policy Compliance", value: 91, format: "percentage" },
+    training_completion: { title: "Training Completion", value: 88, format: "percentage" },
+    vendor_assessments: { title: "Vendor Assessments", value: 3 },
+  },
+  risk_trend_chart: { labels: [], datasets: [] },
+  compliance_by_category: { labels: [], datasets: [] },
+  recent_activities: [],
+};
+
+async function fulfilJson(route: Route, body: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function mockAuthenticatedGrcApi(page: Page) {
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (path === "/api/auth/login/" && request.method() === "POST") {
+      await fulfilJson(route, { access: "test-access-token" });
+      return;
+    }
+
+    if (path === "/api/auth/refresh/" && request.method() === "POST") {
+      await fulfilJson(route, { access: "test-access-token" });
+      return;
+    }
+
+    if (path === "/api/billing/current_subscription/" && request.method() === "GET") {
+      await fulfilJson(route, {
+        enabled_module_keys: [
+          "frameworks",
+          "risk",
+          "assets",
+          "vendors",
+          "policies",
+          "training",
+          "analytics",
+          "vulnerability_scanning",
+        ],
+        trial_module: "",
+        module_catalog: [],
+      });
+      return;
+    }
+
+    if (path === "/api/risk/risks/" && request.method() === "GET") {
+      await fulfilJson(route, {
+        results: [risk],
+        count: 1,
+        next: null,
+        previous: null,
+      });
+      return;
+    }
+
+    if (path === "/api/risk/analytics/dashboard/" && request.method() === "GET") {
+      await fulfilJson(route, analytics);
+      return;
+    }
+
+    if (path === "/api/risk/categories/" && request.method() === "GET") {
+      await fulfilJson(route, {
+        results: [risk.category],
+        count: 1,
+        next: null,
+        previous: null,
+      });
+      return;
+    }
+
+    if (path === "/api/risk/choices/" && request.method() === "GET") {
+      await fulfilJson(route, {
+        risk_levels: [{ value: "high", label: "High" }],
+        status_choices: [{ value: "identified", label: "Identified" }],
+        treatment_strategies: [{ value: "mitigate", label: "Mitigate" }],
+      });
+      return;
+    }
+
+    if (path === "/api/analytics/executive/" && request.method() === "GET") {
+      await fulfilJson(route, executiveDashboard);
+      return;
+    }
+
+    await fulfilJson(route, { detail: `Unhandled test route: ${path}` }, 404);
+  });
+}

--- a/frontend/src/components/AuthWrapper.test.tsx
+++ b/frontend/src/components/AuthWrapper.test.tsx
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import AuthWrapper from "./AuthWrapper";
 
 const pushMock = vi.fn();
+const refreshMock = vi.fn();
+const setAccessTokenMock = vi.fn();
 let pathname = "/";
 let accessToken: string | null = null;
 
@@ -13,6 +15,8 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/lib/auth", () => ({
   getAccessToken: () => accessToken,
+  refresh: () => refreshMock(),
+  setAccessToken: (token: string | null) => setAccessTokenMock(token),
 }));
 
 describe("AuthWrapper", () => {
@@ -20,9 +24,29 @@ describe("AuthWrapper", () => {
     accessToken = null;
     pathname = "/";
     pushMock.mockClear();
+    refreshMock.mockReset();
+    setAccessTokenMock.mockClear();
   });
 
-  it("redirects unauthenticated users away from protected pages", async () => {
+  it("refreshes the access token before rendering protected pages", async () => {
+    refreshMock.mockResolvedValue("refreshed-access");
+
+    render(
+      <AuthWrapper>
+        <main>Protected content</main>
+      </AuthWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(setAccessTokenMock).toHaveBeenCalledWith("refreshed-access");
+    });
+    expect(await screen.findByText("Protected content")).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects unauthenticated users away from protected pages when refresh fails", async () => {
+    refreshMock.mockRejectedValue(new Error("Refresh failed"));
+
     render(
       <AuthWrapper>
         <main>Protected content</main>

--- a/frontend/src/components/AuthWrapper.tsx
+++ b/frontend/src/components/AuthWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
-import { getAccessToken } from '@/lib/auth';
+import { getAccessToken, refresh, setAccessToken } from '@/lib/auth';
 import { Spin } from 'antd';
 
 interface AuthWrapperProps {
@@ -18,21 +18,37 @@ export default function AuthWrapper({ children }: AuthWrapperProps) {
   const isPublicPage = publicPages.some(page => pathname.startsWith(page));
 
   useEffect(() => {
+    let cancelled = false;
     const token = getAccessToken();
 
     if (!token && !isPublicPage) {
-      // No token and not on a public page - redirect to login
-      router.push('/login');
-      return;
+      refresh()
+        .then((newToken) => {
+          if (cancelled) return;
+          setAccessToken(newToken);
+          setIsAuthenticated(true);
+        })
+        .catch(() => {
+          if (cancelled) return;
+          router.push('/login');
+        });
+      return () => {
+        cancelled = true;
+      };
     }
 
     if (token && isPublicPage) {
       // Has token but on login page - redirect to dashboard
       router.push('/');
-      return;
+      return () => {
+        cancelled = true;
+      };
     }
 
     setIsAuthenticated(!!token);
+    return () => {
+      cancelled = true;
+    };
   }, [pathname, isPublicPage, router]);
 
   // Show loading spinner while checking authentication

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from "axios";
 import { getAccessToken, setAccessToken, refresh } from "./auth";
+import { getApiBaseUrl } from "./config";
 import { getTenantFromHost } from "./tenant";
 
 // Define API error interface for Django backend
@@ -26,7 +27,7 @@ export class APIException extends Error {
 }
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE,
+  baseURL: getApiBaseUrl(),
   withCredentials: true, // allow refresh cookie
 });
 
@@ -34,7 +35,10 @@ api.interceptors.request.use((config) => {
   const token = getAccessToken();
   const tenant = getTenantFromHost();
   if (token) config.headers.Authorization = `Bearer ${token}`;
-  if (tenant) config.headers["X-Tenant-Id"] = tenant;
+  if (tenant) {
+    config.headers["X-Tenancy-Mode"] = "header";
+    config.headers["X-Tenant-Id"] = tenant;
+  }
   return config;
 });
 

--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -4,6 +4,7 @@ import { getAccessToken, login, logout, refresh, setAccessToken } from "./auth";
 describe("auth helpers", () => {
   afterEach(() => {
     setAccessToken(null);
+    window.history.replaceState({}, "", "http://localhost:3000/");
     vi.unstubAllGlobals();
   });
 
@@ -18,6 +19,7 @@ describe("auth helpers", () => {
   });
 
   it("logs in with credentials included and stores the returned access token", async () => {
+    window.history.replaceState({}, "", "http://localhost:3000/login?tenant=demo");
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ access: "new-access" }),
@@ -29,7 +31,7 @@ describe("auth helpers", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "undefined/auth/login/",
+      "/api/auth/login/",
       expect.objectContaining({
         body: JSON.stringify({
           username: "alice@example.com",
@@ -37,6 +39,11 @@ describe("auth helpers", () => {
           otp: "123456",
         }),
         credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Tenancy-Mode": "header",
+          "X-Tenant-Id": "demo",
+        },
         method: "POST",
       }),
     );
@@ -53,7 +60,7 @@ describe("auth helpers", () => {
     await expect(refresh()).resolves.toBe("refreshed-access");
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "undefined/auth/refresh/",
+      "/api/auth/refresh/",
       expect.objectContaining({
         credentials: "include",
         method: "POST",
@@ -69,7 +76,7 @@ describe("auth helpers", () => {
     await logout();
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "undefined/auth/logout/",
+      "/api/auth/logout/",
       expect.objectContaining({
         credentials: "include",
         method: "POST",

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,16 +1,26 @@
+import { getApiBaseUrl } from "./config";
+import { getTenantFromHost } from "./tenant";
+
 let accessToken: string | null = null;
 
 export function setAccessToken(t: string | null) { accessToken = t; }
 export function getAccessToken() { return accessToken; }
 
 export async function login(email: string, password: string, otp?: string) {
-  const r = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/login/`, {
+  const tenant = getTenantFromHost();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (tenant) {
+    headers["X-Tenancy-Mode"] = "header";
+    headers["X-Tenant-Id"] = tenant;
+  }
+
+  const r = await fetch(`${getApiBaseUrl()}/auth/login/`, {
     method: "POST",
     credentials: "include", // set refresh cookie on server
-    headers: { 
-      "Content-Type": "application/json",
-      "Host": "demo.localhost"  // Add tenant header
-    },
+    headers,
     body: JSON.stringify({ 
       username: email,  // Django expects username field
       password, 
@@ -24,7 +34,7 @@ export async function login(email: string, password: string, otp?: string) {
 }
 
 export async function refresh(): Promise<string> {
-  const r = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/refresh/`, {
+  const r = await fetch(`${getApiBaseUrl()}/auth/refresh/`, {
     method: "POST",
     credentials: "include",
   });
@@ -34,7 +44,7 @@ export async function refresh(): Promise<string> {
 }
 
 export async function logout() {
-  await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/logout/`, {
+  await fetch(`${getApiBaseUrl()}/auth/logout/`, {
     method: "POST", credentials: "include"
   });
   setAccessToken(null);

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,0 +1,3 @@
+export function getApiBaseUrl() {
+  return process.env.NEXT_PUBLIC_API_BASE || "/api";
+}

--- a/frontend/src/lib/tenant.test.ts
+++ b/frontend/src/lib/tenant.test.ts
@@ -13,6 +13,14 @@ describe("getTenantFromHost", () => {
     expect(getTenantFromHost()).toBe("demo");
   });
 
+  it("does not treat loopback IP address segments as tenant subdomains", () => {
+    window.history.replaceState({}, "", "http://localhost:3000/?tenant=demo");
+
+    expect(getTenantFromHost("127.0.0.1:3000")).toBe("demo");
+    window.history.replaceState({}, "", "http://localhost:3000/");
+    expect(getTenantFromHost("127.0.0.1:3000")).toBeNull();
+  });
+
   it("returns null when no tenant signal exists", () => {
     window.history.replaceState({}, "", "http://localhost:3000/");
 

--- a/frontend/src/lib/tenant.ts
+++ b/frontend/src/lib/tenant.ts
@@ -1,6 +1,14 @@
 export function getTenantFromHost(host?: string) {
   const h = (host || (typeof window !== "undefined" ? window.location.host : "")).split(":")[0];
   const parts = h.split(".");
+  const isIpv4Address = parts.length === 4 && parts.every(part => /^\d+$/.test(part));
+  if (isIpv4Address) {
+    if (typeof window !== "undefined") {
+      const t = new URLSearchParams(window.location.search).get("tenant");
+      if (t) return t;
+    }
+    return null;
+  }
   if (parts.length === 2 && parts[1] === "localhost") return parts[0];
   if (parts.length >= 3) return parts[0];
   if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- add a Playwright authenticated smoke test for login through to the risk register using mocked backend API responses
- exercise bearer-token and tenant-header propagation on protected API calls
- refresh access tokens from the HttpOnly refresh-cookie path before redirecting protected page reloads
- default the frontend API base to /api and stop constructing undefined/... request URLs
- send X-Tenancy-Mode: header with X-Tenant-Id so the backend actually honours header-based tenant selection
- fix loopback IP tenant parsing so 127.0.0.1 is not treated as tenant 127

Part of #81.

## Verification
- npm run test
- npm run type-check
- npm run lint (existing warnings only)
- npm run build
- npm run test:e2e
- npm audit --audit-level high
- git diff --check