### PR TITLE
refactor: route analytics through domain services

### DIFF
--- a/app/analytics/services.py
+++ b/app/analytics/services.py
@@ -1,34 +1,19 @@
 """
-Cross-Module Analytics and Reporting Services
+Cross-module analytics orchestration.
 
-Provides comprehensive analytics across all GRC modules including compliance,
-risk management, vendor tracking, policy management, and training programs.
+The analytics app composes domain-owned service outputs. It does not reach
+directly into other apps' models; each domain owns its own ORM queries.
 """
 
-from datetime import date, timedelta
-from decimal import Decimal
-from django.db.models import Count, Q, Avg, Sum, F, Case, When, Value, CharField, IntegerField
-from django.db.models.functions import TruncMonth, TruncWeek, Coalesce
+from datetime import timedelta
+
 from django.utils import timezone
-from django.contrib.auth import get_user_model
-from collections import defaultdict
-import json
 
-# Import models from all modules
-from risk.models import Risk, RiskCategory, RiskAction
-from catalogs.models import Framework, Control, ControlAssessment, AssessmentEvidence
-from policies.models import Policy, PolicyVersion, PolicyAcknowledgment, PolicyDistribution
-from vendors.models import Vendor, VendorTask
-from training.models import TrainingVideo, TrainingCategory, SecurityAwarenessCampaign, VideoView
-
-# Use ControlAssessment as our main assessment model
-Assessment = ControlAssessment
-try:
-    from vendors.models import VendorAssessment
-except ImportError:
-    VendorAssessment = None
-
-User = get_user_model()
+from catalogs.services import CatalogueAnalyticsService
+from policies.services import PolicyAnalyticsService
+from risk.services import RiskDomainAnalyticsService
+from training.services import TrainingAnalyticsService
+from vendors.services import VendorAnalyticsService
 
 
 class CrossModuleAnalyticsService:
@@ -48,103 +33,17 @@ class CrossModuleAnalyticsService:
         now = timezone.now().date()
         quarter_ago = now - timedelta(days=90)
 
-        # Risk metrics
-        risk_metrics = {
-            'total_risks': Risk.objects.count(),
-            'active_risks': Risk.objects.exclude(status__in=['closed', 'transferred']).count(),
-            'critical_high_risks': Risk.objects.filter(
-                risk_level__in=['critical', 'high']
-            ).exclude(status__in=['closed', 'transferred']).count(),
-            'overdue_actions': RiskAction.objects.filter(
-                due_date__lt=now,
-                status__in=['pending', 'in_progress', 'deferred']
-            ).count()
-        }
-
-        # Compliance metrics
-        compliance_metrics = {
-            'total_assessments': Assessment.objects.count(),
-            'active_assessments': Assessment.objects.filter(status='in_progress').count(),
-            'completed_assessments': Assessment.objects.filter(status='complete').count(),
-            'overdue_assessments': Assessment.objects.filter(
-                due_date__lt=now,
-                status__in=['not_started', 'in_progress']
-            ).count(),
-            'avg_completion_rate': Assessment.objects.filter(
-                status='complete'
-            ).aggregate(avg_score=Avg('compliance_score'))['avg_score'] or 0
-        }
-
-        # Policy metrics
-        policy_metrics = {
-            'total_policies': Policy.objects.count(),
-            'active_policies': Policy.objects.filter(status='active').count(),
-            'pending_acknowledgments': PolicyDistribution.objects.filter(
-                acknowledgments__isnull=True
-            ).count(),
-            'overdue_acknowledgments': PolicyDistribution.objects.filter(
-                acknowledgments__isnull=True,
-                is_overdue=True
-            ).count(),
-            'acknowledgment_rate': 0  # Will calculate below
-        }
-
-        # Calculate acknowledgment rate
-        total_distributions = PolicyDistribution.objects.count()
-        acknowledged_distributions = PolicyDistribution.objects.filter(
-            acknowledgments__isnull=False
-        ).count()
-        if total_distributions > 0:
-            policy_metrics['acknowledgment_rate'] = round(
-                (acknowledged_distributions / total_distributions) * 100, 1
-            )
-
-        # Vendor metrics
-        vendor_metrics = {
-            'total_vendors': Vendor.objects.count(),
-            'active_vendors': Vendor.objects.filter(status='active').count(),
-            'high_risk_vendors': Vendor.objects.filter(risk_level='high').count(),
-            'contracts_expiring_soon': Vendor.objects.filter(
-                contract_end_date__lte=now + timedelta(days=90),
-                contract_end_date__gte=now,
-                status='active'
-            ).count(),
-            'overdue_tasks': VendorTask.objects.filter(
-                due_date__lt=now,
-                status__in=['pending', 'in_progress']
-            ).count()
-        }
-
-        # Training metrics
-        training_metrics = {
-            'total_videos': TrainingVideo.objects.count(),
-            'total_views': VideoView.objects.count(),
-            'unique_viewers': VideoView.objects.values('user').distinct().count(),
-            'completion_rate': 0,  # Will calculate below
-            'active_campaigns': SecurityAwarenessCampaign.objects.filter(
-                is_active=True
-            ).count()
-        }
-
-        # Calculate training completion rate
-        total_views = VideoView.objects.count()
-        completed_views = VideoView.objects.filter(completed=True).count()
-        if total_views > 0:
-            training_metrics['completion_rate'] = round(
-                (completed_views / total_views) * 100, 1
-            )
-
         return {
-            'risk_summary': risk_metrics,
-            'compliance_summary': compliance_metrics,
-            'policy_summary': policy_metrics,
-            'vendor_summary': vendor_metrics,
-            'training_summary': training_metrics,
-            'generated_at': now.isoformat(),
-            'report_period': {
-                'start_date': quarter_ago.isoformat(),
-                'end_date': now.isoformat()
-            }
+            "risk_summary": RiskDomainAnalyticsService.executive_summary(now),
+            "compliance_summary": CatalogueAnalyticsService.executive_summary(now),
+            "policy_summary": PolicyAnalyticsService.executive_summary(),
+            "vendor_summary": VendorAnalyticsService.executive_summary(now),
+            "training_summary": TrainingAnalyticsService.executive_summary(),
+            "generated_at": now.isoformat(),
+            "report_period": {
+                "start_date": quarter_ago.isoformat(),
+                "end_date": now.isoformat(),
+            },
         }
 
     @staticmethod
@@ -155,94 +54,7 @@ class CrossModuleAnalyticsService:
         Returns:
             dict: Compliance-focused analytics
         """
-        now = timezone.now().date()
-
-        # Framework completion rates
-        framework_stats = list(Framework.objects.annotate(
-            total_assessments=Count('assessment_set'),
-            completed_assessments=Count(
-                Case(When(assessment_set__status='complete', then=1))
-            ),
-            in_progress_assessments=Count(
-                Case(When(assessment_set__status='in_progress', then=1))
-            ),
-            overdue_assessments=Count(
-                Case(
-                    When(
-                        Q(assessment_set__due_date__lt=now) &
-                        Q(assessment_set__status__in=['not_started', 'in_progress']),
-                        then=1
-                    )
-                )
-            ),
-            avg_score=Avg('assessment_set__compliance_score')
-        ).values(
-            'name', 'framework_type', 'total_assessments', 'completed_assessments',
-            'in_progress_assessments', 'overdue_assessments', 'avg_score'
-        ))
-
-        # Calculate completion rates
-        for framework in framework_stats:
-            if framework['total_assessments'] > 0:
-                framework['completion_rate'] = round(
-                    (framework['completed_assessments'] / framework['total_assessments']) * 100, 1
-                )
-            else:
-                framework['completion_rate'] = 0
-
-        # Control effectiveness analysis
-        control_effectiveness = list(Control.objects.annotate(
-            assessment_count=Count('controlassessment'),
-            avg_maturity=Avg('controlassessment__maturity_level'),
-            avg_effectiveness=Avg('controlassessment__effectiveness_rating'),
-            high_risk_count=Count(
-                Case(When(controlassessment__risk_rating__gte=7, then=1))
-            )
-        ).values(
-            'control_type', 'automation_level', 'assessment_count',
-            'avg_maturity', 'avg_effectiveness', 'high_risk_count'
-        ).order_by('-assessment_count'))
-
-        # Assessment progress trends (last 6 months)
-        six_months_ago = now - timedelta(days=180)
-        assessment_trends = list(Assessment.objects.filter(
-            created_at__date__gte=six_months_ago
-        ).extra(
-            select={'month': 'DATE_TRUNC(\'month\', created_at)'}
-        ).values('month').annotate(
-            created=Count('id'),
-            completed=Count(Case(When(status='complete', then=1))),
-            avg_score=Avg('compliance_score')
-        ).order_by('month'))
-
-        # Evidence collection metrics
-        evidence_stats = {
-            'total_evidence': AssessmentEvidence.objects.count(),
-            'validated_evidence': AssessmentEvidence.objects.filter(is_validated=True).count(),
-            'evidence_by_type': dict(AssessmentEvidence.objects.values('evidence_type').annotate(
-                count=Count('id')
-            ).values_list('evidence_type', 'count')),
-            'assessments_with_evidence': Assessment.objects.filter(
-                evidence__isnull=False
-            ).distinct().count()
-        }
-
-        return {
-            'framework_statistics': framework_stats,
-            'control_effectiveness': control_effectiveness,
-            'assessment_trends': assessment_trends,
-            'evidence_statistics': evidence_stats,
-            'overall_metrics': {
-                'total_frameworks': Framework.objects.count(),
-                'active_frameworks': Framework.objects.filter(status='active').count(),
-                'total_controls': Control.objects.count(),
-                'automated_controls': Control.objects.filter(automation_level='automated').count(),
-                'avg_maturity_score': Control.objects.aggregate(
-                    avg=Avg('controlassessment__maturity_level')
-                )['avg'] or 0
-            },
-            'generated_at': now.isoformat()
-        }
+        return CatalogueAnalyticsService.dashboard_data(timezone.now().date())
 
     @staticmethod
     def get_vendor_risk_dashboard_data():
@@ -252,97 +64,7 @@ class CrossModuleAnalyticsService:
         Returns:
             dict: Vendor-focused analytics and risk metrics
         """
-        now = timezone.now().date()
-
-        # Vendor risk distribution
-        vendor_risk_stats = {
-            'risk_distribution': dict(Vendor.objects.values('risk_level').annotate(
-                count=Count('id'),
-                total_spend=Sum('annual_spend'),
-                avg_performance=Avg('performance_score')
-            ).values_list('risk_level', 'count')),
-            'total_vendors': Vendor.objects.count(),
-            'active_vendors': Vendor.objects.filter(status='active').count(),
-            'total_annual_spend': Vendor.objects.aggregate(
-                total=Sum('annual_spend')
-            )['total'] or 0,
-            'avg_performance_score': Vendor.objects.aggregate(
-                avg=Avg('performance_score')
-            )['avg'] or 0
-        }
-
-        # Contract management metrics
-        contract_metrics = {
-            'expiring_30_days': Vendor.objects.filter(
-                contract_end_date__lte=now + timedelta(days=30),
-                contract_end_date__gte=now,
-                status='active'
-            ).count(),
-            'expiring_90_days': Vendor.objects.filter(
-                contract_end_date__lte=now + timedelta(days=90),
-                contract_end_date__gte=now,
-                status='active'
-            ).count(),
-            'expired_contracts': Vendor.objects.filter(
-                contract_end_date__lt=now,
-                status='active'
-            ).count(),
-            'renewals_needed': Vendor.objects.filter(
-                contract_end_date__lte=now + timedelta(days=180),
-                contract_end_date__gte=now,
-                status='active'
-            ).count()
-        }
-
-        # Vendor task analysis
-        task_analytics = {
-            'total_tasks': VendorTask.objects.count(),
-            'overdue_tasks': VendorTask.objects.filter(
-                due_date__lt=now,
-                status__in=['pending', 'in_progress']
-            ).count(),
-            'due_this_week': VendorTask.objects.filter(
-                due_date__gte=now,
-                due_date__lte=now + timedelta(days=7),
-                status__in=['pending', 'in_progress']
-            ).count(),
-            'task_type_distribution': dict(VendorTask.objects.values('task_type').annotate(
-                count=Count('id')
-            ).values_list('task_type', 'count')),
-            'completion_rate': 0
-        }
-
-        # Calculate task completion rate
-        total_tasks = VendorTask.objects.count()
-        completed_tasks = VendorTask.objects.filter(status='completed').count()
-        if total_tasks > 0:
-            task_analytics['completion_rate'] = round(
-                (completed_tasks / total_tasks) * 100, 1
-            )
-
-        # Top vendors by spend and risk
-        top_vendors = list(Vendor.objects.values(
-            'name', 'risk_level', 'annual_spend', 'performance_score',
-            'contract_end_date', 'status'
-        ).order_by('-annual_spend')[:10])
-
-        # High-risk vendor analysis
-        high_risk_vendors = list(Vendor.objects.filter(
-            risk_level='high'
-        ).values(
-            'name', 'annual_spend', 'performance_score', 'contract_end_date'
-        ).annotate(
-            open_tasks=Count('vendortask', filter=Q(vendortask__status__in=['pending', 'in_progress']))
-        ).order_by('-annual_spend'))
-
-        return {
-            'vendor_risk_statistics': vendor_risk_stats,
-            'contract_management': contract_metrics,
-            'task_analytics': task_analytics,
-            'top_vendors': top_vendors,
-            'high_risk_vendors': high_risk_vendors,
-            'generated_at': now.isoformat()
-        }
+        return VendorAnalyticsService.dashboard_data(timezone.now().date())
 
     @staticmethod
     def get_policy_management_dashboard_data():
@@ -352,86 +74,7 @@ class CrossModuleAnalyticsService:
         Returns:
             dict: Policy-focused analytics and compliance metrics
         """
-        now = timezone.now().date()
-
-        # Policy distribution metrics
-        policy_stats = {
-            'total_policies': Policy.objects.count(),
-            'active_policies': Policy.objects.filter(status='active').count(),
-            'policies_requiring_acknowledgment': Policy.objects.filter(
-                requires_acknowledgment=True
-            ).count(),
-            'draft_policies': Policy.objects.filter(status='draft').count(),
-            'under_review_policies': Policy.objects.filter(status='under_review').count()
-        }
-
-        # Acknowledgment analytics
-        total_distributions = PolicyDistribution.objects.count()
-        acknowledged_distributions = PolicyDistribution.objects.filter(
-            acknowledgments__isnull=False
-        ).distinct().count()
-
-        acknowledgment_stats = {
-            'total_distributions': total_distributions,
-            'acknowledged_distributions': acknowledged_distributions,
-            'pending_acknowledgments': total_distributions - acknowledged_distributions,
-            'overdue_acknowledgments': PolicyDistribution.objects.filter(
-                acknowledgments__isnull=True,
-                is_overdue=True
-            ).count(),
-            'acknowledgment_rate': round(
-                (acknowledged_distributions / max(total_distributions, 1)) * 100, 1
-            )
-        }
-
-        # Policy category analysis
-        category_stats = list(Policy.objects.values('category').annotate(
-            policy_count=Count('id'),
-            active_policies=Count(Case(When(status='active', then=1))),
-            avg_acknowledgment_rate=Avg(
-                Case(
-                    When(
-                        requires_acknowledgment=True,
-                        then=F('policydistribution__acknowledgments__id')
-                    ),
-                    default=Value(0),
-                    output_field=IntegerField()
-                )
-            )
-        ).order_by('-policy_count'))
-
-        # Recent policy activity (last 90 days)
-        ninety_days_ago = now - timedelta(days=90)
-        recent_activity = {
-            'new_policies': Policy.objects.filter(created_at__date__gte=ninety_days_ago).count(),
-            'updated_policies': PolicyVersion.objects.filter(
-                created_at__date__gte=ninety_days_ago
-            ).count(),
-            'new_acknowledgments': PolicyAcknowledgment.objects.filter(
-                acknowledged_at__date__gte=ninety_days_ago
-            ).count(),
-            'distributions_sent': PolicyDistribution.objects.filter(
-                distributed_at__date__gte=ninety_days_ago
-            ).count()
-        }
-
-        # Acknowledgment trends over time
-        acknowledgment_trends = list(PolicyAcknowledgment.objects.filter(
-            acknowledged_at__date__gte=now - timedelta(days=180)
-        ).extra(
-            select={'month': 'DATE_TRUNC(\'month\', acknowledged_at)'}
-        ).values('month').annotate(
-            acknowledgments=Count('id')
-        ).order_by('month'))
-
-        return {
-            'policy_statistics': policy_stats,
-            'acknowledgment_analytics': acknowledgment_stats,
-            'category_breakdown': category_stats,
-            'recent_activity': recent_activity,
-            'acknowledgment_trends': acknowledgment_trends,
-            'generated_at': now.isoformat()
-        }
+        return PolicyAnalyticsService.dashboard_data(timezone.now().date())
 
     @staticmethod
     def get_training_effectiveness_dashboard_data():
@@ -441,93 +84,7 @@ class CrossModuleAnalyticsService:
         Returns:
             dict: Training-focused metrics and engagement analysis
         """
-        now = timezone.now().date()
-
-        # Video engagement metrics
-        video_stats = {
-            'total_videos': TrainingVideo.objects.count(),
-            'total_views': VideoView.objects.count(),
-            'unique_viewers': VideoView.objects.values('user').distinct().count(),
-            'total_watch_time': VideoView.objects.aggregate(
-                total_minutes=Sum('duration_watched')
-            )['total_minutes'] or 0,
-            'avg_completion_rate': VideoView.objects.aggregate(
-                avg_completion=Avg('completion_percentage')
-            )['avg_completion'] or 0
-        }
-
-        # Category performance
-        category_performance = list(TrainingCategory.objects.annotate(
-            video_count=Count('trainingvideo'),
-            total_views=Count('trainingvideo__videoview'),
-            avg_completion=Avg('trainingvideo__videoview__completion_percentage'),
-            total_watch_time=Sum('trainingvideo__videoview__duration_watched')
-        ).values(
-            'name', 'description', 'color', 'video_count', 'total_views',
-            'avg_completion', 'total_watch_time'
-        ).order_by('-total_views'))
-
-        # User engagement analysis
-        user_engagement = {
-            'active_learners_30_days': VideoView.objects.filter(
-                view_date__gte=now - timedelta(days=30)
-            ).values('user').distinct().count(),
-            'completed_videos_30_days': VideoView.objects.filter(
-                view_date__gte=now - timedelta(days=30),
-                completed=True
-            ).count(),
-            'avg_videos_per_user': VideoView.objects.values('user').annotate(
-                video_count=Count('video', distinct=True)
-            ).aggregate(avg=Avg('video_count'))['avg'] or 0,
-            'completion_rate': 0
-        }
-
-        # Calculate overall completion rate
-        total_views = VideoView.objects.count()
-        completed_views = VideoView.objects.filter(completed=True).count()
-        if total_views > 0:
-            user_engagement['completion_rate'] = round(
-                (completed_views / total_views) * 100, 1
-            )
-
-        # Security awareness campaign metrics
-        campaign_stats = list(SecurityAwarenessCampaign.objects.annotate(
-            engagement_rate=Case(
-                When(total_sent=0, then=Value(0)),
-                default=F('total_opened') * 100.0 / F('total_sent'),
-                output_field=CharField()
-            ),
-            click_through_rate=Case(
-                When(total_opened=0, then=Value(0)),
-                default=F('total_clicked') * 100.0 / F('total_opened'),
-                output_field=CharField()
-            )
-        ).values(
-            'name', 'send_frequency', 'total_sent', 'total_opened',
-            'total_clicked', 'engagement_rate', 'click_through_rate', 'is_active'
-        ))
-
-        # Training trends (last 6 months)
-        six_months_ago = now - timedelta(days=180)
-        training_trends = list(VideoView.objects.filter(
-            view_date__gte=six_months_ago
-        ).extra(
-            select={'month': 'DATE_TRUNC(\'month\', view_date)'}
-        ).values('month').annotate(
-            views=Count('id'),
-            unique_users=Count('user', distinct=True),
-            completions=Count(Case(When(completed=True, then=1))),
-            avg_completion_percentage=Avg('completion_percentage')
-        ).order_by('month'))
-
-        return {
-            'video_engagement': video_stats,
-            'category_performance': category_performance,
-            'user_engagement': user_engagement,
-            'campaign_analytics': campaign_stats,
-            'training_trends': training_trends,
-            'generated_at': now.isoformat()
-        }
+        return TrainingAnalyticsService.dashboard_data(timezone.now().date())
 
     @staticmethod
     def get_integrated_risk_posture():
@@ -538,118 +95,48 @@ class CrossModuleAnalyticsService:
             dict: Cross-module risk analysis and correlations
         """
         now = timezone.now().date()
+        risk_velocity = RiskDomainAnalyticsService.velocity_metrics(now)
+        risk_velocity["overdue_items"] = (
+            risk_velocity.pop("overdue_actions")
+            + CatalogueAnalyticsService.overdue_assessment_count(now)
+            + VendorAnalyticsService.overdue_task_count(now)
+        )
 
-        # Risk sources across modules
         risk_sources = {
-            'operational_risks': Risk.objects.exclude(status__in=['closed', 'transferred']).count(),
-            'compliance_gaps': Assessment.objects.filter(
-                status='complete',
-                compliance_score__lt=70  # Assuming 70% is the compliance threshold
-            ).count(),
-            'vendor_risks': Vendor.objects.filter(risk_level__in=['high', 'critical']).count(),
-            'policy_violations': PolicyDistribution.objects.filter(
-                acknowledgments__isnull=True,
-                is_overdue=True
-            ).count(),
-            'training_gaps': User.objects.exclude(
-                videoview__completed=True
-            ).count()
+            "operational_risks": RiskDomainAnalyticsService.active_risk_count(),
+            "compliance_gaps": CatalogueAnalyticsService.compliance_gap_count(),
+            "vendor_risks": VendorAnalyticsService.high_or_critical_vendor_count(),
+            "policy_violations": PolicyAnalyticsService.policy_violation_count(),
+            "training_gaps": TrainingAnalyticsService.training_gap_count(),
         }
 
-        # Risk correlation analysis
-        high_risk_vendors_with_assessments = Vendor.objects.filter(
-            risk_level='high'
-        ).annotate(
-            assessment_count=Count('vendorassessment')
-        ).values('name', 'annual_spend', 'assessment_count')
-
-        # Compliance framework risk correlation
-        framework_risk_correlation = list(Framework.objects.annotate(
-            incomplete_assessments=Count(
-                Case(
-                    When(
-                        Q(assessment_set__status__in=['not_started', 'in_progress']) &
-                        Q(assessment_set__due_date__lt=now),
-                        then=1
-                    )
-                )
-            ),
-            low_scoring_assessments=Count(
-                Case(
-                    When(
-                        Q(assessment_set__status='complete') &
-                        Q(assessment_set__compliance_score__lt=70),
-                        then=1
-                    )
-                )
-            ),
-            related_risks=Count('assessment_set__risks', distinct=True)
-        ).values(
-            'name', 'framework_type', 'incomplete_assessments',
-            'low_scoring_assessments', 'related_risks'
-        ))
-
-        # Risk velocity and trending
-        thirty_days_ago = now - timedelta(days=30)
-        risk_velocity = {
-            'new_risks_30_days': Risk.objects.filter(
-                created_at__date__gte=thirty_days_ago
-            ).count(),
-            'resolved_risks_30_days': Risk.objects.filter(
-                closed_date__gte=thirty_days_ago,
-                closed_date__isnull=False
-            ).count(),
-            'escalated_risks': Risk.objects.filter(
-                created_at__date__gte=thirty_days_ago,
-                risk_level__in=['high', 'critical']
-            ).count(),
-            'overdue_items': (
-                RiskAction.objects.filter(
-                    due_date__lt=now,
-                    status__in=['pending', 'in_progress']
-                ).count() +
-                Assessment.objects.filter(
-                    due_date__lt=now,
-                    status__in=['not_started', 'in_progress']
-                ).count() +
-                VendorTask.objects.filter(
-                    due_date__lt=now,
-                    status__in=['pending', 'in_progress']
-                ).count()
-            )
-        }
-
-        # Risk maturity indicators
-        risk_maturity = {
-            'risk_treatment_coverage': Risk.objects.exclude(
-                treatment_strategy__isnull=True
-            ).exclude(treatment_strategy='').count() / max(Risk.objects.count(), 1) * 100,
-            'control_automation_rate': Control.objects.filter(
-                automation_level='automated'
-            ).count() / max(Control.objects.count(), 1) * 100,
-            'policy_acknowledgment_rate': (
-                PolicyDistribution.objects.filter(
-                    acknowledgments__isnull=False
-                ).distinct().count() / max(PolicyDistribution.objects.count(), 1) * 100
-            ),
-            'vendor_assessment_coverage': Vendor.objects.filter(
-                vendorassessment__isnull=False
-            ).distinct().count() / max(Vendor.objects.count(), 1) * 100
-        }
+        framework_risk_correlation = CatalogueAnalyticsService.framework_risk_correlation(now)
+        for framework in framework_risk_correlation:
+            # Risk-control mappings are not modelled yet; preserve the response key
+            # while keeping the catalogue service as the source of framework metrics.
+            framework["related_risks"] = 0
 
         return {
-            'risk_source_analysis': risk_sources,
-            'vendor_risk_correlation': list(high_risk_vendors_with_assessments),
-            'framework_risk_correlation': framework_risk_correlation,
-            'risk_velocity_metrics': risk_velocity,
-            'risk_maturity_indicators': {
-                'treatment_coverage': round(risk_maturity['risk_treatment_coverage'], 1),
-                'automation_rate': round(risk_maturity['control_automation_rate'], 1),
-                'acknowledgment_rate': round(risk_maturity['policy_acknowledgment_rate'], 1),
-                'assessment_coverage': round(risk_maturity['vendor_assessment_coverage'], 1)
+            "risk_source_analysis": risk_sources,
+            "vendor_risk_correlation": VendorAnalyticsService.high_risk_assessment_correlation(),
+            "framework_risk_correlation": framework_risk_correlation,
+            "risk_velocity_metrics": risk_velocity,
+            "risk_maturity_indicators": {
+                "treatment_coverage": round(
+                    RiskDomainAnalyticsService.treatment_coverage_percentage(), 1
+                ),
+                "automation_rate": round(
+                    CatalogueAnalyticsService.automation_rate_percentage(), 1
+                ),
+                "acknowledgment_rate": round(
+                    PolicyAnalyticsService.acknowledgment_rate_percentage(), 1
+                ),
+                "assessment_coverage": round(
+                    VendorAnalyticsService.assessment_coverage_percentage(), 1
+                ),
             },
-            'overall_risk_score': round(sum(risk_sources.values()) / len(risk_sources), 1),
-            'generated_at': now.isoformat()
+            "overall_risk_score": round(sum(risk_sources.values()) / len(risk_sources), 1),
+            "generated_at": now.isoformat(),
         }
 
 
@@ -668,17 +155,19 @@ class AnalyticsReportGenerator:
             dict: Complete executive analytics package
         """
         return {
-            'executive_dashboard': CrossModuleAnalyticsService.get_executive_dashboard_data(),
-            'integrated_risk_posture': CrossModuleAnalyticsService.get_integrated_risk_posture(),
-            'compliance_overview': CrossModuleAnalyticsService.get_compliance_dashboard_data(),
-            'vendor_risk_summary': CrossModuleAnalyticsService.get_vendor_risk_dashboard_data(),
-            'policy_compliance': CrossModuleAnalyticsService.get_policy_management_dashboard_data(),
-            'training_effectiveness': CrossModuleAnalyticsService.get_training_effectiveness_dashboard_data(),
-            'report_metadata': {
-                'generated_at': timezone.now().isoformat(),
-                'report_type': 'executive_comprehensive',
-                'version': '1.0'
-            }
+            "executive_dashboard": CrossModuleAnalyticsService.get_executive_dashboard_data(),
+            "integrated_risk_posture": CrossModuleAnalyticsService.get_integrated_risk_posture(),
+            "compliance_overview": CrossModuleAnalyticsService.get_compliance_dashboard_data(),
+            "vendor_risk_summary": CrossModuleAnalyticsService.get_vendor_risk_dashboard_data(),
+            "policy_compliance": CrossModuleAnalyticsService.get_policy_management_dashboard_data(),
+            "training_effectiveness": (
+                CrossModuleAnalyticsService.get_training_effectiveness_dashboard_data()
+            ),
+            "report_metadata": {
+                "generated_at": timezone.now().isoformat(),
+                "report_type": "executive_comprehensive",
+                "version": "1.0",
+            },
         }
 
     @staticmethod
@@ -689,18 +178,17 @@ class AnalyticsReportGenerator:
         Returns:
             dict: Operational analytics focused on actionable metrics
         """
-        # Import risk analytics for integration
-        from risk.analytics import RiskAnalyticsService
-
         return {
-            'risk_analytics': RiskAnalyticsService.get_risk_overview_stats(),
-            'compliance_metrics': CrossModuleAnalyticsService.get_compliance_dashboard_data(),
-            'vendor_management': CrossModuleAnalyticsService.get_vendor_risk_dashboard_data(),
-            'policy_tracking': CrossModuleAnalyticsService.get_policy_management_dashboard_data(),
-            'training_progress': CrossModuleAnalyticsService.get_training_effectiveness_dashboard_data(),
-            'report_metadata': {
-                'generated_at': timezone.now().isoformat(),
-                'report_type': 'operational_dashboard',
-                'version': '1.0'
-            }
+            "risk_analytics": RiskDomainAnalyticsService.overview_stats(),
+            "compliance_metrics": CrossModuleAnalyticsService.get_compliance_dashboard_data(),
+            "vendor_management": CrossModuleAnalyticsService.get_vendor_risk_dashboard_data(),
+            "policy_tracking": CrossModuleAnalyticsService.get_policy_management_dashboard_data(),
+            "training_progress": (
+                CrossModuleAnalyticsService.get_training_effectiveness_dashboard_data()
+            ),
+            "report_metadata": {
+                "generated_at": timezone.now().isoformat(),
+                "report_type": "operational_dashboard",
+                "version": "1.0",
+            },
         }

--- a/app/analytics/test_service_boundaries.py
+++ b/app/analytics/test_service_boundaries.py
@@ -1,0 +1,41 @@
+"""Service-boundary regression tests for cross-module analytics."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from analytics.services import CrossModuleAnalyticsService
+
+
+FORBIDDEN_DIRECT_MODEL_IMPORTS = {
+    "catalogs.models",
+    "policies.models",
+    "risk.models",
+    "training.models",
+    "vendors.models",
+}
+
+
+def test_analytics_services_do_not_import_cross_domain_models_directly():
+    source = Path(__file__).with_name("services.py").read_text()
+    tree = ast.parse(source)
+
+    direct_model_imports = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module in FORBIDDEN_DIRECT_MODEL_IMPORTS
+    }
+
+    assert direct_model_imports == set()
+
+
+@pytest.mark.django_db
+def test_cross_module_dashboard_services_smoke():
+    assert "risk_summary" in CrossModuleAnalyticsService.get_executive_dashboard_data()
+    assert "framework_statistics" in CrossModuleAnalyticsService.get_compliance_dashboard_data()
+    assert "vendor_risk_statistics" in CrossModuleAnalyticsService.get_vendor_risk_dashboard_data()
+    assert "policy_statistics" in CrossModuleAnalyticsService.get_policy_management_dashboard_data()
+    assert "video_engagement" in CrossModuleAnalyticsService.get_training_effectiveness_dashboard_data()
+    assert "risk_source_analysis" in CrossModuleAnalyticsService.get_integrated_risk_posture()

--- a/app/catalogs/services.py
+++ b/app/catalogs/services.py
@@ -24,10 +24,10 @@ def _maturity_score():
 
 def _effectiveness_score():
     return Case(
-        When(assessments__effectiveness_rating="not_effective", then=Value(1.0)),
-        When(assessments__effectiveness_rating="partially_effective", then=Value(2.0)),
-        When(assessments__effectiveness_rating="largely_effective", then=Value(3.0)),
-        When(assessments__effectiveness_rating="fully_effective", then=Value(4.0)),
+        When(effectiveness_rating="not_effective", then=Value(1.0)),
+        When(effectiveness_rating="partially_effective", then=Value(2.0)),
+        When(effectiveness_rating="largely_effective", then=Value(3.0)),
+        When(effectiveness_rating="fully_effective", then=Value(4.0)),
         output_field=FloatField(),
     )
 

--- a/app/catalogs/services.py
+++ b/app/catalogs/services.py
@@ -1,0 +1,215 @@
+"""Catalogue and control-assessment service entry points."""
+
+from datetime import timedelta
+
+from django.db.models import Avg, Case, Count, FloatField, Q, Value, When
+from django.utils import timezone
+
+from .models import AssessmentEvidence, Control, ControlAssessment, Framework
+
+
+ASSESSMENT_OPEN_STATUSES = ["not_started", "in_progress"]
+
+
+def _maturity_score():
+    return Case(
+        When(assessments__maturity_level="ad_hoc", then=Value(1.0)),
+        When(assessments__maturity_level="repeatable", then=Value(2.0)),
+        When(assessments__maturity_level="defined", then=Value(3.0)),
+        When(assessments__maturity_level="managed", then=Value(4.0)),
+        When(assessments__maturity_level="optimized", then=Value(5.0)),
+        output_field=FloatField(),
+    )
+
+
+def _effectiveness_score():
+    return Case(
+        When(assessments__effectiveness_rating="not_effective", then=Value(1.0)),
+        When(assessments__effectiveness_rating="partially_effective", then=Value(2.0)),
+        When(assessments__effectiveness_rating="largely_effective", then=Value(3.0)),
+        When(assessments__effectiveness_rating="fully_effective", then=Value(4.0)),
+        output_field=FloatField(),
+    )
+
+
+class CatalogueAnalyticsService:
+    """Read-side analytics owned by the catalogue/control-assessment domain."""
+
+    @staticmethod
+    def executive_summary(now=None):
+        today = now or timezone.now().date()
+        return {
+            "total_assessments": ControlAssessment.objects.count(),
+            "active_assessments": ControlAssessment.objects.filter(
+                status="in_progress"
+            ).count(),
+            "completed_assessments": ControlAssessment.objects.filter(
+                status="complete"
+            ).count(),
+            "overdue_assessments": CatalogueAnalyticsService.overdue_assessment_count(today),
+            "avg_completion_rate": ControlAssessment.objects.filter(
+                status="complete"
+            ).aggregate(avg_score=Avg("compliance_score"))["avg_score"]
+            or 0,
+        }
+
+    @staticmethod
+    def dashboard_data(now=None):
+        today = now or timezone.now().date()
+        six_months_ago = today - timedelta(days=180)
+
+        framework_stats = list(
+            Framework.objects.annotate(
+                total_assessments=Count("control_assessments"),
+                completed_assessments=Count(
+                    "control_assessments",
+                    filter=Q(control_assessments__status="complete"),
+                ),
+                in_progress_assessments=Count(
+                    "control_assessments",
+                    filter=Q(control_assessments__status="in_progress"),
+                ),
+                overdue_assessments=Count(
+                    "control_assessments",
+                    filter=Q(
+                        control_assessments__due_date__lt=today,
+                        control_assessments__status__in=ASSESSMENT_OPEN_STATUSES,
+                    ),
+                ),
+                avg_score=Avg("control_assessments__compliance_score"),
+            ).values(
+                "name",
+                "framework_type",
+                "total_assessments",
+                "completed_assessments",
+                "in_progress_assessments",
+                "overdue_assessments",
+                "avg_score",
+            )
+        )
+
+        for framework in framework_stats:
+            total = framework["total_assessments"]
+            framework["completion_rate"] = (
+                round((framework["completed_assessments"] / total) * 100, 1)
+                if total > 0
+                else 0
+            )
+
+        control_effectiveness = list(
+            Control.objects.annotate(
+                assessment_count=Count("assessments"),
+                avg_maturity=Avg(_maturity_score()),
+                avg_effectiveness=Avg(_effectiveness_score()),
+                high_risk_count=Count(
+                    "assessments",
+                    filter=Q(assessments__risk_rating__in=["high", "critical"]),
+                ),
+            )
+            .values(
+                "control_type",
+                "automation_level",
+                "assessment_count",
+                "avg_maturity",
+                "avg_effectiveness",
+                "high_risk_count",
+            )
+            .order_by("-assessment_count")
+        )
+
+        assessment_trends = list(
+            ControlAssessment.objects.filter(created_at__date__gte=six_months_ago)
+            .extra(select={"month": "DATE_TRUNC('month', created_at)"})
+            .values("month")
+            .annotate(
+                created=Count("id"),
+                completed=Count("id", filter=Q(status="complete")),
+                avg_score=Avg("compliance_score"),
+            )
+            .order_by("month")
+        )
+
+        evidence_stats = {
+            "total_evidence": AssessmentEvidence.objects.count(),
+            "validated_evidence": AssessmentEvidence.objects.filter(
+                evidence__is_validated=True
+            ).count(),
+            "evidence_by_type": dict(
+                AssessmentEvidence.objects.values("evidence__evidence_type")
+                .annotate(count=Count("id"))
+                .values_list("evidence__evidence_type", "count")
+            ),
+            "assessments_with_evidence": ControlAssessment.objects.filter(
+                evidence_links__isnull=False
+            )
+            .distinct()
+            .count(),
+        }
+
+        return {
+            "framework_statistics": framework_stats,
+            "control_effectiveness": control_effectiveness,
+            "assessment_trends": assessment_trends,
+            "evidence_statistics": evidence_stats,
+            "overall_metrics": {
+                "total_frameworks": Framework.objects.count(),
+                "active_frameworks": Framework.objects.filter(status="active").count(),
+                "total_controls": Control.objects.count(),
+                "automated_controls": Control.objects.filter(
+                    automation_level="automated"
+                ).count(),
+                "avg_maturity_score": Control.objects.aggregate(
+                    avg=Avg(_maturity_score())
+                )["avg"]
+                or 0,
+            },
+            "generated_at": today.isoformat(),
+        }
+
+    @staticmethod
+    def overdue_assessment_count(now=None):
+        today = now or timezone.now().date()
+        return ControlAssessment.objects.filter(
+            due_date__lt=today,
+            status__in=ASSESSMENT_OPEN_STATUSES,
+        ).count()
+
+    @staticmethod
+    def compliance_gap_count():
+        return ControlAssessment.objects.filter(
+            status="complete",
+            compliance_score__lt=70,
+        ).count()
+
+    @staticmethod
+    def automation_rate_percentage():
+        return Control.objects.filter(automation_level="automated").count() / max(
+            Control.objects.count(), 1
+        ) * 100
+
+    @staticmethod
+    def framework_risk_correlation(now=None):
+        today = now or timezone.now().date()
+        return list(
+            Framework.objects.annotate(
+                incomplete_assessments=Count(
+                    "control_assessments",
+                    filter=Q(
+                        control_assessments__status__in=ASSESSMENT_OPEN_STATUSES,
+                        control_assessments__due_date__lt=today,
+                    ),
+                ),
+                low_scoring_assessments=Count(
+                    "control_assessments",
+                    filter=Q(
+                        control_assessments__status="complete",
+                        control_assessments__compliance_score__lt=70,
+                    ),
+                ),
+            ).values(
+                "name",
+                "framework_type",
+                "incomplete_assessments",
+                "low_scoring_assessments",
+            )
+        )

--- a/app/policies/services.py
+++ b/app/policies/services.py
@@ -1,0 +1,144 @@
+"""Policy domain service entry points."""
+
+from datetime import timedelta
+
+from django.db.models import Count, Q
+from django.utils import timezone
+
+from .models import Policy, PolicyAcknowledgment, PolicyDistribution, PolicyVersion
+
+
+class PolicyAnalyticsService:
+    """Read-side analytics owned by the policy domain."""
+
+    @staticmethod
+    def executive_summary():
+        total_distributions = PolicyDistribution.objects.count()
+        acknowledged_distributions = PolicyDistribution.objects.filter(
+            acknowledged=True
+        ).count()
+        acknowledgment_rate = 0
+        if total_distributions > 0:
+            acknowledgment_rate = round(
+                (acknowledged_distributions / total_distributions) * 100,
+                1,
+            )
+
+        return {
+            "total_policies": Policy.objects.count(),
+            "active_policies": Policy.objects.filter(status="active").count(),
+            "pending_acknowledgments": PolicyDistribution.objects.filter(
+                acknowledged=False
+            ).count(),
+            "overdue_acknowledgments": PolicyAnalyticsService.overdue_acknowledgment_count(),
+            "acknowledgment_rate": acknowledgment_rate,
+        }
+
+    @staticmethod
+    def dashboard_data(now=None):
+        today = now or timezone.now().date()
+        ninety_days_ago = today - timedelta(days=90)
+
+        policy_stats = {
+            "total_policies": Policy.objects.count(),
+            "active_policies": Policy.objects.filter(status="active").count(),
+            "policies_requiring_acknowledgment": Policy.objects.filter(
+                requires_acknowledgment=True
+            ).count(),
+            "draft_policies": Policy.objects.filter(status="draft").count(),
+            "under_review_policies": Policy.objects.filter(
+                status="under_review"
+            ).count(),
+        }
+
+        total_distributions = PolicyDistribution.objects.count()
+        acknowledged_distributions = PolicyDistribution.objects.filter(
+            acknowledged=True
+        ).count()
+
+        acknowledgment_stats = {
+            "total_distributions": total_distributions,
+            "acknowledged_distributions": acknowledged_distributions,
+            "pending_acknowledgments": total_distributions - acknowledged_distributions,
+            "overdue_acknowledgments": PolicyAnalyticsService.overdue_acknowledgment_count(),
+            "acknowledgment_rate": round(
+                (acknowledged_distributions / max(total_distributions, 1)) * 100,
+                1,
+            ),
+        }
+
+        category_stats = list(
+            Policy.objects.values("category", "category__name")
+            .annotate(
+                policy_count=Count("id"),
+                active_policies=Count("id", filter=Q(status="active")),
+                acknowledged_distributions=Count(
+                    "versions__distributions",
+                    filter=Q(versions__distributions__acknowledged=True),
+                ),
+                total_distributions=Count("versions__distributions"),
+            )
+            .order_by("-policy_count")
+        )
+
+        for category in category_stats:
+            total = category["total_distributions"]
+            category["avg_acknowledgment_rate"] = (
+                round((category["acknowledged_distributions"] / total) * 100, 1)
+                if total
+                else 0
+            )
+
+        recent_activity = {
+            "new_policies": Policy.objects.filter(
+                created_at__date__gte=ninety_days_ago
+            ).count(),
+            "updated_policies": PolicyVersion.objects.filter(
+                created_at__date__gte=ninety_days_ago
+            ).count(),
+            "new_acknowledgments": PolicyAcknowledgment.objects.filter(
+                acknowledged_at__date__gte=ninety_days_ago
+            ).count(),
+            "distributions_sent": PolicyDistribution.objects.filter(
+                distributed_at__date__gte=ninety_days_ago
+            ).count(),
+        }
+
+        acknowledgment_trends = list(
+            PolicyAcknowledgment.objects.filter(
+                acknowledged_at__date__gte=today - timedelta(days=180)
+            )
+            .extra(select={"month": "DATE_TRUNC('month', acknowledged_at)"})
+            .values("month")
+            .annotate(acknowledgments=Count("id"))
+            .order_by("month")
+        )
+
+        return {
+            "policy_statistics": policy_stats,
+            "acknowledgment_analytics": acknowledgment_stats,
+            "category_breakdown": category_stats,
+            "recent_activity": recent_activity,
+            "acknowledgment_trends": acknowledgment_trends,
+            "generated_at": today.isoformat(),
+        }
+
+    @staticmethod
+    def overdue_acknowledgment_count():
+        overdue_cutoff = timezone.now() - timedelta(days=30)
+        return PolicyDistribution.objects.filter(
+            acknowledged=False,
+            distributed_at__lt=overdue_cutoff,
+        ).count()
+
+    @staticmethod
+    def policy_violation_count():
+        return PolicyAnalyticsService.overdue_acknowledgment_count()
+
+    @staticmethod
+    def acknowledgment_rate_percentage():
+        total_distributions = PolicyDistribution.objects.count()
+        acknowledged_distributions = PolicyDistribution.objects.filter(
+            acknowledged=True
+        ).count()
+        return acknowledged_distributions / max(total_distributions, 1) * 100

--- a/app/risk/services.py
+++ b/app/risk/services.py
@@ -1,0 +1,82 @@
+"""Risk domain service entry points."""
+
+from datetime import timedelta
+
+from django.db.models import Count
+from django.utils import timezone
+
+from .analytics import RiskAnalyticsService
+from .models import Risk, RiskAction
+
+
+OPEN_RISK_STATUSES = ["closed", "transferred"]
+OPEN_ACTION_STATUSES = ["pending", "in_progress", "deferred"]
+
+
+class RiskDomainAnalyticsService:
+    """Read-side analytics owned by the risk domain."""
+
+    @staticmethod
+    def executive_summary(now=None):
+        today = now or timezone.now().date()
+        return {
+            "total_risks": Risk.objects.count(),
+            "active_risks": Risk.objects.exclude(status__in=OPEN_RISK_STATUSES).count(),
+            "critical_high_risks": Risk.objects.filter(
+                risk_level__in=["critical", "high"]
+            )
+            .exclude(status__in=OPEN_RISK_STATUSES)
+            .count(),
+            "overdue_actions": RiskAction.objects.filter(
+                due_date__lt=today,
+                status__in=OPEN_ACTION_STATUSES,
+            ).count(),
+        }
+
+    @staticmethod
+    def active_risk_count():
+        return Risk.objects.exclude(status__in=OPEN_RISK_STATUSES).count()
+
+    @staticmethod
+    def velocity_metrics(now=None):
+        today = now or timezone.now().date()
+        thirty_days_ago = today - timedelta(days=30)
+        return {
+            "new_risks_30_days": Risk.objects.filter(
+                created_at__date__gte=thirty_days_ago
+            ).count(),
+            "resolved_risks_30_days": Risk.objects.filter(
+                closed_date__gte=thirty_days_ago,
+                closed_date__isnull=False,
+            ).count(),
+            "escalated_risks": Risk.objects.filter(
+                created_at__date__gte=thirty_days_ago,
+                risk_level__in=["high", "critical"],
+            ).count(),
+            "overdue_actions": RiskAction.objects.filter(
+                due_date__lt=today,
+                status__in=["pending", "in_progress"],
+            ).count(),
+        }
+
+    @staticmethod
+    def treatment_coverage_percentage():
+        total_risks = Risk.objects.count()
+        covered_risks = (
+            Risk.objects.exclude(treatment_strategy__isnull=True)
+            .exclude(treatment_strategy="")
+            .count()
+        )
+        return covered_risks / max(total_risks, 1) * 100
+
+    @staticmethod
+    def overview_stats():
+        return RiskAnalyticsService.get_risk_overview_stats()
+
+    @staticmethod
+    def category_breakdown():
+        return list(
+            Risk.objects.values("category__name")
+            .annotate(count=Count("id"))
+            .order_by("-count")
+        )

--- a/app/training/services.py
+++ b/app/training/services.py
@@ -1,0 +1,143 @@
+"""Training domain service entry points."""
+
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.db.models import Avg, Case, Count, F, FloatField, Q, Sum, Value, When
+from django.utils import timezone
+
+from .models import SecurityAwarenessCampaign, TrainingCategory, TrainingVideo, VideoView
+
+User = get_user_model()
+
+
+class TrainingAnalyticsService:
+    """Read-side analytics owned by the training domain."""
+
+    @staticmethod
+    def executive_summary():
+        total_views = VideoView.objects.count()
+        completed_views = VideoView.objects.filter(completed=True).count()
+        completion_rate = (
+            round((completed_views / total_views) * 100, 1) if total_views > 0 else 0
+        )
+
+        return {
+            "total_videos": TrainingVideo.objects.count(),
+            "total_views": total_views,
+            "unique_viewers": VideoView.objects.values("user").distinct().count(),
+            "completion_rate": completion_rate,
+            "active_campaigns": SecurityAwarenessCampaign.objects.filter(
+                is_active=True
+            ).count(),
+        }
+
+    @staticmethod
+    def dashboard_data(now=None):
+        today = now or timezone.now().date()
+        video_stats = {
+            "total_videos": TrainingVideo.objects.count(),
+            "total_views": VideoView.objects.count(),
+            "unique_viewers": VideoView.objects.values("user").distinct().count(),
+            "total_watch_time": VideoView.objects.aggregate(
+                total_minutes=Sum("duration_watched")
+            )["total_minutes"]
+            or 0,
+            "avg_completion_rate": VideoView.objects.aggregate(
+                avg_completion=Avg("completion_percentage")
+            )["avg_completion"]
+            or 0,
+        }
+
+        category_performance = list(
+            TrainingCategory.objects.annotate(
+                video_count=Count("videos"),
+                total_views=Count("videos__views"),
+                avg_completion=Avg("videos__views__completion_percentage"),
+                total_watch_time=Sum("videos__views__duration_watched"),
+            )
+            .values(
+                "name",
+                "description",
+                "color",
+                "video_count",
+                "total_views",
+                "avg_completion",
+                "total_watch_time",
+            )
+            .order_by("-total_views")
+        )
+
+        user_engagement = {
+            "active_learners_30_days": VideoView.objects.filter(
+                started_at__date__gte=today - timedelta(days=30)
+            )
+            .values("user")
+            .distinct()
+            .count(),
+            "completed_videos_30_days": VideoView.objects.filter(
+                started_at__date__gte=today - timedelta(days=30),
+                completed=True,
+            ).count(),
+            "avg_videos_per_user": VideoView.objects.values("user")
+            .annotate(video_count=Count("video", distinct=True))
+            .aggregate(avg=Avg("video_count"))["avg"]
+            or 0,
+            "completion_rate": TrainingAnalyticsService.completion_rate_percentage(),
+        }
+
+        campaign_stats = list(
+            SecurityAwarenessCampaign.objects.annotate(
+                engagement_rate=Case(
+                    When(total_sent=0, then=Value(0.0)),
+                    default=F("total_opened") * 100.0 / F("total_sent"),
+                    output_field=FloatField(),
+                ),
+                click_through_rate=Case(
+                    When(total_opened=0, then=Value(0.0)),
+                    default=F("total_clicked") * 100.0 / F("total_opened"),
+                    output_field=FloatField(),
+                ),
+            ).values(
+                "name",
+                "send_frequency",
+                "total_sent",
+                "total_opened",
+                "total_clicked",
+                "engagement_rate",
+                "click_through_rate",
+                "is_active",
+            )
+        )
+
+        training_trends = list(
+            VideoView.objects.filter(started_at__date__gte=today - timedelta(days=180))
+            .extra(select={"month": "DATE_TRUNC('month', started_at)"})
+            .values("month")
+            .annotate(
+                views=Count("id"),
+                unique_users=Count("user", distinct=True),
+                completions=Count("id", filter=Q(completed=True)),
+                avg_completion_percentage=Avg("completion_percentage"),
+            )
+            .order_by("month")
+        )
+
+        return {
+            "video_engagement": video_stats,
+            "category_performance": category_performance,
+            "user_engagement": user_engagement,
+            "campaign_analytics": campaign_stats,
+            "training_trends": training_trends,
+            "generated_at": today.isoformat(),
+        }
+
+    @staticmethod
+    def training_gap_count():
+        return User.objects.exclude(video_views__completed=True).count()
+
+    @staticmethod
+    def completion_rate_percentage():
+        total_views = VideoView.objects.count()
+        completed_views = VideoView.objects.filter(completed=True).count()
+        return round((completed_views / total_views) * 100, 1) if total_views > 0 else 0

--- a/app/vendors/services.py
+++ b/app/vendors/services.py
@@ -1,0 +1,162 @@
+"""Vendor domain service entry points."""
+
+from datetime import timedelta
+
+from django.db.models import Avg, Count, Q, Sum
+from django.utils import timezone
+
+from .models import Vendor, VendorTask
+
+
+OPEN_VENDOR_TASK_STATUSES = ["pending", "in_progress"]
+
+
+class VendorAnalyticsService:
+    """Read-side analytics owned by the vendor domain."""
+
+    @staticmethod
+    def executive_summary(now=None):
+        today = now or timezone.now().date()
+        return {
+            "total_vendors": Vendor.objects.count(),
+            "active_vendors": Vendor.objects.filter(status="active").count(),
+            "high_risk_vendors": Vendor.objects.filter(risk_level="high").count(),
+            "contracts_expiring_soon": Vendor.objects.filter(
+                contract_end_date__lte=today + timedelta(days=90),
+                contract_end_date__gte=today,
+                status="active",
+            ).count(),
+            "overdue_tasks": VendorAnalyticsService.overdue_task_count(today),
+        }
+
+    @staticmethod
+    def dashboard_data(now=None):
+        today = now or timezone.now().date()
+        vendor_risk_stats = {
+            "risk_distribution": dict(
+                Vendor.objects.values("risk_level")
+                .annotate(count=Count("id"))
+                .values_list("risk_level", "count")
+            ),
+            "total_vendors": Vendor.objects.count(),
+            "active_vendors": Vendor.objects.filter(status="active").count(),
+            "total_annual_spend": Vendor.objects.aggregate(
+                total=Sum("annual_spend")
+            )["total"]
+            or 0,
+            "avg_performance_score": Vendor.objects.aggregate(
+                avg=Avg("performance_score")
+            )["avg"]
+            or 0,
+        }
+
+        contract_metrics = {
+            "expiring_30_days": Vendor.objects.filter(
+                contract_end_date__lte=today + timedelta(days=30),
+                contract_end_date__gte=today,
+                status="active",
+            ).count(),
+            "expiring_90_days": Vendor.objects.filter(
+                contract_end_date__lte=today + timedelta(days=90),
+                contract_end_date__gte=today,
+                status="active",
+            ).count(),
+            "expired_contracts": Vendor.objects.filter(
+                contract_end_date__lt=today,
+                status="active",
+            ).count(),
+            "renewals_needed": Vendor.objects.filter(
+                contract_end_date__lte=today + timedelta(days=180),
+                contract_end_date__gte=today,
+                status="active",
+            ).count(),
+        }
+
+        task_analytics = {
+            "total_tasks": VendorTask.objects.count(),
+            "overdue_tasks": VendorAnalyticsService.overdue_task_count(today),
+            "due_this_week": VendorTask.objects.filter(
+                due_date__gte=today,
+                due_date__lte=today + timedelta(days=7),
+                status__in=OPEN_VENDOR_TASK_STATUSES,
+            ).count(),
+            "task_type_distribution": dict(
+                VendorTask.objects.values("task_type")
+                .annotate(count=Count("id"))
+                .values_list("task_type", "count")
+            ),
+            "completion_rate": VendorAnalyticsService.task_completion_rate(),
+        }
+
+        top_vendors = list(
+            Vendor.objects.values(
+                "name",
+                "risk_level",
+                "annual_spend",
+                "performance_score",
+                "contract_end_date",
+                "status",
+            ).order_by("-annual_spend")[:10]
+        )
+
+        high_risk_vendors = list(
+            Vendor.objects.filter(risk_level="high")
+            .values("name", "annual_spend", "performance_score", "contract_end_date")
+            .annotate(
+                open_tasks=Count(
+                    "tasks",
+                    filter=Q(tasks__status__in=OPEN_VENDOR_TASK_STATUSES),
+                )
+            )
+            .order_by("-annual_spend")
+        )
+
+        return {
+            "vendor_risk_statistics": vendor_risk_stats,
+            "contract_management": contract_metrics,
+            "task_analytics": task_analytics,
+            "top_vendors": top_vendors,
+            "high_risk_vendors": high_risk_vendors,
+            "generated_at": today.isoformat(),
+        }
+
+    @staticmethod
+    def overdue_task_count(now=None):
+        today = now or timezone.now().date()
+        return VendorTask.objects.filter(
+            due_date__lt=today,
+            status__in=OPEN_VENDOR_TASK_STATUSES,
+        ).count()
+
+    @staticmethod
+    def high_or_critical_vendor_count():
+        return Vendor.objects.filter(risk_level__in=["high", "critical"]).count()
+
+    @staticmethod
+    def high_risk_assessment_correlation():
+        return list(
+            Vendor.objects.filter(risk_level="high")
+            .values("name", "annual_spend")
+            .annotate(
+                assessment_count=Count(
+                    "services",
+                    filter=Q(services__risk_assessment_completed=True),
+                )
+            )
+        )
+
+    @staticmethod
+    def task_completion_rate():
+        total_tasks = VendorTask.objects.count()
+        completed_tasks = VendorTask.objects.filter(status="completed").count()
+        return round((completed_tasks / total_tasks) * 100, 1) if total_tasks > 0 else 0
+
+    @staticmethod
+    def assessment_coverage_percentage():
+        return (
+            Vendor.objects.filter(services__risk_assessment_completed=True)
+            .distinct()
+            .count()
+            / max(Vendor.objects.count(), 1)
+            * 100
+        )


### PR DESCRIPTION
Closes #87.\n\nFollow-up logged: #194 for the remaining production cross-domain imports in exports, calendarhub, vuln and operator metrics.\n\n## Summary\n- Add domain-owned analytics service entry points in catalogs, risk, vendors, policies and training.\n- Refactor analytics.services into orchestration only, removing direct imports from cross-domain model modules.\n- Fix existing analytics query assumptions while moving them: catalogue reverse names, policy distribution acknowledgment state, training view timestamps, and numeric control maturity/effectiveness aggregation.\n- Add a static boundary regression test and a database-backed dashboard smoke test for CI.\n\n## Verification\n- ruff check app\n- PYTHONPATH=app python -m py_compile app/analytics/services.py app/analytics/test_service_boundaries.py app/catalogs/services.py app/policies/services.py app/risk/services.py app/training/services.py app/vendors/services.py\n- PYTHONPATH=app POSTGRES_DB=grc_test POSTGRES_USER=grc POSTGRES_PASSWORD=grc POSTGRES_HOST=localhost POSTGRES_PORT=5432 SECRET_KEY=test-secret-key DJANGO_SETTINGS_MODULE=app.settings.test CELERY_BROKER_URL=redis://localhost:6379/0 CELERY_RESULT_BACKEND=redis://localhost:6379/1 python manage.py check\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=app POSTGRES_DB=grc_test POSTGRES_USER=grc POSTGRES_PASSWORD=grc POSTGRES_HOST=localhost POSTGRES_PORT=5432 SECRET_KEY=test-secret-key DJANGO_SETTINGS_MODULE=app.settings.test CELERY_BROKER_URL=redis://localhost:6379/0 CELERY_RESULT_BACKEND=redis://localhost:6379/1 python -m pytest -p django app/analytics/test_service_boundaries.py::test_analytics_services_do_not_import_cross_domain_models_directly -q -o addopts=''\n- Metadata check for the new reverse relation names via manage.py shell\n- git diff --check\n\nLocal note: the DB-backed smoke test is committed for CI, but local execution could not complete because no localhost Postgres server is running.