### PR TITLE
test: cover critical frontend GRC flows

### DIFF
--- a/frontend/e2e/critical-grc-flows.smoke.spec.ts
+++ b/frontend/e2e/critical-grc-flows.smoke.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mockAuthenticatedGrcApi } from "./helpers/api";
+
+async function signIn(page: Page) {
+  await page.goto("/login?tenant=demo");
+  await page.getByLabel("Email").fill("user@example.com");
+  await page.getByLabel("Password").fill("E2ePassw0rd!");
+  await page.getByRole("button", { name: "Login" }).click();
+  await expect(page).toHaveURL(/\/$/);
+}
+
+async function chooseSelectOption(page: Page, fieldId: string, option: string) {
+  await page.locator(`#${fieldId}`).click({ force: true });
+  await page.getByTitle(option).click({ force: true });
+}
+
+test("users can acknowledge assigned policies", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+  await signIn(page);
+
+  let acknowledgementRequestSent = false;
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/api/policies/policies/1/acknowledge/" && request.method() === "POST") {
+      acknowledgementRequestSent = true;
+    }
+  });
+
+  await page.goto("/policies?tenant=demo");
+
+  await expect(page.getByRole("heading", { name: "Policy Acknowledgments" })).toBeVisible();
+  await expect(page.getByText("Information Security Policy")).toBeVisible();
+  await expect(page.getByText("2 policies require your acknowledgment")).toBeVisible();
+
+  const policyCard = page.locator(".ant-card").filter({ hasText: "Information Security Policy" });
+  await policyCard.getByRole("button", { name: "Acknowledge" }).click();
+
+  await expect.poll(() => acknowledgementRequestSent).toBe(true);
+  await expect(page.getByText("Information Security Policy")).toHaveCount(0);
+  await expect(page.getByText("1 policies require your acknowledgment")).toBeVisible();
+});
+
+test("users can open a vendor profile from the vendor directory", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+  await signIn(page);
+
+  await page.goto("/vendors?tenant=demo");
+
+  await expect(page.getByRole("heading", { name: "Vendor Management" })).toBeVisible();
+  await expect(page.getByText("Vendor Directory")).toBeVisible();
+
+  await page.getByRole("button", { name: /Axim Cloud Services/ }).click();
+
+  await expect(page).toHaveURL(/\/vendors\/1/);
+  await expect(page.getByText("Axim Cloud Services Ltd")).toBeVisible();
+  await expect(page.getByText("Compliance & Security")).toBeVisible();
+  await expect(page.getByText("ISO 27001")).toBeVisible();
+  await expect(page.getByText("Ada Lovelace")).toBeVisible();
+});
+
+test("users can complete the assessment creation wizard", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+  await signIn(page);
+
+  await page.goto("/assessments/create?tenant=demo");
+
+  await expect(page.getByRole("heading", { name: "Create New Assessment" })).toBeVisible();
+  await expect(page.getByText("Risk Assessment")).toBeVisible();
+  await page.getByRole("button", { name: "Next", exact: true }).click();
+
+  await page.getByPlaceholder("Enter assessment title").fill("Quarterly risk assessment");
+  await page.getByPlaceholder("Enter assessor name").fill("Ada Lovelace");
+  await page
+    .getByPlaceholder("Describe the assessment scope and objectives")
+    .fill("Review supplier access and control evidence for the quarter.");
+
+  const dateInputs = page.locator(".ant-picker input");
+  await dateInputs.nth(0).fill("2026-07-20");
+  await dateInputs.nth(0).press("Enter");
+  await dateInputs.nth(1).fill("2026-08-20");
+  await dateInputs.nth(1).press("Enter");
+  await page.keyboard.press("Escape");
+
+  await page.getByRole("button", { name: "Next", exact: true }).click();
+
+  await page
+    .getByPlaceholder("Define what will be assessed, boundaries, and exclusions")
+    .fill("Supplier privileged access, approval evidence, and review records.");
+  await chooseSelectOption(page, "methodology", "ISO 27001");
+  await page
+    .getByPlaceholder("Define what constitutes successful completion of this assessment")
+    .fill("All sampled access rights have valid owners and evidence.");
+  await chooseSelectOption(page, "priority", "High");
+
+  await page.getByRole("button", { name: "Create Assessment" }).click();
+
+  await expect(page).toHaveURL(/\/assessments$/);
+  await expect(page.getByRole("heading", { name: "Compliance Assessments" })).toBeVisible();
+});

--- a/frontend/e2e/critical-grc-flows.smoke.spec.ts
+++ b/frontend/e2e/critical-grc-flows.smoke.spec.ts
@@ -11,7 +11,9 @@ async function signIn(page: Page) {
 
 async function chooseSelectOption(page: Page, fieldId: string, option: string) {
   await page.locator(`#${fieldId}`).click({ force: true });
-  await page.getByTitle(option).click({ force: true });
+  const dropdown = page.locator(".ant-select-dropdown:not(.ant-select-dropdown-hidden)").last();
+  await expect(dropdown).toBeVisible();
+  await dropdown.locator(".ant-select-item-option", { hasText: option }).click();
 }
 
 test("users can acknowledge assigned policies", async ({ page }) => {

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -47,6 +47,72 @@ const analytics = {
   riskTrend: -1,
 };
 
+const vendorCategory = {
+  id: 1,
+  name: "Cloud Services",
+  description: "Cloud hosting and managed services",
+  color_code: "#2F6FED",
+  risk_weight: "high",
+  compliance_requirements: {},
+};
+
+const vendor = {
+  id: 1,
+  vendor_id: "VEN-001",
+  name: "Axim Cloud Services",
+  legal_name: "Axim Cloud Services Ltd",
+  category: vendorCategory,
+  business_description: "Hosts regulated SaaS workloads and managed infrastructure.",
+  website: "https://vendor.example.test",
+  tax_id: "GB123456789",
+  duns_number: "123456789",
+  address_line1: "10 Cloud Street",
+  address_line2: "",
+  city: "London",
+  state_province: "London",
+  postal_code: "EC1A 1AA",
+  country: "United Kingdom",
+  status: "active",
+  vendor_type: "service_provider",
+  risk_level: "high",
+  risk_score: 72,
+  annual_spend: 120000,
+  credit_rating: "A",
+  payment_terms: "Net 30",
+  operating_regions: ["UK", "EU"],
+  primary_region: "UK",
+  custom_fields: {},
+  certifications: ["ISO 27001", "SOC 2 Type II"],
+  compliance_status: { gdpr: "compliant" },
+  data_processing_agreement: true,
+  security_assessment_completed: true,
+  security_assessment_date: "2026-06-01",
+  assigned_to: {
+    id: 1,
+    username: "owner",
+    first_name: "Ada",
+    last_name: "Lovelace",
+    email: "ada@example.com",
+  },
+  relationship_start_date: "2025-01-15",
+  created_at: "2025-01-15T09:00:00Z",
+  updated_at: "2026-07-01T09:00:00Z",
+  created_by: {
+    id: 1,
+    username: "admin",
+    first_name: "Grace",
+    last_name: "Hopper",
+  },
+};
+
+const vendorAnalytics = {
+  totalVendors: 1,
+  contractsExpiring: 0,
+  highRiskVendors: 1,
+  avgPerformance: 86,
+  performanceTrend: 4,
+};
+
 const executiveDashboard = {
   summary_metrics: {
     total_risks: { title: "Total Risks", value: 1 },
@@ -133,6 +199,50 @@ export async function mockAuthenticatedGrcApi(page: Page) {
         status_choices: [{ value: "identified", label: "Identified" }],
         treatment_strategies: [{ value: "mitigate", label: "Mitigate" }],
       });
+      return;
+    }
+
+    if (path === "/api/vendors/vendors/" && request.method() === "GET") {
+      await fulfilJson(route, {
+        results: [vendor],
+        count: 1,
+        next: null,
+        previous: null,
+      });
+      return;
+    }
+
+    if (path === "/api/vendors/vendors/1/" && request.method() === "GET") {
+      await fulfilJson(route, vendor);
+      return;
+    }
+
+    if (path === "/api/vendors/analytics/dashboard/" && request.method() === "GET") {
+      await fulfilJson(route, vendorAnalytics);
+      return;
+    }
+
+    if (path === "/api/vendors/categories/" && request.method() === "GET") {
+      await fulfilJson(route, {
+        results: [vendorCategory],
+        count: 1,
+        next: null,
+        previous: null,
+      });
+      return;
+    }
+
+    if (path === "/api/vendors/choices/" && request.method() === "GET") {
+      await fulfilJson(route, {
+        status_choices: [{ value: "active", label: "Active" }],
+        vendor_type_choices: [{ value: "service_provider", label: "Service Provider" }],
+        risk_level_choices: [{ value: "high", label: "High" }],
+      });
+      return;
+    }
+
+    if (path === "/api/policies/policies/1/acknowledge/" && request.method() === "POST") {
+      await fulfilJson(route, { status: "acknowledged" });
       return;
     }
 

--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -303,11 +303,11 @@ export default function AnalyticsPage() {
       // Uncomment when backend API is ready:
       /*
       const [executiveResponse, complianceResponse, vendorResponse, policyResponse, trainingResponse] = await Promise.all([
-        api.get('/api/analytics/executive/'),
-        api.get('/api/analytics/compliance/'),
-        api.get('/api/analytics/vendor-risk/'),
-        api.get('/api/analytics/policy-management/'),
-        api.get('/api/analytics/training-effectiveness/')
+        api.get('/analytics/executive/'),
+        api.get('/analytics/compliance/'),
+        api.get('/analytics/vendor-risk/'),
+        api.get('/analytics/policy-management/'),
+        api.get('/analytics/training-effectiveness/')
       ])
 
       setExecutiveData(executiveResponse.data)

--- a/frontend/src/app/policies/dashboard/page.tsx
+++ b/frontend/src/app/policies/dashboard/page.tsx
@@ -86,7 +86,7 @@ export default function PolicyDashboardPage() {
   const fetchDashboardData = async () => {
     try {
       setLoading(true)
-      const response = await api.get('/api/policies/policies/acknowledgment_dashboard/')
+      const response = await api.get('/policies/policies/acknowledgment_dashboard/')
       setDashboardData(response.data)
     } catch (error) {
       console.error('Failed to fetch dashboard data:', error)

--- a/frontend/src/app/policies/page.tsx
+++ b/frontend/src/app/policies/page.tsx
@@ -102,7 +102,7 @@ export default function PoliciesPage() {
       setPolicies(mockPolicies)
 
       // Uncomment when backend is ready:
-      // const response = await api.get('/api/policies/policies/my_policies/')
+      // const response = await api.get('/policies/policies/my_policies/')
       // setPolicies(response.data.policies || [])
     } catch (error) {
       console.error('Failed to fetch policies:', error)
@@ -115,7 +115,7 @@ export default function PoliciesPage() {
   const handleAcknowledge = async (policyId: string) => {
     try {
       setAcknowledging(policyId)
-      await api.post(`/api/policies/policies/${policyId}/acknowledge/`)
+      await api.post(`/policies/policies/${policyId}/acknowledge/`)
       message.success('Policy acknowledged successfully!')
 
       // Remove the acknowledged policy from the list

--- a/frontend/src/app/training/page.tsx
+++ b/frontend/src/app/training/page.tsx
@@ -141,8 +141,8 @@ export default function TrainingPage() {
       // Try to fetch from API first, fallback to mock data
       try {
         const [videosResponse, categoriesResponse] = await Promise.all([
-          api.get('/api/training/videos/'),
-          api.get('/api/training/categories/')
+          api.get('/training/videos/'),
+          api.get('/training/categories/')
         ])
 
         setVideos(videosResponse.data.results || videosResponse.data)
@@ -170,7 +170,7 @@ export default function TrainingPage() {
 
   const trackVideoView = async (videoId: string) => {
     try {
-      await api.post(`/api/training/videos/${videoId}/track_view/`, {
+      await api.post(`/training/videos/${videoId}/track_view/`, {
         duration_watched: 0,
         completed: false,
         completion_percentage: 0

--- a/frontend/src/app/training/video/[id]/page.tsx
+++ b/frontend/src/app/training/video/[id]/page.tsx
@@ -68,7 +68,7 @@ export default function VideoPlayerPage() {
   const fetchVideo = async () => {
     try {
       setLoading(true)
-      const response = await api.get(`/api/training/videos/${videoId}/`)
+      const response = await api.get(`/training/videos/${videoId}/`)
       setVideo(response.data)
       setViewStartTime(new Date())
 
@@ -102,7 +102,7 @@ export default function VideoPlayerPage() {
     const durationWatched = Math.floor((new Date().getTime() - viewStartTime.getTime()) / 1000)
 
     try {
-      await api.post(`/api/training/videos/${video.id}/track_view/`, {
+      await api.post(`/training/videos/${video.id}/track_view/`, {
         duration_watched: durationWatched,
         completed,
         completion_percentage: watchProgress


### PR DESCRIPTION
## Summary
- add Playwright smoke coverage for policy acknowledgement, vendor profile navigation, and the assessment creation wizard
- extend the authenticated E2E API shim with vendor and policy responses
- remove stale duplicated /api prefixes from frontend API calls now that the shared client owns the /api base path

Part of #81.

## Verification
- npm run test
- npm run type-check
- npm run lint
- npm run build
- npm run test:e2e
- npm audit --audit-level high
- git diff --check