### PR TITLE
chore: clean frontend lint annotations

### DIFF
--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useEffect, useState } from 'react'
-import { Card, Row, Col, Typography, Spin, message, Tabs, Space, Divider } from 'antd'
+import { Card, Row, Col, Typography, Spin, message, Tabs, Space } from 'antd'
 import {
   BarChartOutlined,
   DashboardOutlined,
@@ -12,7 +12,6 @@ import {
   TrophyOutlined,
   RiseOutlined
 } from '@ant-design/icons'
-import { api } from '@/lib/api'
 import {
   KPICard,
   ComplianceKPICard,
@@ -20,8 +19,6 @@ import {
   VendorKPICard,
   PolicyKPICard
 } from '@/components/ui'
-import { StatusTag, AssessmentStatusTag, RiskStatusTag } from '@/components/ui/StatusTag'
-import { PriorityTag } from '@/components/ui'
 import { EmptyState } from '@/components/ui/EmptyState'
 
 const { Title, Text, Paragraph } = Typography

--- a/frontend/src/app/assessments/create/page.tsx
+++ b/frontend/src/app/assessments/create/page.tsx
@@ -5,10 +5,10 @@ import { Card, Typography, Space, Button, Row, Col, Form, Input, Select, DatePic
 import { SafetyOutlined, ArrowLeftOutlined, CheckOutlined } from '@ant-design/icons'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Breadcrumb } from '@/components/ui'
-import { riskService } from '@/lib/services/riskService'
-import { vendorService } from '@/lib/services/vendorService'
+import { riskService, type Risk } from '@/lib/services/riskService'
+import { vendorService, type Vendor } from '@/lib/services/vendorService'
 
-const { Title, Text, Paragraph } = Typography
+const { Title, Text } = Typography
 const { TextArea } = Input
 const { Step } = Steps
 
@@ -17,8 +17,8 @@ export default function CreateAssessmentPage() {
   const [form] = Form.useForm()
   const [loading, setLoading] = useState(false)
   const [assessmentType, setAssessmentType] = useState<'risk' | 'vendor' | 'security'>('risk')
-  const [risks, setRisks] = useState([])
-  const [vendors, setVendors] = useState([])
+  const [risks, setRisks] = useState<Risk[]>([])
+  const [vendors, setVendors] = useState<Vendor[]>([])
   const router = useRouter()
   const searchParams = useSearchParams()
 
@@ -60,7 +60,7 @@ export default function CreateAssessmentPage() {
     setCurrentStep(currentStep - 1)
   }
 
-  const handleSubmit = async (values: any) => {
+  const handleSubmit = async () => {
     try {
       setLoading(true)
 
@@ -194,7 +194,7 @@ export default function CreateAssessmentPage() {
                 placeholder="Select related risks (optional)"
                 allowClear
               >
-                {risks.map((risk: any) => (
+                {risks.map((risk) => (
                   <Select.Option key={risk.id} value={risk.id}>
                     {risk.risk_id} - {risk.title}
                   </Select.Option>
@@ -214,7 +214,7 @@ export default function CreateAssessmentPage() {
                 placeholder="Select vendors to assess"
                 allowClear
               >
-                {vendors.map((vendor: any) => (
+                {vendors.map((vendor) => (
                   <Select.Option key={vendor.id} value={vendor.id}>
                     {vendor.name} ({vendor.vendor_id})
                   </Select.Option>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,13 +6,10 @@ import {
   SafetyOutlined,
   TeamOutlined,
   FileTextOutlined,
-  RiseOutlined,
-  WarningOutlined,
   EyeOutlined,
   PlusOutlined
 } from "@ant-design/icons";
 import {
-  KPICard,
   ComplianceKPICard,
   RiskKPICard,
   PolicyKPICard,
@@ -20,12 +17,30 @@ import {
   StatusTag,
   AssessmentStatusTag,
   RiskStatusTag,
-  EmptyState,
   Loading
 } from "@/components/ui";
 import { useTheme } from "@/theme";
-import { riskService } from "@/lib/services/riskService";
+import { riskService, type Risk } from "@/lib/services/riskService";
 import { analyticsService } from "@/lib/services/analyticsService";
+
+interface RecentAssessment {
+  name: string
+  framework: string
+  progress: number
+  status: string
+  dueDate: string
+}
+
+interface DashboardData {
+  recentAssessments: RecentAssessment[]
+  recentRisks: Risk[]
+  analytics: {
+    totalAssessments: number
+    activeRisks: number
+    totalVendors: number
+    complianceScore: number
+  }
+}
 
 const { Title, Text } = Typography;
 
@@ -35,7 +50,7 @@ export default function DashboardPage() {
 
   // State management
   const [loading, setLoading] = useState(true);
-  const [dashboardData, setDashboardData] = useState({
+  const [dashboardData, setDashboardData] = useState<DashboardData>({
     recentAssessments: [],
     recentRisks: [],
     analytics: {
@@ -103,7 +118,7 @@ export default function DashboardPage() {
       title: 'Assessment',
       dataIndex: 'name',
       key: 'name',
-      render: (text: string, record: any) => (
+      render: (text: string, record: RecentAssessment) => (
         <div>
           <Text strong style={{ display: 'block' }}>{text}</Text>
           <Text type="secondary" style={{ fontSize: 12 }}>
@@ -151,7 +166,7 @@ export default function DashboardPage() {
       title: 'Risk',
       dataIndex: 'title',
       key: 'title',
-      render: (text: string, record: any) => (
+      render: (text: string, record: Risk) => (
         <div>
           <Text strong style={{ display: 'block' }}>{text}</Text>
           <Text type="secondary" style={{ fontSize: 12 }}>

--- a/frontend/src/app/policies/dashboard/page.tsx
+++ b/frontend/src/app/policies/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import {
   Card,
   Row,
@@ -26,7 +26,6 @@ import {
   CheckCircleOutlined,
   ClockCircleOutlined,
   ExclamationCircleOutlined,
-  SearchOutlined,
   ReloadOutlined,
   TrophyOutlined,
   WarningOutlined
@@ -79,10 +78,6 @@ export default function PolicyDashboardPage() {
     fetchDashboardData()
   }, [])
 
-  useEffect(() => {
-    filterAndSortData()
-  }, [dashboardData, searchTerm, filterStatus, sortBy])
-
   const fetchDashboardData = async () => {
     try {
       setLoading(true)
@@ -96,7 +91,7 @@ export default function PolicyDashboardPage() {
     }
   }
 
-  const filterAndSortData = () => {
+  const filterAndSortData = useCallback(() => {
     let filtered = [...dashboardData]
 
     // Apply search filter
@@ -133,7 +128,11 @@ export default function PolicyDashboardPage() {
     })
 
     setFilteredData(filtered)
-  }
+  }, [dashboardData, filterStatus, searchTerm, sortBy])
+
+  useEffect(() => {
+    filterAndSortData()
+  }, [filterAndSortData])
 
   const getOverallStats = () => {
     if (dashboardData.length === 0) {
@@ -184,7 +183,7 @@ export default function PolicyDashboardPage() {
       title: 'Policy',
       dataIndex: 'policy',
       key: 'policy',
-      render: (policy: any) => (
+      render: (policy: PolicyStats['policy']) => (
         <div>
           <Text strong>{policy.title}</Text>
           <br />
@@ -203,7 +202,7 @@ export default function PolicyDashboardPage() {
       title: 'Acknowledgment Rate',
       dataIndex: 'stats',
       key: 'rate',
-      render: (stats: any) => (
+      render: (stats: PolicyStats['stats']) => (
         <div>
           <Progress
             percent={stats.acknowledgment_rate}
@@ -219,7 +218,7 @@ export default function PolicyDashboardPage() {
       title: 'Stats',
       dataIndex: 'stats',
       key: 'stats',
-      render: (stats: any) => (
+      render: (stats: PolicyStats['stats']) => (
         <Space direction="vertical">
           <Text>
             <CheckCircleOutlined style={{ color: '#52c41a' }} /> {stats.total_acknowledged} / {stats.total_distributed}
@@ -239,9 +238,9 @@ export default function PolicyDashboardPage() {
       title: 'Pending Users',
       dataIndex: 'pending_users',
       key: 'pending_users',
-      render: (pending_users: any[]) => (
+      render: (pending_users: PolicyStats['pending_users']) => (
         <div>
-          {pending_users.slice(0, 3).map((user, index) => (
+          {pending_users.slice(0, 3).map((user) => (
             <Tag key={user.id}>
               {user.first_name} {user.last_name}
               {user.reminder_count > 0 && (

--- a/frontend/src/app/policies/page.tsx
+++ b/frontend/src/app/policies/page.tsx
@@ -2,8 +2,8 @@
 
 import React, { useEffect, useState } from 'react'
 import { Card, Row, Col, Typography, Button, Empty, Spin, message, Badge, Tag } from 'antd'
-import { FileTextOutlined, CheckCircleOutlined, ClockCircleOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
-import { api } from '@/lib/api'
+import { FileTextOutlined, CheckCircleOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
+import { api, getErrorMessage } from '@/lib/api'
 import { useTheme } from '@/theme'
 
 const { Title, Text, Paragraph } = Typography
@@ -120,10 +120,9 @@ export default function PoliciesPage() {
 
       // Remove the acknowledged policy from the list
       setPolicies(prev => prev.filter(p => p.policy.id !== policyId))
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Failed to acknowledge policy:', error)
-      const errorMsg = error.response?.data?.error || 'Failed to acknowledge policy'
-      message.error(errorMsg)
+      message.error(getErrorMessage(error) || 'Failed to acknowledge policy')
     } finally {
       setAcknowledging(null)
     }

--- a/frontend/src/app/risk/[id]/page.tsx
+++ b/frontend/src/app/risk/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useCallback, useState, useEffect } from 'react'
 import { Card, Typography, Space, Button, Row, Col, Descriptions, Tag, Progress, Divider, message, Modal, Form, Input, Select } from 'antd'
 import { SafetyOutlined, EditOutlined, DeleteOutlined, ArrowLeftOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
 import { useRouter, useParams } from 'next/navigation'
@@ -18,7 +18,7 @@ export default function RiskDetailPage() {
   const params = useParams()
 
   // Fetch risk details
-  const fetchRisk = async () => {
+  const fetchRisk = useCallback(async () => {
     try {
       setLoading(true)
       const data = await riskService.getRisk(params.id as string)
@@ -32,11 +32,11 @@ export default function RiskDetailPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [editForm, params.id, router])
 
   useEffect(() => {
     fetchRisk()
-  }, [params.id])
+  }, [fetchRisk])
 
   // Handle edit risk
   const handleEditRisk = () => {
@@ -44,7 +44,7 @@ export default function RiskDetailPage() {
   }
 
   // Handle edit form submission
-  const handleEditSubmit = async (values: any) => {
+  const handleEditSubmit = async (values: Partial<Risk>) => {
     try {
       const updatedRisk = await riskService.updateRisk(params.id as string, values)
       setRisk(updatedRisk)

--- a/frontend/src/app/risk/mitigation/page.tsx
+++ b/frontend/src/app/risk/mitigation/page.tsx
@@ -2,15 +2,49 @@
 
 import React, { useState } from 'react'
 import { Card, Typography, Space, Button, Table, Tag, Progress, Row, Col, Modal, Descriptions, Divider, Form, Input, Select, message } from 'antd'
-import { SafetyOutlined, ArrowLeftOutlined, CheckCircleOutlined, ClockCircleOutlined, EyeOutlined, EditOutlined } from '@ant-design/icons'
+import { SafetyOutlined, ArrowLeftOutlined, CheckCircleOutlined, EyeOutlined, EditOutlined } from '@ant-design/icons'
 import { useRouter } from 'next/navigation'
 import { Breadcrumb, StatusTag, PriorityTag } from '@/components/ui'
 
 const { Title, Text } = Typography
 
+interface MitigationAction {
+  task: string
+  status: string
+  dueDate: string
+}
+
+interface MitigationPlan {
+  id: number
+  riskId: string
+  riskTitle: string
+  strategy: string
+  status: string
+  owner: string
+  ownerEmail: string
+  progress: number
+  dueDate: string
+  priority: string
+  description: string
+  riskLevel: string
+  impact: number
+  likelihood: number
+  category: string
+  treatmentPlan: string
+  currentControls: string
+  actions: MitigationAction[]
+}
+
+interface MitigationFormValues {
+  treatmentPlan: string
+  currentControls?: string
+  progress: number
+  status: string
+}
+
 export default function RiskMitigationPage() {
   const router = useRouter()
-  const [selectedRisk, setSelectedRisk] = useState<any>(null)
+  const [selectedRisk, setSelectedRisk] = useState<MitigationPlan | null>(null)
   const [isViewModalVisible, setIsViewModalVisible] = useState(false)
   const [isEditModalVisible, setIsEditModalVisible] = useState(false)
   const [editForm] = Form.useForm()
@@ -72,7 +106,7 @@ export default function RiskMitigationPage() {
       title: 'Risk ID',
       dataIndex: 'riskId',
       key: 'riskId',
-      render: (text: string, record: any) => (
+      render: (text: string, record: MitigationPlan) => (
         <Button
           type="link"
           style={{ padding: 0, height: 'auto' }}
@@ -127,7 +161,7 @@ export default function RiskMitigationPage() {
     {
       title: 'Actions',
       key: 'actions',
-      render: (record: any) => (
+      render: (record: MitigationPlan) => (
         <Space>
           <Button
             icon={<EyeOutlined />}
@@ -226,7 +260,9 @@ export default function RiskMitigationPage() {
         footer={[
           <Button key="edit" type="primary" onClick={() => {
             setIsViewModalVisible(false)
-            handleEditRisk(selectedRisk)
+            if (selectedRisk) {
+              handleEditRisk(selectedRisk)
+            }
           }}>
             Edit Mitigation Plan
           </Button>,
@@ -278,7 +314,7 @@ export default function RiskMitigationPage() {
             <Table
 
               pagination={false}
-              dataSource={selectedRisk.actions.map((action: any, index: number) => ({ ...action, key: index }))}
+              dataSource={selectedRisk.actions.map((action, index) => ({ ...action, key: index }))}
               columns={[
                 { title: 'Task', dataIndex: 'task', key: 'task' },
                 {
@@ -371,12 +407,12 @@ export default function RiskMitigationPage() {
   )
 
   // Handler functions
-  function handleViewRisk(record: any) {
+  function handleViewRisk(record: MitigationPlan) {
     setSelectedRisk(record)
     setIsViewModalVisible(true)
   }
 
-  function handleEditRisk(record: any) {
+  function handleEditRisk(record: MitigationPlan) {
     setSelectedRisk(record)
     editForm.setFieldsValue({
       treatmentPlan: record.treatmentPlan,
@@ -387,7 +423,7 @@ export default function RiskMitigationPage() {
     setIsEditModalVisible(true)
   }
 
-  function handleEditSubmit(values: any) {
+  function handleEditSubmit(values: MitigationFormValues) {
     try {
       // Simulate API call
       console.log('Updating mitigation plan:', { ...selectedRisk, ...values })

--- a/frontend/src/app/risk/page.tsx
+++ b/frontend/src/app/risk/page.tsx
@@ -1,18 +1,42 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
-import { Card, Typography, Space, Button, Row, Col, Statistic, Progress, Table, Tag, message, Modal, Form, Input, Select } from 'antd'
+import React, { useCallback, useRef, useState, useEffect } from 'react'
+import { Card, Typography, Space, Button, Row, Col, Progress, Table, Tag, message, Modal, Form, Input, Select } from 'antd'
 import { SafetyOutlined, PlusOutlined, ExclamationCircleOutlined, WarningOutlined, CheckCircleOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { useRouter } from 'next/navigation'
 import { Breadcrumb, KPICard, RiskKPICard, StatusTag, PriorityTag, Loading, ExportButton, FilterPanel } from '@/components/ui'
-import { riskService, type Risk, type RiskCategory } from '@/lib/services/riskService'
+import { riskService, type Risk, type RiskCategory, type RiskFilters } from '@/lib/services/riskService'
 
 const { Title, Text } = Typography
+
+interface RiskAnalytics {
+  totalRisks: number
+  highRiskItems: number
+  overdueActions: number
+  avgRiskScore: number
+  riskTrend: number
+}
+
+interface ChoiceOption {
+  value: string
+  label: string
+}
+
+interface RiskChoices {
+  risk_levels?: ChoiceOption[]
+  status_choices?: ChoiceOption[]
+  treatment_strategies?: ChoiceOption[]
+}
+
+type FilterValue = string | string[] | null | undefined
+type FilterValues = Record<string, FilterValue>
+type PaginationConfig = { current?: number; pageSize?: number }
 
 export default function RiskPage() {
   const [loading, setLoading] = useState(true)
   const [riskData, setRiskData] = useState<Risk[]>([])
-  const [analytics, setAnalytics] = useState<any>({
+  const riskDataRef = useRef<Risk[]>([])
+  const [analytics, setAnalytics] = useState<RiskAnalytics>({
     totalRisks: 0,
     highRiskItems: 0,
     overdueActions: 0,
@@ -20,16 +44,22 @@ export default function RiskPage() {
     riskTrend: 0
   })
   const [pagination, setPagination] = useState({ current: 1, pageSize: 10, total: 0 })
-  const [filters, setFilters] = useState<any>({})
-  const [dynamicFilters, setDynamicFilters] = useState<any[]>([])
+  const [filters, setFilters] = useState<FilterValues>({})
+  const [dynamicFilters, setDynamicFilters] = useState<Array<{
+    key: string
+    label: string
+    type: 'multiSelect' | 'search'
+    options?: ChoiceOption[]
+    placeholder?: string
+  }>>([])
   const [riskCategories, setRiskCategories] = useState<RiskCategory[]>([])
-  const [riskChoices, setRiskChoices] = useState<any>({})
+  const [riskChoices, setRiskChoices] = useState<RiskChoices>({})
   const [isAddRiskModalVisible, setIsAddRiskModalVisible] = useState(false)
   const [addRiskForm] = Form.useForm()
   const router = useRouter()
 
   // Fetch risks data
-  const fetchRisks = async (currentFilters = filters, page = 1, pageSize = 10) => {
+  const fetchRisks = useCallback(async (currentFilters: RiskFilters = {}, page = 1, pageSize = 10) => {
     try {
       setLoading(true)
       const response = await riskService.getRisks({
@@ -38,7 +68,9 @@ export default function RiskPage() {
         pageSize
       })
 
-      setRiskData(response.results || [])
+      const risks = response.results || []
+      riskDataRef.current = risks
+      setRiskData(risks)
       setPagination({
         current: page,
         pageSize,
@@ -48,36 +80,38 @@ export default function RiskPage() {
       message.error('Failed to load risk data. Using cached data.')
       console.error('Error fetching risks:', error)
       // Keep existing data if available
-      if (riskData.length === 0) {
+      setRiskData((previousRisks) => {
+        riskDataRef.current = previousRisks
         // Only show empty state if no data at all
-        setRiskData([])
-      }
+        return previousRisks.length === 0 ? [] : previousRisks
+      })
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
 
   // Fetch analytics
-  const fetchAnalytics = async () => {
+  const fetchAnalytics = useCallback(async () => {
     try {
       const data = await riskService.getRiskAnalytics()
       setAnalytics(data)
     } catch (error) {
       console.error('Error fetching analytics:', error)
+      const currentRisks = riskDataRef.current
       // Set default analytics if API fails
       setAnalytics({
-        totalRisks: riskData.length || 0,
-        highRiskItems: riskData.filter(r => r.risk_level === 'high' || r.risk_level === 'critical').length || 0,
+        totalRisks: currentRisks.length || 0,
+        highRiskItems: currentRisks.filter(r => r.risk_level === 'high' || r.risk_level === 'critical').length || 0,
         overdueActions: 0,
-        avgRiskScore: riskData.length ?
-          riskData.reduce((sum, r) => sum + (r.risk_score || 0), 0) / riskData.length : 0,
+        avgRiskScore: currentRisks.length ?
+          currentRisks.reduce((sum, r) => sum + (r.risk_score || 0), 0) / currentRisks.length : 0,
         riskTrend: 0
       })
     }
-  }
+  }, [])
 
   // Fetch dynamic filter data
-  const fetchDynamicData = async () => {
+  const fetchDynamicData = useCallback(async () => {
     try {
       const [categories, choices] = await Promise.all([
         riskService.getRiskCategories(),
@@ -128,23 +162,23 @@ export default function RiskPage() {
         }
       ])
     }
-  }
+  }, [])
 
   useEffect(() => {
     fetchRisks()
     fetchAnalytics()
     fetchDynamicData()
-  }, [])
+  }, [fetchAnalytics, fetchDynamicData, fetchRisks])
 
   // Handle filter changes
-  const handleFilterChange = (newFilters: any) => {
+  const handleFilterChange = (newFilters: FilterValues) => {
     setFilters(newFilters)
-    fetchRisks(newFilters, 1, pagination.pageSize)
+    fetchRisks(newFilters as RiskFilters, 1, pagination.pageSize)
   }
 
   // Handle table pagination/sorting
-  const handleTableChange = (paginationConfig: any) => {
-    fetchRisks(filters, paginationConfig.current, paginationConfig.pageSize)
+  const handleTableChange = (paginationConfig: PaginationConfig) => {
+    fetchRisks(filters as RiskFilters, paginationConfig.current, paginationConfig.pageSize)
   }
 
   // Handle Add Risk
@@ -163,7 +197,7 @@ export default function RiskPage() {
   }
 
   // Handle Add Risk form submission
-  const handleAddRiskSubmit = async (values: any) => {
+  const handleAddRiskSubmit = async (values: Partial<Risk>) => {
     try {
       await riskService.createRisk(values)
       message.success('Risk created successfully')
@@ -207,7 +241,7 @@ export default function RiskPage() {
       title: 'Category',
       dataIndex: 'category',
       key: 'category',
-      render: (category: any) => {
+      render: (category: RiskCategory | null) => {
         if (!category) return <Tag>Uncategorized</Tag>
         return <Tag color={category.color || 'default'}>{category.name}</Tag>
       }
@@ -228,7 +262,7 @@ export default function RiskPage() {
       title: 'Owner',
       dataIndex: 'risk_owner',
       key: 'risk_owner',
-      render: (owner: any) => {
+      render: (owner: Risk['risk_owner']) => {
         if (!owner) return <Text type="secondary">Unassigned</Text>
         return <Text>{owner.first_name} {owner.last_name}</Text>
       }
@@ -485,7 +519,7 @@ export default function RiskPage() {
                 label="Treatment Strategy"
               >
                 <Select placeholder="Select strategy">
-                  {riskChoices.treatment_strategies?.map((strategy: any) => (
+                  {riskChoices.treatment_strategies?.map((strategy) => (
                     <Select.Option key={strategy.value} value={strategy.value}>
                       {strategy.label}
                     </Select.Option>

--- a/frontend/src/app/training/page.tsx
+++ b/frontend/src/app/training/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react'
 import { Card, Row, Col, Typography, Button, Select, Input, Tag, Empty, Spin, message } from 'antd'
-import { PlayCircleOutlined, SearchOutlined, FilterOutlined, ClockCircleOutlined, UserOutlined } from '@ant-design/icons'
+import { PlayCircleOutlined, SearchOutlined, ClockCircleOutlined, UserOutlined } from '@ant-design/icons'
 import { api } from '@/lib/api'
 
 const { Title, Text, Paragraph } = Typography

--- a/frontend/src/app/training/video/[id]/page.tsx
+++ b/frontend/src/app/training/video/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useState, useRef } from 'react'
+import React, { useCallback, useEffect, useState, useRef } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { Card, Typography, Button, Tag, Row, Col, Progress, message, Spin } from 'antd'
 import {
@@ -43,42 +43,51 @@ export default function VideoPlayerPage() {
   const [loading, setLoading] = useState(true)
   const [watchProgress, setWatchProgress] = useState(0)
   const [isCompleted, setIsCompleted] = useState(false)
-  const [viewStartTime, setViewStartTime] = useState<Date | null>(null)
   const progressInterval = useRef<NodeJS.Timeout | null>(null)
+  const videoRef = useRef<TrainingVideo | null>(null)
+  const viewStartTimeRef = useRef<Date | null>(null)
+  const watchProgressRef = useRef(0)
+  const isCompletedRef = useRef(false)
 
   const videoId = params.id as string
 
-  useEffect(() => {
-    if (videoId) {
-      fetchVideo()
+  const trackVideoView = useCallback(async (completed: boolean) => {
+    const currentVideo = videoRef.current
+    const currentViewStartTime = viewStartTimeRef.current
+    if (!currentVideo || !currentViewStartTime) return
+
+    const durationWatched = Math.floor((new Date().getTime() - currentViewStartTime.getTime()) / 1000)
+
+    try {
+      await api.post(`/training/videos/${currentVideo.id}/track_view/`, {
+        duration_watched: durationWatched,
+        completed,
+        completion_percentage: watchProgressRef.current
+      })
+    } catch (error) {
+      console.error('Failed to track video view:', error)
     }
+  }, [])
 
-    return () => {
-      if (progressInterval.current) {
-        clearInterval(progressInterval.current)
-      }
-
-      // Track final view when component unmounts
-      if (video && viewStartTime) {
-        trackVideoView(false)
-      }
-    }
-  }, [videoId])
-
-  const fetchVideo = async () => {
+  const fetchVideo = useCallback(async () => {
     try {
       setLoading(true)
       const response = await api.get(`/training/videos/${videoId}/`)
-      setVideo(response.data)
-      setViewStartTime(new Date())
+      const fetchedVideo = response.data as TrainingVideo
+      const startedAt = new Date()
+      setVideo(fetchedVideo)
+      videoRef.current = fetchedVideo
+      viewStartTimeRef.current = startedAt
 
       // Start tracking progress every 10 seconds
       progressInterval.current = setInterval(() => {
         setWatchProgress(prev => {
           const newProgress = Math.min(prev + 10, 100)
+          watchProgressRef.current = newProgress
 
           // Mark as completed when reaching 80% or more
-          if (newProgress >= 80 && !isCompleted) {
+          if (newProgress >= 80 && !isCompletedRef.current) {
+            isCompletedRef.current = true
             setIsCompleted(true)
             trackVideoView(true)
           }
@@ -94,23 +103,24 @@ export default function VideoPlayerPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [router, trackVideoView, videoId])
 
-  const trackVideoView = async (completed: boolean) => {
-    if (!video || !viewStartTime) return
-
-    const durationWatched = Math.floor((new Date().getTime() - viewStartTime.getTime()) / 1000)
-
-    try {
-      await api.post(`/training/videos/${video.id}/track_view/`, {
-        duration_watched: durationWatched,
-        completed,
-        completion_percentage: watchProgress
-      })
-    } catch (error) {
-      console.error('Failed to track video view:', error)
+  useEffect(() => {
+    if (videoId) {
+      fetchVideo()
     }
-  }
+
+    return () => {
+      if (progressInterval.current) {
+        clearInterval(progressInterval.current)
+      }
+
+      // Track final view when component unmounts
+      if (videoRef.current && viewStartTimeRef.current) {
+        trackVideoView(false)
+      }
+    }
+  }, [fetchVideo, trackVideoView, videoId])
 
   const handleVideoLoad = () => {
     // Called when video iframe loads
@@ -118,7 +128,9 @@ export default function VideoPlayerPage() {
   }
 
   const handleMarkComplete = () => {
+    isCompletedRef.current = true
     setIsCompleted(true)
+    watchProgressRef.current = 100
     setWatchProgress(100)
     trackVideoView(true)
     message.success('Video marked as completed!')

--- a/frontend/src/app/vendors/[id]/page.tsx
+++ b/frontend/src/app/vendors/[id]/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
-import { Card, Typography, Space, Button, Row, Col, Descriptions, Tag, Progress, Divider, message, Modal, Form, Input, Select, Avatar } from 'antd'
-import { TeamOutlined, EditOutlined, DeleteOutlined, ArrowLeftOutlined, GlobalOutlined, MailOutlined, PhoneOutlined } from '@ant-design/icons'
+import React, { useCallback, useState, useEffect } from 'react'
+import { Card, Typography, Space, Button, Row, Col, Descriptions, Tag, Progress, Divider, message, Modal, Form, Input, Avatar } from 'antd'
+import { TeamOutlined, EditOutlined, DeleteOutlined, ArrowLeftOutlined, GlobalOutlined } from '@ant-design/icons'
 import { useRouter, useParams } from 'next/navigation'
 import { Breadcrumb, StatusTag, PriorityTag, Loading } from '@/components/ui'
 import { vendorService, type Vendor } from '@/lib/services/vendorService'
@@ -18,7 +18,7 @@ export default function VendorDetailPage() {
   const params = useParams()
 
   // Fetch vendor details
-  const fetchVendor = async () => {
+  const fetchVendor = useCallback(async () => {
     try {
       setLoading(true)
       const data = await vendorService.getVendor(params.id as string)
@@ -32,11 +32,11 @@ export default function VendorDetailPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [editForm, params.id, router])
 
   useEffect(() => {
     fetchVendor()
-  }, [params.id])
+  }, [fetchVendor])
 
   // Handle edit vendor
   const handleEditVendor = () => {
@@ -44,7 +44,7 @@ export default function VendorDetailPage() {
   }
 
   // Handle edit form submission
-  const handleEditSubmit = async (values: any) => {
+  const handleEditSubmit = async (values: Partial<Vendor>) => {
     try {
       const updatedVendor = await vendorService.updateVendor(params.id as string, values)
       setVendor(updatedVendor)

--- a/frontend/src/app/vendors/contracts/page.tsx
+++ b/frontend/src/app/vendors/contracts/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { Card, Typography, Space, Button, Table, Tag, Progress } from 'antd'
+import { Card, Typography, Space, Button, Table, Tag } from 'antd'
 import { TeamOutlined, ArrowLeftOutlined, ClockCircleOutlined, WarningOutlined } from '@ant-design/icons'
 import { useRouter } from 'next/navigation'
 import { Breadcrumb } from '@/components/ui'

--- a/frontend/src/app/vendors/page.tsx
+++ b/frontend/src/app/vendors/page.tsx
@@ -1,18 +1,41 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useCallback, useState, useEffect } from 'react'
 import { Card, Typography, Space, Button, Row, Col, Table, Tag, Progress, Avatar, message, Modal, Form, Input, Select } from 'antd'
 import { TeamOutlined, PlusOutlined, WarningOutlined, CheckCircleOutlined, ClockCircleOutlined } from '@ant-design/icons'
 import { useRouter } from 'next/navigation'
 import { Breadcrumb, VendorKPICard, KPICard, StatusTag, PriorityTag, Loading, ExportButton, FilterPanel } from '@/components/ui'
-import { vendorService, type Vendor, type VendorCategory } from '@/lib/services/vendorService'
+import { vendorService, type Vendor, type VendorCategory, type VendorFilters } from '@/lib/services/vendorService'
 
 const { Title, Text } = Typography
+
+interface VendorAnalytics {
+  totalVendors: number
+  contractsExpiring: number
+  highRiskVendors: number
+  avgPerformance: number
+  performanceTrend: number
+}
+
+interface ChoiceOption {
+  value: string
+  label: string
+}
+
+interface VendorChoices {
+  risk_level_choices?: ChoiceOption[]
+  status_choices?: ChoiceOption[]
+  vendor_type_choices?: ChoiceOption[]
+}
+
+type FilterValue = string | string[] | null | undefined
+type FilterValues = Record<string, FilterValue>
+type PaginationConfig = { current?: number; pageSize?: number }
 
 export default function VendorsPage() {
   const [loading, setLoading] = useState(true)
   const [vendorData, setVendorData] = useState<Vendor[]>([])
-  const [analytics, setAnalytics] = useState<any>({
+  const [analytics, setAnalytics] = useState<VendorAnalytics>({
     totalVendors: 0,
     contractsExpiring: 0,
     highRiskVendors: 0,
@@ -20,16 +43,22 @@ export default function VendorsPage() {
     performanceTrend: 0
   })
   const [pagination, setPagination] = useState({ current: 1, pageSize: 10, total: 0 })
-  const [filters, setFilters] = useState<any>({})
-  const [dynamicFilters, setDynamicFilters] = useState<any[]>([])
+  const [filters, setFilters] = useState<FilterValues>({})
+  const [dynamicFilters, setDynamicFilters] = useState<Array<{
+    key: string
+    label: string
+    type: 'multiSelect' | 'search'
+    options?: ChoiceOption[]
+    placeholder?: string
+  }>>([])
   const [vendorCategories, setVendorCategories] = useState<VendorCategory[]>([])
-  const [vendorChoices, setVendorChoices] = useState<any>({})
+  const [vendorChoices, setVendorChoices] = useState<VendorChoices>({})
   const [isAddVendorModalVisible, setIsAddVendorModalVisible] = useState(false)
   const [addVendorForm] = Form.useForm()
   const router = useRouter()
 
   // Fetch vendors data
-  const fetchVendors = async (currentFilters = filters, page = 1, pageSize = 10) => {
+  const fetchVendors = useCallback(async (currentFilters: VendorFilters = {}, page = 1, pageSize = 10) => {
     try {
       setLoading(true)
       const response = await vendorService.getVendors({
@@ -50,20 +79,20 @@ export default function VendorsPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
 
   // Fetch analytics
-  const fetchAnalytics = async () => {
+  const fetchAnalytics = useCallback(async () => {
     try {
       const data = await vendorService.getVendorAnalytics()
       setAnalytics(data)
     } catch (error) {
       console.error('Error fetching analytics:', error)
     }
-  }
+  }, [])
 
   // Fetch dynamic filter data
-  const fetchDynamicData = async () => {
+  const fetchDynamicData = useCallback(async () => {
     try {
       const [categories, choices] = await Promise.all([
         vendorService.getVendorCategories(),
@@ -120,23 +149,23 @@ export default function VendorsPage() {
         }
       ])
     }
-  }
+  }, [])
 
   useEffect(() => {
     fetchVendors()
     fetchAnalytics()
     fetchDynamicData()
-  }, [])
+  }, [fetchAnalytics, fetchDynamicData, fetchVendors])
 
   // Handle filter changes
-  const handleFilterChange = (newFilters: any) => {
+  const handleFilterChange = (newFilters: FilterValues) => {
     setFilters(newFilters)
-    fetchVendors(newFilters, 1, pagination.pageSize)
+    fetchVendors(newFilters as VendorFilters, 1, pagination.pageSize)
   }
 
   // Handle table pagination/sorting
-  const handleTableChange = (paginationConfig: any) => {
-    fetchVendors(filters, paginationConfig.current, paginationConfig.pageSize)
+  const handleTableChange = (paginationConfig: PaginationConfig) => {
+    fetchVendors(filters as VendorFilters, paginationConfig.current, paginationConfig.pageSize)
   }
 
   // Handle Add Vendor
@@ -155,7 +184,7 @@ export default function VendorsPage() {
   }
 
   // Handle Add Vendor form submission
-  const handleAddVendorSubmit = async (values: any) => {
+  const handleAddVendorSubmit = async (values: Partial<Vendor>) => {
     try {
       await vendorService.createVendor(values)
       message.success('Vendor created successfully')
@@ -275,7 +304,7 @@ export default function VendorsPage() {
       title: 'Owner',
       dataIndex: 'assigned_to',
       key: 'assigned_to',
-      render: (owner: any) => {
+      render: (owner: Vendor['assigned_to']) => {
         if (!owner) return <Text type="secondary">Unassigned</Text>
         return <Text>{owner.first_name} {owner.last_name}</Text>
       }
@@ -501,7 +530,7 @@ export default function VendorsPage() {
                 rules={[{ required: true, message: 'Please select vendor type' }]}
               >
                 <Select placeholder="Select vendor type">
-                  {vendorChoices.vendor_type_choices?.map((type: any) => (
+                  {vendorChoices.vendor_type_choices?.map((type) => (
                     <Select.Option key={type.value} value={type.value}>
                       {type.label}
                     </Select.Option>

--- a/frontend/src/components/ui/Breadcrumb.tsx
+++ b/frontend/src/components/ui/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { Breadcrumb as AntBreadcrumb, Typography } from 'antd'
+import { Breadcrumb as AntBreadcrumb } from 'antd'
 import { HomeOutlined } from '@ant-design/icons'
 import Link from 'next/link'
 import { useTheme } from '@/theme'

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Empty, Button, Typography, Space } from "antd";
+import { Button, Typography, Space } from "antd";
 import {
   FileTextOutlined,
   PlusOutlined,
@@ -158,14 +158,17 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
       {image ? (
         <div style={{ marginBottom: 24 }}>
           {typeof image === 'string' ? (
-            <img
-              src={image}
-              alt="Empty state"
-              style={{
-                maxWidth: size === 'small' ? 120 : size === 'large' ? 200 : 160,
-                opacity: 0.8
-              }}
-            />
+            <>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={image}
+                alt="Empty state"
+                style={{
+                  maxWidth: size === 'small' ? 120 : size === 'large' ? 200 : 160,
+                  opacity: 0.8
+                }}
+              />
+            </>
           ) : (
             image
           )}

--- a/frontend/src/components/ui/ExportButton.tsx
+++ b/frontend/src/components/ui/ExportButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { Button, Dropdown, Space, message } from 'antd'
+import { Button, Dropdown, message } from 'antd'
 import { DownloadOutlined, FileExcelOutlined, FilePdfOutlined, FileTextOutlined } from '@ant-design/icons'
 import { useTheme } from '@/theme'
 

--- a/frontend/src/components/ui/FilterPanel.tsx
+++ b/frontend/src/components/ui/FilterPanel.tsx
@@ -2,11 +2,16 @@
 
 import React, { useState } from 'react'
 import { Card, Space, Select, DatePicker, Input, Button, Row, Col, Collapse, Badge } from 'antd'
-import { FilterOutlined, ClearOutlined, SearchOutlined } from '@ant-design/icons'
+import { FilterOutlined, ClearOutlined } from '@ant-design/icons'
+import type { Dayjs } from 'dayjs'
 import { useTheme } from '@/theme'
 
 const { Option } = Select
 const { RangePicker } = DatePicker
+
+type DateRangeValue = [Dayjs | null, Dayjs | null]
+type FilterValue = string | string[] | DateRangeValue | null | undefined
+type FilterValues = Record<string, FilterValue>
 
 interface FilterOption {
   key: string
@@ -18,7 +23,7 @@ interface FilterOption {
 
 interface FilterPanelProps {
   filters: FilterOption[]
-  onFilterChange?: (filters: Record<string, any>) => void
+  onFilterChange?: (filters: FilterValues) => void
   onClear?: () => void
   defaultOpen?: boolean
   showCount?: boolean
@@ -35,10 +40,10 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
 }) => {
   const { mode } = useTheme()
   const isDark = mode === 'dark'
-  const [filterValues, setFilterValues] = useState<Record<string, any>>({})
+  const [filterValues, setFilterValues] = useState<FilterValues>({})
   const [isOpen, setIsOpen] = useState(defaultOpen)
 
-  const handleFilterChange = (key: string, value: any) => {
+  const handleFilterChange = (key: string, value: FilterValue) => {
     const newFilters = { ...filterValues, [key]: value }
 
     // Remove empty values
@@ -66,7 +71,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
             placeholder={filter.placeholder || `Select ${filter.label}`}
             style={{ width: '100%' }}
             allowClear
-            value={filterValues[filter.key]}
+            value={filterValues[filter.key] as string | undefined}
             onChange={(value) => handleFilterChange(filter.key, value)}
           >
             {filter.options?.map(option => (
@@ -84,7 +89,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
             placeholder={filter.placeholder || `Select ${filter.label}`}
             style={{ width: '100%' }}
             allowClear
-            value={filterValues[filter.key]}
+            value={filterValues[filter.key] as string[] | undefined}
             onChange={(value) => handleFilterChange(filter.key, value)}
           >
             {filter.options?.map(option => (
@@ -100,7 +105,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
           <Input.Search
             placeholder={filter.placeholder || `Search ${filter.label}`}
             allowClear
-            value={filterValues[filter.key]}
+            value={filterValues[filter.key] as string | undefined}
             onChange={(e) => handleFilterChange(filter.key, e.target.value)}
             onSearch={(value) => handleFilterChange(filter.key, value)}
           />
@@ -111,7 +116,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
           <Input
             placeholder={filter.placeholder || filter.label}
             allowClear
-            value={filterValues[filter.key]}
+            value={filterValues[filter.key] as string | undefined}
             onChange={(e) => handleFilterChange(filter.key, e.target.value)}
           />
         )
@@ -121,7 +126,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
           <RangePicker
             style={{ width: '100%' }}
             placeholder={['Start Date', 'End Date']}
-            value={filterValues[filter.key]}
+            value={filterValues[filter.key] as DateRangeValue | null | undefined}
             onChange={(dates) => handleFilterChange(filter.key, dates)}
           />
         )
@@ -150,7 +155,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
     children: (
       <>
         <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
-          {filters.map((filter, index) => (
+          {filters.map((filter) => (
             <Col
               key={filter.key}
               xs={24}

--- a/frontend/src/components/ui/KPICard.tsx
+++ b/frontend/src/components/ui/KPICard.tsx
@@ -3,9 +3,7 @@ import { Card, Statistic, Progress, Typography, Space } from "antd";
 import {
   ArrowUpOutlined,
   ArrowDownOutlined,
-  MinusOutlined,
   RiseOutlined,
-  FallOutlined
 } from "@ant-design/icons";
 import { useTheme } from "@/theme";
 

--- a/frontend/src/components/ui/SearchBar.tsx
+++ b/frontend/src/components/ui/SearchBar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { Input, AutoComplete, Space, Tag, Typography } from 'antd'
 import { SearchOutlined, FileTextOutlined, TeamOutlined, SafetyOutlined, CheckSquareOutlined, VideoCameraOutlined } from '@ant-design/icons'
 import { useTheme } from '@/theme'

--- a/frontend/src/components/ui/StatusTag.tsx
+++ b/frontend/src/components/ui/StatusTag.tsx
@@ -11,7 +11,6 @@ import {
   PlayCircleOutlined,
   PauseCircleOutlined
 } from "@ant-design/icons";
-import { useTheme } from "@/theme";
 
 // Status definitions for different contexts
 export const StatusConfigs = {
@@ -209,9 +208,6 @@ export const StatusTag: React.FC<StatusTagProps> = ({
   style,
   onClick
 }) => {
-  const { mode } = useTheme();
-  const isDark = mode === 'dark';
-
   const config = StatusConfigs[context]?.[status];
 
   if (!config) {

--- a/frontend/src/hooks/useMe.ts
+++ b/frontend/src/hooks/useMe.ts
@@ -1,6 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import api from "@/lib/api";
-
 // This is a placeholder. We'll need to implement the /api/me endpoint in Django.
 const fetchMe = async () => {
     // const { data } = await api.get("/auth/me/");

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,7 +17,7 @@ export class APIException extends Error {
   public data: APIError;
   public isAPIError = true;
 
-  constructor(status: number, data: APIError, originalError?: AxiosError) {
+  constructor(status: number, data: APIError) {
     const message = data.detail || data.message || data.non_field_errors?.[0] || 'An error occurred';
     super(message);
     this.name = 'APIException';
@@ -94,7 +94,7 @@ api.interceptors.response.use(
       }
       
       // Create structured API exception
-      const apiError = new APIException(status, data as APIError, err);
+      const apiError = new APIException(status, data as APIError);
       
       // Handle specific status codes
       switch (status) {
@@ -134,14 +134,14 @@ api.interceptors.response.use(
       console.error('Network error - check your connection');
       const networkError = new APIException(0, { 
         message: 'Network error - please check your connection and try again'
-      }, err);
+      });
       return Promise.reject(networkError);
     } else {
       // Request setup error
       console.error('Request setup error:', err.message);
       const setupError = new APIException(0, { 
         message: 'Request setup error - please try again'
-      }, err);
+      });
       return Promise.reject(setupError);
     }
   }


### PR DESCRIPTION
## Summary

Closes #200.

- Removes the current non-blocking frontend ESLint annotations from app pages and shared UI helpers.
- Replaces loose any usage with existing domain types or small local interfaces.
- Stabilises hook dependencies in risk/vendor detail pages, the policy dashboard, and training video tracking.
- Keeps the clean-up focused on frontend lint/type hygiene ahead of the larger ESLint 10 + jsdom 30 migration tracked in #233.

## Verification

- npm run lint
- npm run type-check
- npm run test
- npm run build
