### PR TITLE
Clean production OpenAPI schema diagnostics

### DIFF
--- a/app/analytics/views.py
+++ b/app/analytics/views.py
@@ -20,6 +20,8 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 import logging
 import mimetypes
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 
 from .services import CrossModuleAnalyticsService, AnalyticsReportGenerator
 from .models import AnalyticsReport, DashboardConfiguration
@@ -40,6 +42,15 @@ def _is_operator(user, tenant):
     )
 
 
+@extend_schema(
+    summary="Operator usage dashboard",
+    parameters=[
+        OpenApiParameter('days', OpenApiTypes.INT, OpenApiParameter.QUERY),
+        OpenApiParameter('export', OpenApiTypes.STR, OpenApiParameter.QUERY),
+    ],
+    responses={200: OpenApiTypes.OBJECT, 403: OpenApiResponse(description='Operator access required')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def operator_usage_dashboard(request):
@@ -74,6 +85,11 @@ def operator_usage_dashboard(request):
     return Response(dashboard)
 
 
+@extend_schema(
+    summary="Executive analytics dashboard",
+    responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate executive dashboard')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @cache_page(60 * 15)  # Cache for 15 minutes
@@ -95,6 +111,11 @@ def executive_dashboard(request):
         )
 
 
+@extend_schema(
+    summary="Compliance analytics dashboard",
+    responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate compliance dashboard')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @cache_page(60 * 10)  # Cache for 10 minutes
@@ -116,6 +137,11 @@ def compliance_dashboard(request):
         )
 
 
+@extend_schema(
+    summary="Vendor risk analytics dashboard",
+    responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate vendor dashboard')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @cache_page(60 * 10)  # Cache for 10 minutes
@@ -137,6 +163,11 @@ def vendor_risk_dashboard(request):
         )
 
 
+@extend_schema(
+    summary="Policy management analytics dashboard",
+    responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate policy dashboard')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @cache_page(60 * 10)  # Cache for 10 minutes
@@ -158,6 +189,11 @@ def policy_management_dashboard(request):
         )
 
 
+@extend_schema(
+    summary="Training effectiveness analytics dashboard",
+    responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate training dashboard')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @cache_page(60 * 10)  # Cache for 10 minutes
@@ -179,6 +215,11 @@ def training_effectiveness_dashboard(request):
         )
 
 
+@extend_schema(
+    summary="Integrated risk posture analytics",
+    responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate integrated risk analysis')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @require_advanced_reporting  # Premium feature
@@ -202,6 +243,11 @@ def integrated_risk_posture(request):
         )
 
 
+@extend_schema(
+    summary="Executive report analytics data",
+    responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate executive report')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @require_advanced_reporting  # Premium feature
@@ -225,6 +271,11 @@ def executive_report_data(request):
         )
 
 
+@extend_schema(
+    summary="Operational analytics dashboard",
+    responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate operational dashboard')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @cache_page(60 * 5)  # Cache for 5 minutes
@@ -246,6 +297,11 @@ def operational_dashboard(request):
         )
 
 
+@extend_schema(
+    summary="Analytics health check",
+    responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Analytics service unavailable')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def analytics_health_check(request):
@@ -287,6 +343,16 @@ def analytics_health_check(request):
         )
 
 
+@extend_schema(
+    summary="Create analytics report export",
+    request=OpenApiTypes.OBJECT,
+    responses={
+        202: OpenApiTypes.OBJECT,
+        400: OpenApiResponse(description='Invalid report export request'),
+        500: OpenApiResponse(description='Failed to create export job'),
+    },
+    tags=['Analytics'],
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def export_report(request):
@@ -356,6 +422,11 @@ def export_report(request):
         )
 
 
+@extend_schema(
+    summary="Get analytics report status",
+    responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to check report status')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def report_status(request, report_id):
@@ -409,6 +480,17 @@ def report_status(request, report_id):
         )
 
 
+@extend_schema(
+    summary="Download analytics report",
+    responses={
+        200: OpenApiResponse(description='Generated report file'),
+        400: OpenApiResponse(description='Report is not ready'),
+        404: OpenApiResponse(description='Report file not found'),
+        410: OpenApiResponse(description='Report has expired'),
+        500: OpenApiResponse(description='Failed to download report'),
+    },
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def download_report(request, report_id):
@@ -487,6 +569,12 @@ def download_report(request, report_id):
         )
 
 
+@extend_schema(
+    summary="List my analytics reports",
+    parameters=[OpenApiParameter('page', OpenApiTypes.INT, OpenApiParameter.QUERY)],
+    responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to fetch reports')},
+    tags=['Analytics'],
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def my_reports(request):
@@ -551,6 +639,12 @@ def my_reports(request):
         )
 
 
+@extend_schema(
+    summary="Delete analytics report",
+    request=None,
+    responses={200: OpenApiResponse(description='Report deleted successfully'), 500: OpenApiResponse(description='Failed to delete report')},
+    tags=['Analytics'],
+)
 @api_view(['DELETE'])
 @permission_classes([IsAuthenticated])
 def delete_report(request, report_id):
@@ -588,6 +682,12 @@ def delete_report(request, report_id):
         )
 
 
+@extend_schema(
+    summary="Refresh analytics cache",
+    request=None,
+    responses={202: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to refresh cache')},
+    tags=['Analytics'],
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 @require_advanced_reporting  # Premium feature

--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -324,10 +324,39 @@ SPECTACULAR_SETTINGS = {
 
     # Enum choices handling
     "ENUM_NAME_OVERRIDES": {
-        "StatusEnum": "catalogs.models.ControlAssessment.STATUS_CHOICES",
+        "AnalyticsExportStatusEnum": "exports.models.AssessmentReport.REPORT_STATUS",
+        "ControlAssessmentStatusEnum": "catalogs.models.ControlAssessment.STATUS_CHOICES",
+        "ControlEffectivenessRatingEnum": "catalogs.models.Control.EFFECTIVENESS_RATINGS",
+        "ControlEvidenceTypeEnum": "catalogs.models.ControlEvidence.EVIDENCE_TYPES",
+        "ControlStatusEnum": "catalogs.models.Control.STATUS_CHOICES",
+        "DataClassificationEnum": "vendors.models.VendorService.DATA_CLASSIFICATION_CHOICES",
+        "FrameworkStatusEnum": "catalogs.models.Framework.STATUS_CHOICES",
         "ImplementationStatusEnum": "catalogs.models.ControlAssessment.IMPLEMENTATION_STATUS_CHOICES",
-        "EvidenceTypeEnum": "catalogs.models.ControlEvidence.EVIDENCE_TYPES",
+        "KnowledgeArticleStatusEnum": "knowledge.models.KnowledgeArticle.STATUS_CHOICES",
+        "LimitOverrideStatusEnum": "core.models.LimitOverrideRequest.STATUS_CHOICES",
+        "LowMediumHighCriticalEnum": [
+            ("low", "Low"),
+            ("medium", "Medium"),
+            ("high", "High"),
+            ("critical", "Critical"),
+        ],
+        "PolicyApprovalStatusEnum": "policies.models.Policy.APPROVAL_STATUS_CHOICES",
+        "RiskActionEvidenceTypeEnum": "risk.models.RiskActionEvidence.EVIDENCE_TYPES",
+        "RiskActionNoteTypeEnum": [
+            ("progress", "Progress Update"),
+            ("issue", "Issue/Blocker"),
+            ("completion", "Completion"),
+            ("status_change", "Status Change"),
+            ("general", "General"),
+        ],
+        "RiskActionStatusEnum": "risk.models.RiskAction.STATUS_CHOICES",
+        "RiskActionTypeEnum": "risk.models.RiskAction.ACTION_TYPES",
+        "RiskStatusEnum": "risk.models.Risk.STATUS_CHOICES",
         "ReminderTypeEnum": "catalogs.models.AssessmentReminderLog.REMINDER_TYPES",
+        "RequirementApplicabilityEnum": "catalogs.models.ControlAssessment.APPLICABILITY_CHOICES",
+        "VendorStatusEnum": "vendors.models.Vendor.STATUS_CHOICES",
+        "VendorTaskPriorityEnum": "vendors.models.VendorTask.PRIORITY_CHOICES",
+        "VendorTaskStatusEnum": "vendors.models.VendorTask.STATUS_CHOICES",
     },
 
     # Error response schemas

--- a/app/assets/serializers.py
+++ b/app/assets/serializers.py
@@ -5,8 +5,8 @@ from .models import Asset, AssetReviewReminderLog
 
 class AssetListSerializer(serializers.ModelSerializer):
     owner_display = serializers.SerializerMethodField()
-    is_review_overdue = serializers.ReadOnlyField()
-    days_until_review = serializers.ReadOnlyField()
+    is_review_overdue = serializers.BooleanField(read_only=True)
+    days_until_review = serializers.IntegerField(read_only=True, allow_null=True)
     linked_risk_count = serializers.SerializerMethodField()
     linked_control_count = serializers.SerializerMethodField()
     linked_document_count = serializers.SerializerMethodField()
@@ -21,26 +21,26 @@ class AssetListSerializer(serializers.ModelSerializer):
             'linked_control_count', 'linked_document_count',
         ]
 
-    def get_owner_display(self, obj):
+    def get_owner_display(self, obj) -> str | None:
         if obj.owner:
             return obj.owner.get_full_name() or obj.owner.username
         return obj.owner_name
 
-    def get_linked_risk_count(self, obj):
+    def get_linked_risk_count(self, obj) -> int:
         return obj.linked_risks.count()
 
-    def get_linked_control_count(self, obj):
+    def get_linked_control_count(self, obj) -> int:
         return obj.linked_controls.count()
 
-    def get_linked_document_count(self, obj):
+    def get_linked_document_count(self, obj) -> int:
         return obj.linked_documents.count()
 
 
 class AssetDetailSerializer(serializers.ModelSerializer):
     owner_display = serializers.SerializerMethodField()
     created_by_username = serializers.CharField(source='created_by.username', read_only=True)
-    is_review_overdue = serializers.ReadOnlyField()
-    days_until_review = serializers.ReadOnlyField()
+    is_review_overdue = serializers.BooleanField(read_only=True)
+    days_until_review = serializers.IntegerField(read_only=True, allow_null=True)
 
     class Meta:
         model = Asset
@@ -63,7 +63,7 @@ class AssetDetailSerializer(serializers.ModelSerializer):
             'is_review_overdue', 'days_until_review',
         ]
 
-    def get_owner_display(self, obj):
+    def get_owner_display(self, obj) -> str | None:
         if obj.owner:
             return obj.owner.get_full_name() or obj.owner.username
         return obj.owner_name

--- a/app/authn/views.py
+++ b/app/authn/views.py
@@ -187,7 +187,14 @@ class LoginView(APIView):
 
 class LogoutView(APIView):
     permission_classes = [permissions.IsAuthenticated]
-    
+
+    @extend_schema(
+        summary="Logout current user",
+        description="End the current authenticated session.",
+        request=None,
+        responses={200: OpenApiResponse(description='Logout successful')},
+        tags=['Authentication'],
+    )
     def post(self, request):
         logout(request)
         return Response({
@@ -196,11 +203,22 @@ class LogoutView(APIView):
 
 class ProfileView(APIView):
     permission_classes = [permissions.IsAuthenticated]
-    
+
+    @extend_schema(
+        summary="Get authenticated user profile",
+        responses={200: UserProfileSerializer},
+        tags=['Authentication'],
+    )
     def get(self, request):
         serializer = UserProfileSerializer(request.user)
         return Response(serializer.data)
-    
+
+    @extend_schema(
+        summary="Update authenticated user profile",
+        request=UserProfileSerializer,
+        responses={200: UserProfileSerializer, 400: OpenApiResponse(description='Validation errors')},
+        tags=['Authentication'],
+    )
     def patch(self, request):
         serializer = UserProfileSerializer(request.user, data=request.data, partial=True)
         if serializer.is_valid():
@@ -210,7 +228,16 @@ class ProfileView(APIView):
 
 class ChangePasswordView(APIView):
     permission_classes = [permissions.IsAuthenticated]
-    
+
+    @extend_schema(
+        summary="Change authenticated user password",
+        request=ChangePasswordSerializer,
+        responses={
+            200: OpenApiResponse(description='Password changed successfully'),
+            400: OpenApiResponse(description='Validation errors'),
+        },
+        tags=['Authentication'],
+    )
     def post(self, request):
         serializer = ChangePasswordSerializer(data=request.data, context={'request': request})
         if serializer.is_valid():
@@ -240,7 +267,12 @@ def me(request):
 
 class TwoFactorStatusView(APIView):
     permission_classes = [permissions.IsAuthenticated]
-    
+
+    @extend_schema(
+        summary="Get two-factor authentication status",
+        responses={200: TwoFactorStatusSerializer},
+        tags=['Authentication'],
+    )
     def get(self, request):
         """Get comprehensive 2FA status for current user"""
         user = request.user
@@ -286,7 +318,16 @@ class TwoFactorStatusView(APIView):
 class EnableTwoFactorView(APIView):
     permission_classes = [permissions.IsAuthenticated]
     throttle_scope = "two_factor"
-    
+
+    @extend_schema(
+        summary="Enable two-factor authentication",
+        request=EnableTwoFactorSerializer,
+        responses={
+            200: OpenApiResponse(description='Two-factor authentication method enabled'),
+            400: OpenApiResponse(description='Validation errors'),
+        },
+        tags=['Authentication'],
+    )
     def post(self, request):
         """Enable 2FA for current user - supports email, TOTP, and push"""
         serializer = EnableTwoFactorSerializer(data=request.data, context={'request': request})
@@ -363,7 +404,16 @@ class EnableTwoFactorView(APIView):
 class DisableTwoFactorView(APIView):
     permission_classes = [permissions.IsAuthenticated]
     throttle_scope = "two_factor"
-    
+
+    @extend_schema(
+        summary="Disable two-factor authentication",
+        request=DisableTwoFactorSerializer,
+        responses={
+            200: OpenApiResponse(description='Two-factor authentication method disabled'),
+            400: OpenApiResponse(description='Validation errors'),
+        },
+        tags=['Authentication'],
+    )
     def post(self, request):
         """Disable 2FA methods for current user"""
         serializer = DisableTwoFactorSerializer(data=request.data, context={'request': request})
@@ -443,7 +493,17 @@ class VerifyOTPView(APIView):
 class SetupTOTPView(APIView):
     permission_classes = [permissions.IsAuthenticated]
     throttle_scope = "two_factor"
-    
+
+    @extend_schema(
+        summary="Set up TOTP two-factor authentication",
+        request=SetupTOTPSerializer,
+        responses={
+            200: OpenApiResponse(description='TOTP setup data returned'),
+            400: OpenApiResponse(description='Validation errors'),
+            500: OpenApiResponse(description='Failed to set up TOTP device'),
+        },
+        tags=['Authentication'],
+    )
     def post(self, request):
         """Generate QR code for TOTP setup using enhanced pyotp service"""
         serializer = SetupTOTPSerializer(data=request.data, context={'request': request})
@@ -481,7 +541,16 @@ class SetupTOTPView(APIView):
 class ConfirmTOTPView(APIView):
     permission_classes = [permissions.IsAuthenticated]
     throttle_scope = "two_factor"
-    
+
+    @extend_schema(
+        summary="Confirm TOTP setup",
+        request=ConfirmTOTPSerializer,
+        responses={
+            200: OpenApiResponse(description='TOTP two-factor authentication enabled'),
+            400: OpenApiResponse(description='Invalid verification code or validation errors'),
+        },
+        tags=['Authentication'],
+    )
     def post(self, request):
         """Confirm TOTP setup with verification code using enhanced service"""
         serializer = ConfirmTOTPSerializer(data=request.data)
@@ -508,7 +577,16 @@ class ConfirmTOTPView(APIView):
 class RegisterPushDeviceView(APIView):
     permission_classes = [permissions.IsAuthenticated]
     throttle_scope = "two_factor"
-    
+
+    @extend_schema(
+        summary="Register push notification device",
+        request=RegisterPushDeviceSerializer,
+        responses={
+            201: OpenApiResponse(description='Push notification device registered'),
+            400: OpenApiResponse(description='Validation errors'),
+        },
+        tags=['Authentication'],
+    )
     def post(self, request):
         """Register a new push notification device"""
         serializer = RegisterPushDeviceSerializer(data=request.data)
@@ -538,7 +616,16 @@ class RegisterPushDeviceView(APIView):
 class ApprovePushChallengeView(APIView):
     permission_classes = [permissions.AllowAny]
     throttle_scope = "two_factor"
-    
+
+    @extend_schema(
+        summary="Approve or deny push challenge",
+        request=ApprovePushChallengeSerializer,
+        responses={
+            200: OpenApiResponse(description='Push challenge decision accepted'),
+            400: OpenApiResponse(description='Validation errors'),
+        },
+        tags=['Authentication'],
+    )
     def post(self, request):
         """Approve or deny a push notification challenge"""
         serializer = ApprovePushChallengeSerializer(data=request.data)
@@ -560,7 +647,12 @@ class ApprovePushChallengeView(APIView):
 
 class UserPreferencesView(APIView):
     permission_classes = [permissions.IsAuthenticated]
-    
+
+    @extend_schema(
+        summary="Get two-factor preferences",
+        responses={200: UserPreferencesSerializer},
+        tags=['Authentication'],
+    )
     def get(self, request):
         """Get user 2FA preferences"""
         try:
@@ -575,7 +667,16 @@ class UserPreferencesView(APIView):
                 'require_2fa_for_sensitive_actions': True,
                 'remember_device_days': 30
             })
-    
+
+    @extend_schema(
+        summary="Update two-factor preferences",
+        request=UserPreferencesSerializer,
+        responses={
+            200: OpenApiResponse(description='Preferences updated successfully'),
+            400: OpenApiResponse(description='Validation errors'),
+        },
+        tags=['Authentication'],
+    )
     def post(self, request):
         """Update user 2FA preferences"""
         preferences, created = UserDevicePreference.objects.get_or_create(

--- a/app/billing/serializers.py
+++ b/app/billing/serializers.py
@@ -1,6 +1,14 @@
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
 from core.models import Plan, Subscription
 from .entitlements import get_module_catalog
+
+
+class ModuleCatalogItemSerializer(serializers.Serializer):
+    key = serializers.CharField()
+    name = serializers.CharField()
+    description = serializers.CharField()
+    enabled = serializers.BooleanField(required=False)
 
 
 class PlanSerializer(serializers.ModelSerializer):
@@ -16,6 +24,7 @@ class PlanSerializer(serializers.ModelSerializer):
             'included_modules', 'module_catalog',
         ]
 
+    @extend_schema_field(ModuleCatalogItemSerializer(many=True))
     def get_module_catalog(self, obj):
         return get_module_catalog(obj.get_included_modules())
 
@@ -41,8 +50,10 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             'is_grandfathered', 'created_at', 'updated_at'
         ]
 
+    @extend_schema_field(serializers.ListField(child=serializers.CharField()))
     def get_enabled_module_keys(self, obj):
         return obj.get_enabled_modules()
 
+    @extend_schema_field(ModuleCatalogItemSerializer(many=True))
     def get_module_catalog(self, obj):
         return get_module_catalog(obj.get_enabled_modules())

--- a/app/billing/views.py
+++ b/app/billing/views.py
@@ -91,6 +91,7 @@ class BillingViewSet(viewsets.ViewSet):
     - Access billing history and invoices
     - Cancel or modify subscriptions
     """
+    serializer_class = SubscriptionSerializer
     permission_classes = [IsAuthenticated]
     
     @extend_schema(
@@ -235,6 +236,17 @@ class BillingViewSet(viewsets.ViewSet):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
     
+    @extend_schema(
+        summary="Cancel current subscription",
+        description="Cancel the current tenant subscription at the end of the active billing period.",
+        request=None,
+        responses={
+            200: OpenApiResponse(description='Subscription cancellation scheduled'),
+            404: OpenApiResponse(description='No active subscription found'),
+            500: OpenApiResponse(description='Failed to cancel subscription'),
+        },
+        tags=['Billing'],
+    )
     @action(detail=False, methods=['post'])
     def cancel_subscription(self, request):
         """Cancel current subscription."""
@@ -274,6 +286,16 @@ class BillingViewSet(viewsets.ViewSet):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
     
+    @extend_schema(
+        summary="Create billing portal session",
+        description="Create a Stripe customer portal session for billing self-service.",
+        responses={
+            200: OpenApiResponse(description='Billing portal session created'),
+            404: OpenApiResponse(description='No billing information found'),
+            500: OpenApiResponse(description='Failed to create billing portal session'),
+        },
+        tags=['Billing'],
+    )
     @action(detail=False, methods=['get'])
     def billing_portal(self, request):
         """Create Stripe billing portal session."""

--- a/app/calendarhub/views.py
+++ b/app/calendarhub/views.py
@@ -71,6 +71,7 @@ class CalendarEventViewSet(viewsets.ModelViewSet):
 
 
 class CalendarNotificationPreferenceViewSet(viewsets.ViewSet):
+    serializer_class = CalendarNotificationPreferenceSerializer
     permission_classes = [IsAuthenticated]
 
     def list(self, request):

--- a/app/catalogs/serializers.py
+++ b/app/catalogs/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
 from .models import (
     Framework, Clause, Control, ControlEvidence, FrameworkMapping,
     ControlAssessment, AssessmentEvidence, TemplateDocument
@@ -10,9 +11,9 @@ User = get_user_model()
 
 class FrameworkListSerializer(serializers.ModelSerializer):
     """Lightweight serializer for framework listings."""
-    clause_count = serializers.ReadOnlyField()
-    control_count = serializers.ReadOnlyField()
-    is_active = serializers.ReadOnlyField()
+    clause_count = serializers.IntegerField(read_only=True)
+    control_count = serializers.IntegerField(read_only=True)
+    is_active = serializers.BooleanField(read_only=True)
     
     class Meta:
         model = Framework
@@ -25,9 +26,9 @@ class FrameworkListSerializer(serializers.ModelSerializer):
 
 class FrameworkDetailSerializer(serializers.ModelSerializer):
     """Detailed framework serializer with full information."""
-    clause_count = serializers.ReadOnlyField()
-    control_count = serializers.ReadOnlyField()
-    is_active = serializers.ReadOnlyField()
+    clause_count = serializers.IntegerField(read_only=True)
+    control_count = serializers.IntegerField(read_only=True)
+    is_active = serializers.BooleanField(read_only=True)
     created_by_username = serializers.CharField(source='created_by.username', read_only=True)
     
     class Meta:
@@ -50,8 +51,8 @@ class ClauseListSerializer(serializers.ModelSerializer):
     """Lightweight serializer for clause listings."""
     framework_name = serializers.CharField(source='framework.name', read_only=True)
     framework_short_name = serializers.CharField(source='framework.short_name', read_only=True)
-    control_count = serializers.ReadOnlyField()
-    full_clause_id = serializers.ReadOnlyField()
+    control_count = serializers.IntegerField(read_only=True)
+    full_clause_id = serializers.CharField(read_only=True)
     
     class Meta:
         model = Clause
@@ -66,8 +67,8 @@ class ClauseDetailSerializer(serializers.ModelSerializer):
     """Detailed clause serializer with full information."""
     framework_name = serializers.CharField(source='framework.name', read_only=True)
     framework_short_name = serializers.CharField(source='framework.short_name', read_only=True)
-    control_count = serializers.ReadOnlyField()
-    full_clause_id = serializers.ReadOnlyField()
+    control_count = serializers.IntegerField(read_only=True)
+    full_clause_id = serializers.CharField(read_only=True)
     parent_clause_id = serializers.CharField(source='parent_clause.clause_id', read_only=True)
     subclauses = serializers.SerializerMethodField()
     
@@ -86,9 +87,16 @@ class ClauseDetailSerializer(serializers.ModelSerializer):
             'created_at', 'updated_at'
         ]
     
+    @extend_schema_field(ClauseListSerializer(many=True))
     def get_subclauses(self, obj):
         subclauses = obj.subclauses.all()
         return ClauseListSerializer(subclauses, many=True).data
+
+
+class FrameworkCoverageItemSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    short_name = serializers.CharField()
+    name = serializers.CharField()
 
 
 class ControlEvidenceSerializer(serializers.ModelSerializer):
@@ -162,8 +170,8 @@ class ControlListSerializer(serializers.ModelSerializer):
     """Lightweight serializer for control listings."""
     control_owner_name = serializers.CharField(source='control_owner.get_full_name', read_only=True)
     framework_coverage = serializers.SerializerMethodField()
-    is_active = serializers.ReadOnlyField()
-    needs_testing = serializers.ReadOnlyField()
+    is_active = serializers.BooleanField(read_only=True)
+    needs_testing = serializers.BooleanField(read_only=True)
     clause_count = serializers.SerializerMethodField()
     
     class Meta:
@@ -175,11 +183,12 @@ class ControlListSerializer(serializers.ModelSerializer):
             'framework_coverage', 'clause_count', 'version'
         ]
     
+    @extend_schema_field(FrameworkCoverageItemSerializer(many=True))
     def get_framework_coverage(self, obj):
         frameworks = obj.framework_coverage
         return [{'id': f.id, 'short_name': f.short_name, 'name': f.name} for f in frameworks]
     
-    def get_clause_count(self, obj):
+    def get_clause_count(self, obj) -> int:
         return obj.clauses.count()
 
 
@@ -188,8 +197,8 @@ class ControlDetailSerializer(serializers.ModelSerializer):
     control_owner_name = serializers.CharField(source='control_owner.get_full_name', read_only=True)
     created_by_username = serializers.CharField(source='created_by.username', read_only=True)
     framework_coverage = serializers.SerializerMethodField()
-    is_active = serializers.ReadOnlyField()
-    needs_testing = serializers.ReadOnlyField()
+    is_active = serializers.BooleanField(read_only=True)
+    needs_testing = serializers.BooleanField(read_only=True)
     evidence = ControlEvidenceSerializer(many=True, read_only=True)
     clauses_detail = ClauseListSerializer(source='clauses', many=True, read_only=True)
     template_documents = TemplateDocumentSummarySerializer(many=True, read_only=True)
@@ -211,6 +220,7 @@ class ControlDetailSerializer(serializers.ModelSerializer):
             'created_at', 'updated_at'
         ]
     
+    @extend_schema_field(FrameworkCoverageItemSerializer(many=True))
     def get_framework_coverage(self, obj):
         frameworks = obj.framework_coverage
         return [{'id': f.id, 'short_name': f.short_name, 'name': f.name} for f in frameworks]
@@ -321,26 +331,26 @@ class ControlAssessmentListSerializer(serializers.ModelSerializer):
     framework_version = serializers.SerializerMethodField()
     assigned_to_name = serializers.CharField(source='assigned_to.get_full_name', read_only=True)
     reviewer_name = serializers.CharField(source='reviewer.get_full_name', read_only=True)
-    is_overdue = serializers.ReadOnlyField()
-    is_complete = serializers.ReadOnlyField()
-    completion_percentage = serializers.ReadOnlyField()
-    days_until_due = serializers.ReadOnlyField()
+    is_overdue = serializers.BooleanField(read_only=True)
+    is_complete = serializers.BooleanField(read_only=True)
+    completion_percentage = serializers.FloatField(read_only=True)
+    days_until_due = serializers.IntegerField(read_only=True, allow_null=True)
     evidence_count = serializers.SerializerMethodField()
     has_primary_evidence = serializers.SerializerMethodField()
     
-    def get_evidence_count(self, obj):
+    def get_evidence_count(self, obj) -> int:
         """Get count of evidence linked to this assessment."""
         return obj.evidence_links.count()
     
-    def get_has_primary_evidence(self, obj):
+    def get_has_primary_evidence(self, obj) -> bool:
         """Check if assessment has primary evidence."""
         return obj.evidence_links.filter(is_primary_evidence=True).exists()
 
-    def get_framework_name(self, obj):
+    def get_framework_name(self, obj) -> str:
         framework = obj.framework or self._first_control_framework(obj)
         return framework.name if framework else ''
 
-    def get_framework_version(self, obj):
+    def get_framework_version(self, obj) -> str:
         framework = obj.framework or self._first_control_framework(obj)
         return framework.version if framework else ''
 
@@ -371,10 +381,10 @@ class ControlAssessmentDetailSerializer(serializers.ModelSerializer):
     created_by_username = serializers.CharField(source='created_by.username', read_only=True)
     
     # Computed properties
-    is_overdue = serializers.ReadOnlyField()
-    is_complete = serializers.ReadOnlyField()
-    completion_percentage = serializers.ReadOnlyField()
-    days_until_due = serializers.ReadOnlyField()
+    is_overdue = serializers.BooleanField(read_only=True)
+    is_complete = serializers.BooleanField(read_only=True)
+    completion_percentage = serializers.FloatField(read_only=True)
+    days_until_due = serializers.IntegerField(read_only=True, allow_null=True)
     
     # Related evidence
     evidence_count = serializers.SerializerMethodField()
@@ -402,9 +412,10 @@ class ControlAssessmentDetailSerializer(serializers.ModelSerializer):
             'change_log', 'created_at', 'updated_at'
         ]
     
-    def get_evidence_count(self, obj):
+    def get_evidence_count(self, obj) -> int:
         return obj.evidence_links.count()
     
+    @extend_schema_field(ControlEvidenceSerializer(allow_null=True))
     def get_primary_evidence(self, obj):
         primary_evidence = obj.evidence_links.filter(is_primary_evidence=True)
         if primary_evidence.exists():

--- a/app/compliance/serializers.py
+++ b/app/compliance/serializers.py
@@ -56,7 +56,7 @@ class RegulatoryRequirementSerializer(serializers.ModelSerializer):
 class NonConformitySerializer(serializers.ModelSerializer):
     owner_username = serializers.CharField(source='owner.username', read_only=True)
     raised_by_username = serializers.CharField(source='raised_by.username', read_only=True)
-    is_overdue = serializers.ReadOnlyField()
+    is_overdue = serializers.BooleanField(read_only=True)
 
     class Meta:
         model = NonConformity

--- a/app/core/serializers.py
+++ b/app/core/serializers.py
@@ -11,8 +11,8 @@ class DocumentSerializer(serializers.ModelSerializer):
     Serializer for document uploads with file validation and metadata.
     """
     uploaded_by = serializers.StringRelatedField(read_only=True)
-    file_url = serializers.ReadOnlyField()
-    file_name = serializers.ReadOnlyField()
+    file_url = serializers.URLField(read_only=True, allow_null=True)
+    file_name = serializers.CharField(read_only=True)
     
     class Meta:
         model = Document
@@ -55,7 +55,7 @@ class DocumentListSerializer(serializers.ModelSerializer):
     Simplified serializer for document listings.
     """
     uploaded_by = serializers.StringRelatedField(read_only=True)
-    file_name = serializers.ReadOnlyField()
+    file_name = serializers.CharField(read_only=True)
     
     class Meta:
         model = Document

--- a/app/exports/serializers.py
+++ b/app/exports/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
 from catalogs.models import Framework, ControlAssessment
 from core.serializers import DocumentSerializer
 from .models import AssessmentReport, TenantDataExport
@@ -178,6 +179,7 @@ class TenantDataExportSerializer(serializers.ModelSerializer):
             'coverage_manifest',
         ]
 
+    @extend_schema_field(serializers.URLField(allow_null=True))
     def get_download_url(self, obj):
         if obj.status != 'completed' or not obj.generated_file_id:
             return None

--- a/app/exports/views.py
+++ b/app/exports/views.py
@@ -117,6 +117,8 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
     
     def get_queryset(self):
         """Return reports for the current user's tenant."""
+        if getattr(self, 'swagger_fake_view', False):
+            return AssessmentReport.objects.none()
         return AssessmentReport.objects.filter(
             requested_by=self.request.user
         ).select_related('framework', 'requested_by', 'generated_file')
@@ -472,6 +474,8 @@ class TenantDataExportViewSet(viewsets.ModelViewSet):
     http_method_names = ['get', 'post', 'delete', 'head', 'options']
 
     def get_queryset(self):
+        if getattr(self, 'swagger_fake_view', False):
+            return TenantDataExport.objects.none()
         return TenantDataExport.objects.filter(
             requested_by=self.request.user
         ).select_related('requested_by', 'generated_file')

--- a/app/policies/serializers.py
+++ b/app/policies/serializers.py
@@ -5,6 +5,7 @@ Comprehensive serialization for policy management, versioning, and acknowledgmen
 """
 
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from .models import (
@@ -21,6 +22,7 @@ class UserBasicSerializer(serializers.ModelSerializer):
     full_name = serializers.CharField(read_only=True)
 
     class Meta:
+        ref_name = 'PolicyUserBasic'
         model = User
         fields = ['id', 'email', 'first_name', 'last_name', 'full_name']
         read_only_fields = ['id', 'email', 'first_name', 'last_name', 'full_name']
@@ -39,7 +41,7 @@ class PolicyCategorySerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ['id', 'created_at', 'updated_at']
 
-    def get_policies_count(self, obj):
+    def get_policies_count(self, obj) -> int:
         """Get count of policies in this category."""
         return obj.policies.filter(status__in=['approved', 'under_review']).count()
 
@@ -95,11 +97,11 @@ class PolicyListSerializer(serializers.ModelSerializer):
             'is_due_for_review', 'created_at', 'updated_at'
         ]
 
-    def get_versions_count(self, obj):
+    def get_versions_count(self, obj) -> int:
         """Get count of versions for this policy."""
         return obj.versions.count()
 
-    def get_acknowledgment_count(self, obj):
+    def get_acknowledgment_count(self, obj) -> int:
         """Get count of acknowledgments for current version."""
         current_version = obj.current_version
         if current_version:
@@ -137,7 +139,7 @@ class PolicyVersionDetailSerializer(serializers.ModelSerializer):
             'is_current', 'is_expired', 'acknowledgments_count', 'created_at'
         ]
 
-    def get_acknowledgments_count(self, obj):
+    def get_acknowledgments_count(self, obj) -> int:
         """Get count of acknowledgments for this version."""
         return obj.acknowledgments.count()
 
@@ -206,6 +208,20 @@ class PolicyDetailSerializer(serializers.ModelSerializer):
             'is_due_for_review', 'acknowledgment_stats', 'created_at', 'updated_at'
         ]
 
+    @extend_schema_field({
+        'type': 'object',
+        'properties': {
+            'total_acknowledgments': {'type': 'integer'},
+            'total_distributions': {'type': 'integer'},
+            'pending_acknowledgments': {'type': 'integer'},
+            'acknowledgment_rate': {'type': 'number', 'format': 'float'},
+        },
+        'required': [
+            'total_acknowledgments',
+            'pending_acknowledgments',
+            'acknowledgment_rate',
+        ],
+    })
     def get_acknowledgment_stats(self, obj):
         """Get acknowledgment statistics for current version."""
         current_version = obj.current_version

--- a/app/risk/serializers.py
+++ b/app/risk/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from .models import (
@@ -23,7 +24,7 @@ class RiskCategorySerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ['created_at', 'updated_at']
     
-    def get_risk_count(self, obj):
+    def get_risk_count(self, obj) -> int:
         """Get count of risks in this category."""
         return obj.risks.count()
 
@@ -412,6 +413,7 @@ class RiskActionEvidenceSerializer(serializers.ModelSerializer):
             'validated_by', 'validated_at', 'validation_notes'
         ]
 
+    @extend_schema_field(serializers.URLField(allow_null=True))
     def get_file_url(self, obj):
         """Get absolute URL for uploaded file."""
         if obj.file:
@@ -452,6 +454,17 @@ class RiskActionListSerializer(serializers.ModelSerializer):
             'action_id', 'days_until_due', 'is_overdue', 'is_due_soon',
             'created_at', 'updated_at', 'completed_date'
         ]
+
+
+class RiskActionRiskSummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    risk_id = serializers.CharField()
+    title = serializers.CharField()
+    risk_level = serializers.CharField()
+    risk_level_display = serializers.CharField()
+    status = serializers.CharField()
+    status_display = serializers.CharField()
+    risk_owner = serializers.CharField(allow_null=True)
 
 
 class RiskActionDetailSerializer(serializers.ModelSerializer):
@@ -495,6 +508,7 @@ class RiskActionDetailSerializer(serializers.ModelSerializer):
             'created_at', 'updated_at', 'created_by', 'completed_date'
         ]
 
+    @extend_schema_field(RiskActionRiskSummarySerializer)
     def get_risk_summary(self, obj):
         """Get summary information about the related risk."""
         return {

--- a/app/risk/views.py
+++ b/app/risk/views.py
@@ -1273,11 +1273,12 @@ class RiskActionReminderConfigurationViewSet(viewsets.ModelViewSet):
 
 
 @extend_schema_view(
-    list=extend_schema(
+    dashboard=extend_schema(
         summary="Risk Analytics Dashboard",
         description="Access comprehensive risk analytics, trends, and reporting data for management dashboards and executive reporting.",
         responses={
             200: OpenApiResponse(
+                response=OpenApiTypes.OBJECT,
                 description="Risk analytics data",
                 examples=[
                     OpenApiExample(
@@ -1328,9 +1329,9 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
     All endpoints return comprehensive analytics optimized for dashboard consumption
     with real-time calculations and historical trend analysis.
     """
-    
+    serializer_class = RiskSummarySerializer
     permission_classes = [permissions.IsAuthenticated]
-    
+
     @action(detail=False, methods=['get'])
     def dashboard(self, request):
         """
@@ -1351,7 +1352,12 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
                 {'error': f'Failed to generate dashboard data: {str(e)}'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
-    
+
+    @extend_schema(
+        summary="Risk overview analytics",
+        responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate risk overview')},
+        tags=['Risk Analytics'],
+    )
     @action(detail=False, methods=['get'])
     def risk_overview(self, request):
         """
@@ -1371,7 +1377,12 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
                 {'error': f'Failed to generate risk overview: {str(e)}'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
-    
+
+    @extend_schema(
+        summary="Risk action overview analytics",
+        responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate action overview')},
+        tags=['Risk Analytics'],
+    )
     @action(detail=False, methods=['get'])
     def action_overview(self, request):
         """
@@ -1391,7 +1402,12 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
                 {'error': f'Failed to generate action overview: {str(e)}'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
-    
+
+    @extend_schema(
+        summary="Risk heat map analytics",
+        responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate heat map')},
+        tags=['Risk Analytics'],
+    )
     @action(detail=False, methods=['get'])
     def heat_map(self, request):
         """
@@ -1411,7 +1427,17 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
                 {'error': f'Failed to generate heat map: {str(e)}'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
-    
+
+    @extend_schema(
+        summary="Risk trend analytics",
+        parameters=[OpenApiParameter('days', OpenApiTypes.INT, OpenApiParameter.QUERY)],
+        responses={
+            200: OpenApiTypes.OBJECT,
+            400: OpenApiResponse(description='Invalid days parameter'),
+            500: OpenApiResponse(description='Failed to generate trend analysis'),
+        },
+        tags=['Risk Analytics'],
+    )
     @action(detail=False, methods=['get'])
     def trends(self, request):
         """
@@ -1442,7 +1468,12 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
                 {'error': f'Failed to generate trend analysis: {str(e)}'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
-    
+
+    @extend_schema(
+        summary="Risk action progress analytics",
+        responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate progress analysis')},
+        tags=['Risk Analytics'],
+    )
     @action(detail=False, methods=['get'])
     def action_progress(self, request):
         """
@@ -1462,7 +1493,12 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
                 {'error': f'Failed to generate progress analysis: {str(e)}'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
-    
+
+    @extend_schema(
+        summary="Executive risk summary analytics",
+        responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate executive summary')},
+        tags=['Risk Analytics'],
+    )
     @action(detail=False, methods=['get'])
     def executive_summary(self, request):
         """
@@ -1483,7 +1519,12 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
                 {'error': f'Failed to generate executive summary: {str(e)}'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
-    
+
+    @extend_schema(
+        summary="Risk-control integration analytics",
+        responses={200: OpenApiTypes.OBJECT, 500: OpenApiResponse(description='Failed to generate control integration analysis')},
+        tags=['Risk Analytics'],
+    )
     @action(detail=False, methods=['get'])
     def control_integration(self, request):
         """
@@ -1504,7 +1545,17 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
                 {'error': f'Failed to generate control integration analysis: {str(e)}'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
-    
+
+    @extend_schema(
+        summary="Risk category analytics",
+        parameters=[OpenApiParameter('category_id', OpenApiTypes.INT, OpenApiParameter.QUERY)],
+        responses={
+            200: OpenApiTypes.OBJECT,
+            400: OpenApiResponse(description='Invalid category_id parameter'),
+            500: OpenApiResponse(description='Failed to generate category analysis'),
+        },
+        tags=['Risk Analytics'],
+    )
     @action(detail=False, methods=['get'])
     def category_analysis(self, request):
         """

--- a/app/schema.yml
+++ b/app/schema.yml
@@ -82,46 +82,86 @@ paths:
   /api/auth/logout/:
     post:
       operationId: auth_logout_create
+      description: End the current authenticated session.
+      summary: Logout current user
       tags:
-      - auth
+      - Authentication
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          description: Logout successful
   /api/auth/profile/:
     get:
       operationId: auth_profile_retrieve
+      summary: Get authenticated user profile
       tags:
-      - auth
+      - Authentication
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+          description: ''
     patch:
       operationId: auth_profile_partial_update
+      summary: Update authenticated user profile
       tags:
-      - auth
+      - Authentication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedUserProfileRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedUserProfileRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedUserProfileRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+          description: ''
+        '400':
+          description: Validation errors
   /api/auth/change-password/:
     post:
       operationId: auth_change_password_create
+      summary: Change authenticated user password
       tags:
-      - auth
+      - Authentication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangePasswordRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ChangePasswordRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ChangePasswordRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          description: Password changed successfully
+        '400':
+          description: Validation errors
   /api/auth/me/:
     get:
       operationId: auth_me_retrieve
@@ -146,38 +186,73 @@ paths:
     get:
       operationId: auth_2fa_status_retrieve
       description: Get comprehensive 2FA status for current user
+      summary: Get two-factor authentication status
       tags:
-      - auth
+      - Authentication
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TwoFactorStatus'
+          description: ''
   /api/auth/2fa/enable/:
     post:
       operationId: auth_2fa_enable_create
       description: Enable 2FA for current user - supports email, TOTP, and push
+      summary: Enable two-factor authentication
       tags:
-      - auth
+      - Authentication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnableTwoFactorRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EnableTwoFactorRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EnableTwoFactorRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          description: Two-factor authentication method enabled
+        '400':
+          description: Validation errors
   /api/auth/2fa/disable/:
     post:
       operationId: auth_2fa_disable_create
       description: Disable 2FA methods for current user
+      summary: Disable two-factor authentication
       tags:
-      - auth
+      - Authentication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DisableTwoFactorRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/DisableTwoFactorRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/DisableTwoFactorRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          description: Two-factor authentication method disabled
+        '400':
+          description: Validation errors
   /api/auth/2fa/verify/:
     post:
       operationId: auth_2fa_verify_create
@@ -211,75 +286,183 @@ paths:
     post:
       operationId: auth_2fa_setup_totp_create
       description: Generate QR code for TOTP setup using enhanced pyotp service
+      summary: Set up TOTP two-factor authentication
       tags:
-      - auth
+      - Authentication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetupTOTPRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SetupTOTPRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SetupTOTPRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          description: TOTP setup data returned
+        '400':
+          description: Validation errors
+        '500':
+          description: Failed to set up TOTP device
   /api/auth/2fa/confirm-totp/:
     post:
       operationId: auth_2fa_confirm_totp_create
       description: Confirm TOTP setup with verification code using enhanced service
+      summary: Confirm TOTP setup
       tags:
-      - auth
+      - Authentication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfirmTOTPRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ConfirmTOTPRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ConfirmTOTPRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          description: TOTP two-factor authentication enabled
+        '400':
+          description: Invalid verification code or validation errors
   /api/auth/2fa/register-push/:
     post:
       operationId: auth_2fa_register_push_create
       description: Register a new push notification device
+      summary: Register push notification device
       tags:
-      - auth
+      - Authentication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterPushDeviceRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RegisterPushDeviceRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RegisterPushDeviceRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          description: No response body
+        '201':
+          description: Push notification device registered
+        '400':
+          description: Validation errors
   /api/auth/2fa/approve-push/:
     post:
       operationId: auth_2fa_approve_push_create
       description: Approve or deny a push notification challenge
+      summary: Approve or deny push challenge
       tags:
-      - auth
+      - Authentication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApprovePushChallengeRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ApprovePushChallengeRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ApprovePushChallengeRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       - {}
       responses:
         '200':
-          description: No response body
+          description: Push challenge decision accepted
+        '400':
+          description: Validation errors
   /api/auth/2fa/preferences/:
     get:
       operationId: auth_2fa_preferences_retrieve
       description: Get user 2FA preferences
+      summary: Get two-factor preferences
       tags:
-      - auth
+      - Authentication
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserPreferences'
+          description: ''
     post:
       operationId: auth_2fa_preferences_create
       description: Update user 2FA preferences
+      summary: Update two-factor preferences
       tags:
-      - auth
+      - Authentication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserPreferencesRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/UserPreferencesRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UserPreferencesRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          description: Preferences updated successfully
+        '400':
+          description: Validation errors
   /api/assets/assets/:
+    post:
+      operationId: assets_assets_create
+      description: CRUD API for information assets.
+      tags:
+      - assets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetDetail'
+          description: ''
     get:
       operationId: assets_assets_list
       description: CRUD API for information assets.
@@ -398,33 +581,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedAssetListList'
           description: ''
-    post:
-      operationId: assets_assets_create
-      description: CRUD API for information assets.
-      tags:
-      - assets
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AssetDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AssetDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/AssetDetailRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetDetail'
-          description: ''
   /api/assets/assets/due_for_review/:
     get:
       operationId: assets_assets_due_for_review_retrieve
@@ -467,8 +623,8 @@ paths:
                 $ref: '#/components/schemas/AssetDetail'
           description: ''
   /api/assets/assets/{id}/:
-    get:
-      operationId: assets_assets_retrieve
+    put:
+      operationId: assets_assets_update
       description: CRUD API for information assets.
       parameters:
       - in: path
@@ -479,6 +635,18 @@ paths:
         required: true
       tags:
       - assets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -540,8 +708,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: assets_assets_update
+    get:
+      operationId: assets_assets_retrieve
       description: CRUD API for information assets.
       parameters:
       - in: path
@@ -552,18 +720,6 @@ paths:
         required: true
       tags:
       - assets
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AssetDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AssetDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/AssetDetailRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -646,6 +802,32 @@ paths:
                 $ref: '#/components/schemas/AssetReviewReminderLog'
           description: ''
   /api/calendar/events/:
+    post:
+      operationId: calendar_events_create
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
     get:
       operationId: calendar_events_list
       parameters:
@@ -707,32 +889,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/CalendarEvent'
           description: ''
-    post:
-      operationId: calendar_events_create
-      tags:
-      - calendar
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CalendarEventRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/CalendarEventRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/CalendarEventRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CalendarEvent'
-          description: ''
   /api/calendar/events/combined/:
     get:
       operationId: calendar_events_combined_retrieve
@@ -749,8 +905,8 @@ paths:
                 $ref: '#/components/schemas/CalendarEvent'
           description: ''
   /api/calendar/events/{id}/:
-    get:
-      operationId: calendar_events_retrieve
+    put:
+      operationId: calendar_events_update
       parameters:
       - in: path
         name: id
@@ -761,6 +917,18 @@ paths:
         required: true
       tags:
       - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -822,8 +990,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: calendar_events_update
+    get:
+      operationId: calendar_events_retrieve
       parameters:
       - in: path
         name: id
@@ -834,18 +1002,6 @@ paths:
         required: true
       tags:
       - calendar
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CalendarEventRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/CalendarEventRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/CalendarEventRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -857,8 +1013,33 @@ paths:
                 $ref: '#/components/schemas/CalendarEvent'
           description: ''
   /api/calendar/preferences/:
+    post:
+      operationId: calendar_preferences_create
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarNotificationPreferenceRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarNotificationPreferenceRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarNotificationPreferenceRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarNotificationPreference'
+          description: ''
     get:
-      operationId: calendar_preferences_retrieve
+      operationId: calendar_preferences_list
       tags:
       - calendar
       security:
@@ -866,17 +1047,13 @@ paths:
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
-    post:
-      operationId: calendar_preferences_create
-      tags:
-      - calendar
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CalendarNotificationPreference'
+          description: ''
   /api/calendar/reminders/:
     get:
       operationId: calendar_reminders_list
@@ -1016,6 +1193,35 @@ paths:
                 $ref: '#/components/schemas/CalendarAuditLog'
           description: ''
   /api/catalogs/api/frameworks/:
+    post:
+      operationId: catalogs_api_frameworks_create
+      description: Create a new compliance framework with all required metadata and
+        configuration.
+      summary: Create new compliance framework
+      tags:
+      - Frameworks
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FrameworkDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/FrameworkDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FrameworkDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FrameworkDetail'
+          description: ''
     get:
       operationId: catalogs_api_frameworks_list
       description: Retrieve a paginated list of compliance frameworks with filtering,
@@ -1073,11 +1279,18 @@ paths:
                   summary: Get active ISO 27001 frameworks
                   description: Example of filtering for active ISO 27001 frameworks
           description: ''
-    post:
-      operationId: catalogs_api_frameworks_create
-      description: Create a new compliance framework with all required metadata and
-        configuration.
-      summary: Create new compliance framework
+  /api/catalogs/api/frameworks/{id}/:
+    put:
+      operationId: catalogs_api_frameworks_update
+      description: Update an existing compliance framework. Requires all fields.
+      summary: Update framework
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this framework.
+        required: true
       tags:
       - Frameworks
       requestBody:
@@ -1092,31 +1305,6 @@ paths:
             schema:
               $ref: '#/components/schemas/FrameworkDetailRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FrameworkDetail'
-          description: ''
-  /api/catalogs/api/frameworks/{id}/:
-    get:
-      operationId: catalogs_api_frameworks_retrieve
-      description: Retrieve detailed information about a specific compliance framework
-        including metadata and configuration.
-      summary: Get framework details
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this framework.
-        required: true
-      tags:
-      - Frameworks
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -1181,10 +1369,11 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: catalogs_api_frameworks_update
-      description: Update an existing compliance framework. Requires all fields.
-      summary: Update framework
+    get:
+      operationId: catalogs_api_frameworks_retrieve
+      description: Retrieve detailed information about a specific compliance framework
+        including metadata and configuration.
+      summary: Get framework details
       parameters:
       - in: path
         name: id
@@ -1194,18 +1383,6 @@ paths:
         required: true
       tags:
       - Frameworks
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FrameworkDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/FrameworkDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/FrameworkDetailRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -1404,6 +1581,35 @@ paths:
         '404':
           description: Framework not found
   /api/catalogs/api/clauses/:
+    post:
+      operationId: catalogs_api_clauses_create
+      description: |-
+        ViewSet for managing framework clauses.
+        Provides CRUD operations and clause-specific endpoints.
+      tags:
+      - catalogs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClauseDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ClauseDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ClauseDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClauseDetail'
+          description: ''
     get:
       operationId: catalogs_api_clauses_list
       description: |-
@@ -1482,11 +1688,19 @@ paths:
                 items:
                   $ref: '#/components/schemas/ClauseList'
           description: ''
-    post:
-      operationId: catalogs_api_clauses_create
+  /api/catalogs/api/clauses/{id}/:
+    put:
+      operationId: catalogs_api_clauses_update
       description: |-
         ViewSet for managing framework clauses.
         Provides CRUD operations and clause-specific endpoints.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this clause.
+        required: true
       tags:
       - catalogs
       requestBody:
@@ -1501,31 +1715,6 @@ paths:
             schema:
               $ref: '#/components/schemas/ClauseDetailRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClauseDetail'
-          description: ''
-  /api/catalogs/api/clauses/{id}/:
-    get:
-      operationId: catalogs_api_clauses_retrieve
-      description: |-
-        ViewSet for managing framework clauses.
-        Provides CRUD operations and clause-specific endpoints.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this clause.
-        required: true
-      tags:
-      - catalogs
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -1591,8 +1780,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: catalogs_api_clauses_update
+    get:
+      operationId: catalogs_api_clauses_retrieve
       description: |-
         ViewSet for managing framework clauses.
         Provides CRUD operations and clause-specific endpoints.
@@ -1605,18 +1794,6 @@ paths:
         required: true
       tags:
       - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ClauseDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ClauseDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ClauseDetailRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -1697,6 +1874,35 @@ paths:
                 $ref: '#/components/schemas/ClauseDetail'
           description: ''
   /api/catalogs/api/controls/:
+    post:
+      operationId: catalogs_api_controls_create
+      description: |-
+        ViewSet for managing controls.
+        Provides CRUD operations and control-specific endpoints.
+      tags:
+      - catalogs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ControlCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ControlCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ControlCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlCreateUpdate'
+          description: ''
     get:
       operationId: catalogs_api_controls_list
       description: |-
@@ -1835,35 +2041,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/ControlList'
           description: ''
-    post:
-      operationId: catalogs_api_controls_create
-      description: |-
-        ViewSet for managing controls.
-        Provides CRUD operations and control-specific endpoints.
-      tags:
-      - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ControlCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ControlCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ControlCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlCreateUpdate'
-          description: ''
   /api/catalogs/api/controls/by_effectiveness/:
     get:
       operationId: catalogs_api_controls_by_effectiveness_retrieve
@@ -1897,8 +2074,8 @@ paths:
                 $ref: '#/components/schemas/ControlDetail'
           description: ''
   /api/catalogs/api/controls/{id}/:
-    get:
-      operationId: catalogs_api_controls_retrieve
+    put:
+      operationId: catalogs_api_controls_update
       description: |-
         ViewSet for managing controls.
         Provides CRUD operations and control-specific endpoints.
@@ -1911,6 +2088,18 @@ paths:
         required: true
       tags:
       - catalogs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ControlCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ControlCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ControlCreateUpdateRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -1919,7 +2108,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ControlDetail'
+                $ref: '#/components/schemas/ControlCreateUpdate'
           description: ''
     patch:
       operationId: catalogs_api_controls_partial_update
@@ -1976,8 +2165,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: catalogs_api_controls_update
+    get:
+      operationId: catalogs_api_controls_retrieve
       description: |-
         ViewSet for managing controls.
         Provides CRUD operations and control-specific endpoints.
@@ -1990,18 +2179,6 @@ paths:
         required: true
       tags:
       - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ControlCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ControlCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ControlCreateUpdateRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -2010,7 +2187,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ControlCreateUpdate'
+                $ref: '#/components/schemas/ControlDetail'
           description: ''
   /api/catalogs/api/controls/{id}/evidence/:
     get:
@@ -2094,6 +2271,33 @@ paths:
                 $ref: '#/components/schemas/ControlDetail'
           description: ''
   /api/catalogs/api/evidence/:
+    post:
+      operationId: catalogs_api_evidence_create
+      description: ViewSet for managing control evidence.
+      tags:
+      - catalogs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ControlEvidenceRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ControlEvidenceRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ControlEvidenceRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlEvidence'
+          description: ''
     get:
       operationId: catalogs_api_evidence_list
       description: ViewSet for managing control evidence.
@@ -2160,9 +2364,17 @@ paths:
                 items:
                   $ref: '#/components/schemas/ControlEvidence'
           description: ''
-    post:
-      operationId: catalogs_api_evidence_create
+  /api/catalogs/api/evidence/{id}/:
+    put:
+      operationId: catalogs_api_evidence_update
       description: ViewSet for managing control evidence.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this control evidence.
+        required: true
       tags:
       - catalogs
       requestBody:
@@ -2177,29 +2389,6 @@ paths:
             schema:
               $ref: '#/components/schemas/ControlEvidenceRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlEvidence'
-          description: ''
-  /api/catalogs/api/evidence/{id}/:
-    get:
-      operationId: catalogs_api_evidence_retrieve
-      description: ViewSet for managing control evidence.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this control evidence.
-        required: true
-      tags:
-      - catalogs
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -2261,8 +2450,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: catalogs_api_evidence_update
+    get:
+      operationId: catalogs_api_evidence_retrieve
       description: ViewSet for managing control evidence.
       parameters:
       - in: path
@@ -2273,18 +2462,6 @@ paths:
         required: true
       tags:
       - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ControlEvidenceRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ControlEvidenceRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ControlEvidenceRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -2493,6 +2670,33 @@ paths:
                 $ref: '#/components/schemas/TemplateDocument'
           description: ''
   /api/catalogs/api/mappings/:
+    post:
+      operationId: catalogs_api_mappings_create
+      description: ViewSet for managing framework mappings.
+      tags:
+      - catalogs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FrameworkMappingRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/FrameworkMappingRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FrameworkMappingRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FrameworkMapping'
+          description: ''
     get:
       operationId: catalogs_api_mappings_list
       description: ViewSet for managing framework mappings.
@@ -2545,9 +2749,17 @@ paths:
                 items:
                   $ref: '#/components/schemas/FrameworkMapping'
           description: ''
-    post:
-      operationId: catalogs_api_mappings_create
+  /api/catalogs/api/mappings/{id}/:
+    put:
+      operationId: catalogs_api_mappings_update
       description: ViewSet for managing framework mappings.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this framework mapping.
+        required: true
       tags:
       - catalogs
       requestBody:
@@ -2562,29 +2774,6 @@ paths:
             schema:
               $ref: '#/components/schemas/FrameworkMappingRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FrameworkMapping'
-          description: ''
-  /api/catalogs/api/mappings/{id}/:
-    get:
-      operationId: catalogs_api_mappings_retrieve
-      description: ViewSet for managing framework mappings.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this framework mapping.
-        required: true
-      tags:
-      - catalogs
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -2646,8 +2835,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: catalogs_api_mappings_update
+    get:
+      operationId: catalogs_api_mappings_retrieve
       description: ViewSet for managing framework mappings.
       parameters:
       - in: path
@@ -2658,18 +2847,6 @@ paths:
         required: true
       tags:
       - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FrameworkMappingRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/FrameworkMappingRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/FrameworkMappingRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -2681,6 +2858,35 @@ paths:
                 $ref: '#/components/schemas/FrameworkMapping'
           description: ''
   /api/catalogs/api/assessments/:
+    post:
+      operationId: catalogs_api_assessments_create
+      description: Create a new control assessment with all required metadata and
+        assignment information.
+      summary: Create control assessment
+      tags:
+      - Assessments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlAssessmentCreateUpdate'
+          description: ''
     get:
       operationId: catalogs_api_assessments_list
       description: Retrieve a paginated list of control assessments with comprehensive
@@ -2798,35 +3004,6 @@ paths:
                   summary: Get current user's overdue assessments
                   description: Example of filtering for current user's overdue assessments
           description: ''
-    post:
-      operationId: catalogs_api_assessments_create
-      description: Create a new control assessment with all required metadata and
-        assignment information.
-      summary: Create control assessment
-      tags:
-      - Assessments
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlAssessmentCreateUpdate'
-          description: ''
   /api/catalogs/api/assessments/bulk_create/:
     post:
       operationId: catalogs_api_assessments_bulk_create_create
@@ -2937,11 +3114,10 @@ paths:
                   description: Comprehensive progress report with statistics and breakdowns
           description: ''
   /api/catalogs/api/assessments/{id}/:
-    get:
-      operationId: catalogs_api_assessments_retrieve
-      description: Retrieve detailed information about a specific control assessment
-        including evidence links and progress.
-      summary: Get assessment details
+    put:
+      operationId: catalogs_api_assessments_update
+      description: Update an existing control assessment. Requires all fields.
+      summary: Update assessment
       parameters:
       - in: path
         name: id
@@ -2951,6 +3127,18 @@ paths:
         required: true
       tags:
       - Assessments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -2959,7 +3147,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ControlAssessmentDetail'
+                $ref: '#/components/schemas/ControlAssessmentCreateUpdate'
           description: ''
     patch:
       operationId: catalogs_api_assessments_partial_update
@@ -3014,10 +3202,11 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: catalogs_api_assessments_update
-      description: Update an existing control assessment. Requires all fields.
-      summary: Update assessment
+    get:
+      operationId: catalogs_api_assessments_retrieve
+      description: Retrieve detailed information about a specific control assessment
+        including evidence links and progress.
+      summary: Get assessment details
       parameters:
       - in: path
         name: id
@@ -3027,18 +3216,6 @@ paths:
         required: true
       tags:
       - Assessments
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -3047,7 +3224,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ControlAssessmentCreateUpdate'
+                $ref: '#/components/schemas/ControlAssessmentDetail'
           description: ''
   /api/catalogs/api/assessments/{id}/bulk_upload_evidence/:
     post:
@@ -3256,6 +3433,33 @@ paths:
         '404':
           description: Assessment not found
   /api/catalogs/api/assessment-evidence/:
+    post:
+      operationId: catalogs_api_assessment_evidence_create
+      description: ViewSet for managing assessment evidence links.
+      tags:
+      - catalogs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssessmentEvidenceRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssessmentEvidenceRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssessmentEvidenceRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssessmentEvidence'
+          description: ''
     get:
       operationId: catalogs_api_assessment_evidence_list
       description: ViewSet for managing assessment evidence links.
@@ -3298,9 +3502,17 @@ paths:
                 items:
                   $ref: '#/components/schemas/AssessmentEvidence'
           description: ''
-    post:
-      operationId: catalogs_api_assessment_evidence_create
+  /api/catalogs/api/assessment-evidence/{id}/:
+    put:
+      operationId: catalogs_api_assessment_evidence_update
       description: ViewSet for managing assessment evidence links.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this assessment evidence.
+        required: true
       tags:
       - catalogs
       requestBody:
@@ -3315,29 +3527,6 @@ paths:
             schema:
               $ref: '#/components/schemas/AssessmentEvidenceRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssessmentEvidence'
-          description: ''
-  /api/catalogs/api/assessment-evidence/{id}/:
-    get:
-      operationId: catalogs_api_assessment_evidence_retrieve
-      description: ViewSet for managing assessment evidence links.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this assessment evidence.
-        required: true
-      tags:
-      - catalogs
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -3399,8 +3588,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: catalogs_api_assessment_evidence_update
+    get:
+      operationId: catalogs_api_assessment_evidence_retrieve
       description: ViewSet for managing assessment evidence links.
       parameters:
       - in: path
@@ -3411,18 +3600,6 @@ paths:
         required: true
       tags:
       - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AssessmentEvidenceRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AssessmentEvidenceRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/AssessmentEvidenceRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -3434,6 +3611,32 @@ paths:
                 $ref: '#/components/schemas/AssessmentEvidence'
           description: ''
   /api/compliance/artefacts/:
+    post:
+      operationId: compliance_artefacts_create
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GovernanceArtefact'
+          description: ''
     get:
       operationId: compliance_artefacts_list
       parameters:
@@ -3519,8 +3722,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedGovernanceArtefactList'
           description: ''
-    post:
-      operationId: compliance_artefacts_create
+  /api/compliance/artefacts/{id}/:
+    put:
+      operationId: compliance_artefacts_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this governance artefact.
+        required: true
       tags:
       - compliance
       requestBody:
@@ -3535,28 +3746,6 @@ paths:
             schema:
               $ref: '#/components/schemas/GovernanceArtefactRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GovernanceArtefact'
-          description: ''
-  /api/compliance/artefacts/{id}/:
-    get:
-      operationId: compliance_artefacts_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this governance artefact.
-        required: true
-      tags:
-      - compliance
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -3616,8 +3805,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: compliance_artefacts_update
+    get:
+      operationId: compliance_artefacts_retrieve
       parameters:
       - in: path
         name: id
@@ -3627,18 +3816,6 @@ paths:
         required: true
       tags:
       - compliance
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GovernanceArtefactRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/GovernanceArtefactRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/GovernanceArtefactRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -3650,6 +3827,32 @@ paths:
                 $ref: '#/components/schemas/GovernanceArtefact'
           description: ''
   /api/compliance/regulatory-requirements/:
+    post:
+      operationId: compliance_regulatory_requirements_create
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryRequirement'
+          description: ''
     get:
       operationId: compliance_regulatory_requirements_list
       parameters:
@@ -3759,8 +3962,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedRegulatoryRequirementList'
           description: ''
-    post:
-      operationId: compliance_regulatory_requirements_create
+  /api/compliance/regulatory-requirements/{id}/:
+    put:
+      operationId: compliance_regulatory_requirements_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this regulatory requirement.
+        required: true
       tags:
       - compliance
       requestBody:
@@ -3775,28 +3986,6 @@ paths:
             schema:
               $ref: '#/components/schemas/RegulatoryRequirementRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RegulatoryRequirement'
-          description: ''
-  /api/compliance/regulatory-requirements/{id}/:
-    get:
-      operationId: compliance_regulatory_requirements_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this regulatory requirement.
-        required: true
-      tags:
-      - compliance
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -3856,8 +4045,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: compliance_regulatory_requirements_update
+    get:
+      operationId: compliance_regulatory_requirements_retrieve
       parameters:
       - in: path
         name: id
@@ -3867,18 +4056,6 @@ paths:
         required: true
       tags:
       - compliance
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegulatoryRequirementRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RegulatoryRequirementRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RegulatoryRequirementRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -3890,6 +4067,32 @@ paths:
                 $ref: '#/components/schemas/RegulatoryRequirement'
           description: ''
   /api/compliance/non-conformities/:
+    post:
+      operationId: compliance_non_conformities_create
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NonConformityRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/NonConformityRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/NonConformityRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NonConformity'
+          description: ''
     get:
       operationId: compliance_non_conformities_list
       parameters:
@@ -3987,8 +4190,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedNonConformityList'
           description: ''
-    post:
-      operationId: compliance_non_conformities_create
+  /api/compliance/non-conformities/{id}/:
+    put:
+      operationId: compliance_non_conformities_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this non conformity.
+        required: true
       tags:
       - compliance
       requestBody:
@@ -4003,28 +4214,6 @@ paths:
             schema:
               $ref: '#/components/schemas/NonConformityRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NonConformity'
-          description: ''
-  /api/compliance/non-conformities/{id}/:
-    get:
-      operationId: compliance_non_conformities_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this non conformity.
-        required: true
-      tags:
-      - compliance
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -4084,8 +4273,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: compliance_non_conformities_update
+    get:
+      operationId: compliance_non_conformities_retrieve
       parameters:
       - in: path
         name: id
@@ -4095,18 +4284,6 @@ paths:
         required: true
       tags:
       - compliance
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/NonConformityRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/NonConformityRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/NonConformityRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -4118,6 +4295,32 @@ paths:
                 $ref: '#/components/schemas/NonConformity'
           description: ''
   /api/compliance/management-reviews/:
+    post:
+      operationId: compliance_management_reviews_create
+      tags:
+      - compliance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ManagementReviewRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ManagementReviewRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ManagementReviewRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagementReview'
+          description: ''
     get:
       operationId: compliance_management_reviews_list
       parameters:
@@ -4193,8 +4396,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedManagementReviewList'
           description: ''
-    post:
-      operationId: compliance_management_reviews_create
+  /api/compliance/management-reviews/{id}/:
+    put:
+      operationId: compliance_management_reviews_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this management review.
+        required: true
       tags:
       - compliance
       requestBody:
@@ -4209,28 +4420,6 @@ paths:
             schema:
               $ref: '#/components/schemas/ManagementReviewRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ManagementReview'
-          description: ''
-  /api/compliance/management-reviews/{id}/:
-    get:
-      operationId: compliance_management_reviews_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this management review.
-        required: true
-      tags:
-      - compliance
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -4290,8 +4479,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: compliance_management_reviews_update
+    get:
+      operationId: compliance_management_reviews_retrieve
       parameters:
       - in: path
         name: id
@@ -4301,18 +4490,6 @@ paths:
         required: true
       tags:
       - compliance
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ManagementReviewRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ManagementReviewRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ManagementReviewRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -4324,6 +4501,35 @@ paths:
                 $ref: '#/components/schemas/ManagementReview'
           description: ''
   /api/exports/assessment-reports/:
+    post:
+      operationId: exports_assessment_reports_create
+      description: Create a new assessment report configuration. Use the 'generate'
+        action to start report generation.
+      summary: Create assessment report
+      tags:
+      - Reports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportCreateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportCreateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportCreateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssessmentReportCreate'
+          description: ''
     get:
       operationId: exports_assessment_reports_list
       description: Retrieve a list of assessment reports created by the current user
@@ -4358,35 +4564,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AssessmentReport'
-          description: ''
-    post:
-      operationId: exports_assessment_reports_create
-      description: Create a new assessment report configuration. Use the 'generate'
-        action to start report generation.
-      summary: Create assessment report
-      tags:
-      - Reports
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AssessmentReportCreateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AssessmentReportCreateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/AssessmentReportCreateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssessmentReportCreate'
           description: ''
   /api/exports/assessment-reports/assessment_options/:
     get:
@@ -4451,19 +4628,32 @@ paths:
         '500':
           description: Failed to start generation
   /api/exports/assessment-reports/{id}/:
-    get:
-      operationId: exports_assessment_reports_retrieve
-      description: Retrieve detailed information about a specific assessment report
-        including generation status.
-      summary: Get report details
+    put:
+      operationId: exports_assessment_reports_update
+      description: Update an existing assessment report configuration. Cannot update
+        reports that are processing or completed.
+      summary: Update report
       parameters:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this assessment report.
         required: true
       tags:
       - Reports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -4507,7 +4697,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this assessment report.
         required: true
       tags:
       - exports
@@ -4540,7 +4731,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this assessment report.
         required: true
       tags:
       - Reports
@@ -4550,31 +4742,20 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: exports_assessment_reports_update
-      description: Update an existing assessment report configuration. Cannot update
-        reports that are processing or completed.
-      summary: Update report
+    get:
+      operationId: exports_assessment_reports_retrieve
+      description: Retrieve detailed information about a specific assessment report
+        including generation status.
+      summary: Get report details
       parameters:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this assessment report.
         required: true
       tags:
       - Reports
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AssessmentReportRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AssessmentReportRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/AssessmentReportRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -4593,7 +4774,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this assessment report.
         required: true
       tags:
       - exports
@@ -4617,7 +4799,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this assessment report.
         required: true
       tags:
       - Reports
@@ -4651,7 +4834,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this assessment report.
         required: true
       tags:
       - exports
@@ -4666,24 +4850,6 @@ paths:
                 $ref: '#/components/schemas/AssessmentReport'
           description: ''
   /api/exports/tenant-data-exports/:
-    get:
-      operationId: exports_tenant_data_exports_list
-      description: Retrieve tenant data export jobs requested by the current user.
-      summary: List tenant data exports
-      tags:
-      - Data Exports
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/TenantDataExport'
-          description: ''
     post:
       operationId: exports_tenant_data_exports_create
       description: Create a tenant-wide GRC data export and start asynchronous generation.
@@ -4711,6 +4877,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/TenantDataExportCreate'
           description: ''
+    get:
+      operationId: exports_tenant_data_exports_list
+      description: Retrieve tenant data export jobs requested by the current user.
+      summary: List tenant data exports
+      parameters:
+      - in: query
+        name: export_format
+        schema:
+          type: string
+          enum:
+          - csv_zip
+          - xlsx
+        description: |-
+          * `xlsx` - Excel workbook
+          * `csv_zip` - CSV archive
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - completed
+          - failed
+          - pending
+          - processing
+        description: |-
+          * `pending` - Pending Generation
+          * `processing` - Processing
+          * `completed` - Completed
+          * `failed` - Failed
+      tags:
+      - Data Exports
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TenantDataExport'
+          description: ''
   /api/exports/tenant-data-exports/coverage/:
     get:
       operationId: exports_tenant_data_exports_coverage_retrieve
@@ -4730,6 +4939,25 @@ paths:
                 $ref: '#/components/schemas/TenantDataExport'
           description: ''
   /api/exports/tenant-data-exports/{id}/:
+    delete:
+      operationId: exports_tenant_data_exports_destroy
+      description: Delete a tenant data export job and its generated document reference.
+      summary: Delete tenant data export
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this tenant data export.
+        required: true
+      tags:
+      - Data Exports
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
     get:
       operationId: exports_tenant_data_exports_retrieve
       description: Retrieve status and download metadata for a tenant data export.
@@ -4738,7 +4966,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this tenant data export.
         required: true
       tags:
       - Data Exports
@@ -4752,24 +4981,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/TenantDataExport'
           description: ''
-    delete:
-      operationId: exports_tenant_data_exports_destroy
-      description: Delete a tenant data export job and its generated document reference.
-      summary: Delete tenant data export
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-        required: true
-      tags:
-      - Data Exports
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
   /api/exports/tenant-data-exports/{id}/download/:
     get:
       operationId: exports_tenant_data_exports_download_retrieve
@@ -4778,7 +4989,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this tenant data export.
         required: true
       tags:
       - exports
@@ -4802,7 +5014,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this tenant data export.
         required: true
       tags:
       - Data Exports
@@ -4833,7 +5046,8 @@ paths:
       - in: path
         name: id
         schema:
-          type: string
+          type: integer
+        description: A unique integer value identifying this tenant data export.
         required: true
       tags:
       - exports
@@ -4848,6 +5062,34 @@ paths:
                 $ref: '#/components/schemas/TenantDataExport'
           description: ''
   /api/risk/risks/:
+    post:
+      operationId: risk_risks_create
+      description: Create a new risk entry with impact and likelihood assessment.
+      summary: Create new risk
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskCreateUpdate'
+          description: ''
     get:
       operationId: risk_risks_list
       description: Retrieve a paginated list of risks with comprehensive filtering,
@@ -5016,34 +5258,6 @@ paths:
                   summary: Get high and critical risks
                   description: Example of filtering for high priority risks
           description: ''
-    post:
-      operationId: risk_risks_create
-      description: Create a new risk entry with impact and likelihood assessment.
-      summary: Create new risk
-      tags:
-      - Risk Management
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskCreateUpdate'
-          description: ''
   /api/risk/risks/bulk_create/:
     post:
       operationId: risk_risks_bulk_create_create
@@ -5104,11 +5318,11 @@ paths:
                 $ref: '#/components/schemas/RiskSummary'
           description: ''
   /api/risk/risks/{id}/:
-    get:
-      operationId: risk_risks_retrieve
-      description: Retrieve detailed information about a specific risk including notes
-        and history.
-      summary: Get risk details
+    put:
+      operationId: risk_risks_update
+      description: Update an existing risk entry. Risk level will be automatically
+        recalculated.
+      summary: Update risk
       parameters:
       - in: path
         name: id
@@ -5118,6 +5332,18 @@ paths:
         required: true
       tags:
       - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -5126,7 +5352,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RiskDetail'
+                $ref: '#/components/schemas/RiskCreateUpdate'
           description: ''
     patch:
       operationId: risk_risks_partial_update
@@ -5181,11 +5407,11 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: risk_risks_update
-      description: Update an existing risk entry. Risk level will be automatically
-        recalculated.
-      summary: Update risk
+    get:
+      operationId: risk_risks_retrieve
+      description: Retrieve detailed information about a specific risk including notes
+        and history.
+      summary: Get risk details
       parameters:
       - in: path
         name: id
@@ -5195,18 +5421,6 @@ paths:
         required: true
       tags:
       - Risk Management
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskCreateUpdateRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -5215,7 +5429,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RiskCreateUpdate'
+                $ref: '#/components/schemas/RiskDetail'
           description: ''
   /api/risk/risks/{id}/add_note/:
     post:
@@ -5305,24 +5519,6 @@ paths:
         '404':
           description: Risk not found
   /api/risk/categories/:
-    get:
-      operationId: risk_categories_list
-      description: Retrieve all risk categories with risk counts.
-      summary: List risk categories
-      tags:
-      - Risk Management
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RiskCategory'
-          description: ''
     post:
       operationId: risk_categories_create
       description: Create a new risk category for organizing risks.
@@ -5351,11 +5547,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskCategory'
           description: ''
-  /api/risk/categories/{id}/:
     get:
-      operationId: risk_categories_retrieve
-      description: Retrieve detailed information about a risk category.
-      summary: Get category details
+      operationId: risk_categories_list
+      description: Retrieve all risk categories with risk counts.
+      summary: List risk categories
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskCategory'
+          description: ''
+  /api/risk/categories/{id}/:
+    put:
+      operationId: risk_categories_update
+      description: Update an existing risk category.
+      summary: Update risk category
       parameters:
       - in: path
         name: id
@@ -5365,6 +5579,18 @@ paths:
         required: true
       tags:
       - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -5431,10 +5657,10 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: risk_categories_update
-      description: Update an existing risk category.
-      summary: Update risk category
+    get:
+      operationId: risk_categories_retrieve
+      description: Retrieve detailed information about a risk category.
+      summary: Get category details
       parameters:
       - in: path
         name: id
@@ -5444,18 +5670,6 @@ paths:
         required: true
       tags:
       - Risk Management
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskCategoryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskCategoryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskCategoryRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -5467,24 +5681,6 @@ paths:
                 $ref: '#/components/schemas/RiskCategory'
           description: ''
   /api/risk/matrices/:
-    get:
-      operationId: risk_matrices_list
-      description: Retrieve all available risk assessment matrices.
-      summary: List risk matrices
-      tags:
-      - Risk Management
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RiskMatrix'
-          description: ''
     post:
       operationId: risk_matrices_create
       description: Create a new risk assessment matrix with custom configuration.
@@ -5513,11 +5709,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskMatrix'
           description: ''
-  /api/risk/matrices/{id}/:
     get:
-      operationId: risk_matrices_retrieve
-      description: Retrieve detailed information about a risk matrix including configuration.
-      summary: Get matrix details
+      operationId: risk_matrices_list
+      description: Retrieve all available risk assessment matrices.
+      summary: List risk matrices
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskMatrix'
+          description: ''
+  /api/risk/matrices/{id}/:
+    put:
+      operationId: risk_matrices_update
+      description: Update an existing risk matrix configuration.
+      summary: Update risk matrix
       parameters:
       - in: path
         name: id
@@ -5527,6 +5741,18 @@ paths:
         required: true
       tags:
       - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -5594,10 +5820,10 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: risk_matrices_update
-      description: Update an existing risk matrix configuration.
-      summary: Update risk matrix
+    get:
+      operationId: risk_matrices_retrieve
+      description: Retrieve detailed information about a risk matrix including configuration.
+      summary: Get matrix details
       parameters:
       - in: path
         name: id
@@ -5607,18 +5833,6 @@ paths:
         required: true
       tags:
       - Risk Management
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskMatrixRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskMatrixRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskMatrixRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -5630,6 +5844,34 @@ paths:
                 $ref: '#/components/schemas/RiskMatrix'
           description: ''
   /api/risk/actions/:
+    post:
+      operationId: risk_actions_create
+      description: Create a new risk action with assignment and scheduling.
+      summary: Create new risk action
+      tags:
+      - Risk Actions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionCreateUpdate'
+          description: ''
     get:
       operationId: risk_actions_list
       description: Retrieve a paginated list of risk actions with comprehensive filtering,
@@ -5810,34 +6052,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/RiskActionList'
           description: ''
-    post:
-      operationId: risk_actions_create
-      description: Create a new risk action with assignment and scheduling.
-      summary: Create new risk action
-      tags:
-      - Risk Actions
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskActionCreateUpdate'
-          description: ''
   /api/risk/actions/bulk_create/:
     post:
       operationId: risk_actions_bulk_create_create
@@ -5896,11 +6110,10 @@ paths:
                 $ref: '#/components/schemas/RiskActionSummary'
           description: ''
   /api/risk/actions/{id}/:
-    get:
-      operationId: risk_actions_retrieve
-      description: Retrieve detailed information about a specific risk action including
-        notes and evidence.
-      summary: Get risk action details
+    put:
+      operationId: risk_actions_update
+      description: Update an existing risk action. Progress and status will be validated.
+      summary: Update risk action
       parameters:
       - in: path
         name: id
@@ -5910,6 +6123,18 @@ paths:
         required: true
       tags:
       - Risk Actions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -5918,7 +6143,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RiskActionDetail'
+                $ref: '#/components/schemas/RiskActionCreateUpdate'
           description: ''
     patch:
       operationId: risk_actions_partial_update
@@ -5973,10 +6198,11 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: risk_actions_update
-      description: Update an existing risk action. Progress and status will be validated.
-      summary: Update risk action
+    get:
+      operationId: risk_actions_retrieve
+      description: Retrieve detailed information about a specific risk action including
+        notes and evidence.
+      summary: Get risk action details
       parameters:
       - in: path
         name: id
@@ -5986,18 +6212,6 @@ paths:
         required: true
       tags:
       - Risk Actions
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -6006,7 +6220,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RiskActionCreateUpdate'
+                $ref: '#/components/schemas/RiskActionDetail'
           description: ''
   /api/risk/actions/{id}/add_note/:
     post:
@@ -6146,24 +6360,6 @@ paths:
         '404':
           description: Risk action not found
   /api/risk/reminder-config/:
-    get:
-      operationId: risk_reminder_config_list
-      description: Retrieve risk action reminder configurations for all users.
-      summary: List reminder configurations
-      tags:
-      - Risk Action Reminders
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RiskActionReminderConfiguration'
-          description: ''
     post:
       operationId: risk_reminder_config_create
       description: Create risk action reminder configuration for current user.
@@ -6191,11 +6387,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskActionReminderConfiguration'
           description: ''
-  /api/risk/reminder-config/{id}/:
     get:
-      operationId: risk_reminder_config_retrieve
-      description: Retrieve detailed risk action reminder configuration.
-      summary: Get reminder configuration
+      operationId: risk_reminder_config_list
+      description: Retrieve risk action reminder configurations for all users.
+      summary: List reminder configurations
+      tags:
+      - Risk Action Reminders
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskActionReminderConfiguration'
+          description: ''
+  /api/risk/reminder-config/{id}/:
+    put:
+      operationId: risk_reminder_config_update
+      description: Update risk action reminder configuration settings.
+      summary: Update reminder configuration
       parameters:
       - in: path
         name: id
@@ -6206,6 +6420,17 @@ paths:
         required: true
       tags:
       - Risk Action Reminders
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -6283,10 +6508,10 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: risk_reminder_config_update
-      description: Update risk action reminder configuration settings.
-      summary: Update reminder configuration
+    get:
+      operationId: risk_reminder_config_retrieve
+      description: Retrieve detailed risk action reminder configuration.
+      summary: Get reminder configuration
       parameters:
       - in: path
         name: id
@@ -6297,17 +6522,6 @@ paths:
         required: true
       tags:
       - Risk Action Reminders
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -6329,14 +6543,22 @@ paths:
         - Progress tracking and completion rates
         - Due date analysis and overdue alerts
         - Assignee workload and performance metrics
+      summary: Risk action overview analytics
       tags:
-      - risk
+      - Risk Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate action overview
   /api/risk/analytics/action_progress/:
     get:
       operationId: risk_analytics_action_progress_retrieve
@@ -6348,14 +6570,22 @@ paths:
         - Treatment effectiveness by strategy type
         - Evidence collection and validation statistics
         - Performance analysis by risk level and category
+      summary: Risk action progress analytics
       tags:
-      - risk
+      - Risk Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate progress analysis
   /api/risk/analytics/category_analysis/:
     get:
       operationId: risk_analytics_category_analysis_retrieve
@@ -6369,14 +6599,29 @@ paths:
         - Category-specific risk metrics and breakdowns
         - Treatment analysis and action progress
         - Comparative analysis across categories
+      summary: Risk category analytics
+      parameters:
+      - in: query
+        name: category_id
+        schema:
+          type: integer
       tags:
-      - risk
+      - Risk Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '400':
+          description: Invalid category_id parameter
+        '500':
+          description: Failed to generate category analysis
   /api/risk/analytics/control_integration/:
     get:
       operationId: risk_analytics_control_integration_retrieve
@@ -6389,26 +6634,28 @@ paths:
         - Integration readiness metrics
 
         Note: This will be enhanced with full risk-control mapping in future iterations.
+      summary: Risk-control integration analytics
       tags:
-      - risk
+      - Risk Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate control integration analysis
   /api/risk/analytics/dashboard/:
     get:
       operationId: risk_analytics_dashboard_retrieve
-      description: |-
-        Get comprehensive risk analytics dashboard data.
-
-        Returns complete dashboard dataset including:
-        - Risk overview statistics
-        - Risk action progress metrics
-        - Heat map visualization data
-        - Trend analysis and forecasting
-        - Executive summary metrics
+      description: Access comprehensive risk analytics, trends, and reporting data
+        for management dashboards and executive reporting.
+      summary: Risk Analytics Dashboard
       tags:
       - risk
       security:
@@ -6416,7 +6663,34 @@ paths:
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+              examples:
+                DashboardAnalytics:
+                  value:
+                    risk_overview:
+                      total_risks: 45
+                      active_risks: 38
+                      critical_high_risks: 12
+                      average_risk_score: 8.5
+                    heat_map:
+                      matrix_size: 5
+                      total_risks: 38
+                      heat_map:
+                        '1':
+                          '1':
+                            count: 2
+                            risk_level: low
+                    trend_analysis:
+                      creation_trend: []
+                      closure_trend: []
+                  summary: Dashboard Analytics
+                  description: Complete dashboard data with risk metrics, trends,
+                    and visualizations
+          description: Risk analytics data
   /api/risk/analytics/executive_summary/:
     get:
       operationId: risk_analytics_executive_summary_retrieve
@@ -6429,14 +6703,22 @@ paths:
         - Treatment progress and completion rates
         - Governance indicators and maturity metrics
         - Top risk areas and priority recommendations
+      summary: Executive risk summary analytics
       tags:
-      - risk
+      - Risk Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate executive summary
   /api/risk/analytics/heat_map/:
     get:
       operationId: risk_analytics_heat_map_retrieve
@@ -6448,14 +6730,22 @@ paths:
         - Risk counts and levels for each matrix cell
         - Detailed risk information for drill-down analysis
         - Matrix configuration and labeling
+      summary: Risk heat map analytics
       tags:
-      - risk
+      - Risk Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate heat map
   /api/risk/analytics/risk_overview/:
     get:
       operationId: risk_analytics_risk_overview_retrieve
@@ -6467,14 +6757,22 @@ paths:
         - Risk level and status distributions
         - Category analysis and treatment strategy breakdown
         - Recent activity and overdue review alerts
+      summary: Risk overview analytics
       tags:
-      - risk
+      - Risk Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate risk overview
   /api/risk/analytics/trends/:
     get:
       operationId: risk_analytics_trends_retrieve
@@ -6489,25 +6787,14 @@ paths:
         - Active risk count evolution
         - Monthly and quarterly trend analysis
         - Forecasting indicators
-      tags:
-      - risk
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          description: No response body
-  /api/policies/categories/:
-    get:
-      operationId: policies_categories_list
-      description: ViewSet for managing policy categories.
+      summary: Risk trend analytics
       parameters:
       - in: query
-        name: name
+        name: days
         schema:
-          type: string
+          type: integer
       tags:
-      - policies
+      - Risk Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -6516,10 +6803,14 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PolicyCategory'
+                type: object
+                additionalProperties: {}
           description: ''
+        '400':
+          description: Invalid days parameter
+        '500':
+          description: Failed to generate trend analysis
+  /api/policies/categories/:
     post:
       operationId: policies_categories_create
       description: ViewSet for managing policy categories.
@@ -6547,9 +6838,31 @@ paths:
               schema:
                 $ref: '#/components/schemas/PolicyCategory'
           description: ''
-  /api/policies/categories/{id}/:
     get:
-      operationId: policies_categories_retrieve
+      operationId: policies_categories_list
+      description: ViewSet for managing policy categories.
+      parameters:
+      - in: query
+        name: name
+        schema:
+          type: string
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyCategory'
+          description: ''
+  /api/policies/categories/{id}/:
+    put:
+      operationId: policies_categories_update
       description: ViewSet for managing policy categories.
       parameters:
       - in: path
@@ -6561,6 +6874,18 @@ paths:
         required: true
       tags:
       - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyCategoryRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -6624,8 +6949,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: policies_categories_update
+    get:
+      operationId: policies_categories_retrieve
       description: ViewSet for managing policy categories.
       parameters:
       - in: path
@@ -6637,18 +6962,6 @@ paths:
         required: true
       tags:
       - policies
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PolicyCategoryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PolicyCategoryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PolicyCategoryRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -6684,6 +6997,33 @@ paths:
                 $ref: '#/components/schemas/PolicyCategory'
           description: ''
   /api/policies/policies/:
+    post:
+      operationId: policies_policies_create
+      description: ViewSet for managing policies with versioning support.
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCreateUpdate'
+          description: ''
     get:
       operationId: policies_policies_list
       description: ViewSet for managing policies with versioning support.
@@ -6789,33 +7129,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/PolicyList'
           description: ''
-    post:
-      operationId: policies_policies_create
-      description: ViewSet for managing policies with versioning support.
-      tags:
-      - policies
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PolicyCreateUpdate'
-          description: ''
   /api/policies/policies/acknowledgment_dashboard/:
     get:
       operationId: policies_policies_acknowledgment_dashboard_retrieve
@@ -6865,8 +7178,8 @@ paths:
                 $ref: '#/components/schemas/PolicyDetail'
           description: ''
   /api/policies/policies/{id}/:
-    get:
-      operationId: policies_policies_retrieve
+    put:
+      operationId: policies_policies_update
       description: ViewSet for managing policies with versioning support.
       parameters:
       - in: path
@@ -6878,6 +7191,18 @@ paths:
         required: true
       tags:
       - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -6886,7 +7211,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PolicyDetail'
+                $ref: '#/components/schemas/PolicyCreateUpdate'
           description: ''
     patch:
       operationId: policies_policies_partial_update
@@ -6941,8 +7266,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: policies_policies_update
+    get:
+      operationId: policies_policies_retrieve
       description: ViewSet for managing policies with versioning support.
       parameters:
       - in: path
@@ -6954,18 +7279,6 @@ paths:
         required: true
       tags:
       - policies
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -6974,7 +7287,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PolicyCreateUpdate'
+                $ref: '#/components/schemas/PolicyDetail'
           description: ''
   /api/policies/policies/{id}/acknowledge/:
     post:
@@ -7097,6 +7410,33 @@ paths:
                 $ref: '#/components/schemas/PolicyDetail'
           description: ''
   /api/policies/versions/:
+    post:
+      operationId: policies_versions_create
+      description: ViewSet for managing policy versions.
+      tags:
+      - policies
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
     get:
       operationId: policies_versions_list
       description: ViewSet for managing policy versions.
@@ -7178,9 +7518,18 @@ paths:
                 items:
                   $ref: '#/components/schemas/PolicyVersionList'
           description: ''
-    post:
-      operationId: policies_versions_create
+  /api/policies/versions/{id}/:
+    put:
+      operationId: policies_versions_update
       description: ViewSet for managing policy versions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
       tags:
       - policies
       requestBody:
@@ -7195,30 +7544,6 @@ paths:
             schema:
               $ref: '#/components/schemas/PolicyVersionDetailRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PolicyVersionDetail'
-          description: ''
-  /api/policies/versions/{id}/:
-    get:
-      operationId: policies_versions_retrieve
-      description: ViewSet for managing policy versions.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Policy Version.
-        required: true
-      tags:
-      - policies
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -7282,8 +7607,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: policies_versions_update
+    get:
+      operationId: policies_versions_retrieve
       description: ViewSet for managing policy versions.
       parameters:
       - in: path
@@ -7295,18 +7620,6 @@ paths:
         required: true
       tags:
       - policies
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PolicyVersionDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PolicyVersionDetailRequest'
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PolicyVersionDetailRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -7708,6 +8021,33 @@ paths:
                 $ref: '#/components/schemas/PolicyDistribution'
           description: ''
   /api/training/categories/:
+    post:
+      operationId: training_categories_create
+      description: ViewSet for managing training categories.
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainingCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TrainingCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TrainingCategoryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingCategory'
+          description: ''
     get:
       operationId: training_categories_list
       description: ViewSet for managing training categories.
@@ -7738,9 +8078,18 @@ paths:
                 items:
                   $ref: '#/components/schemas/TrainingCategory'
           description: ''
-    post:
-      operationId: training_categories_create
+  /api/training/categories/{id}/:
+    put:
+      operationId: training_categories_update
       description: ViewSet for managing training categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training category.
+        required: true
       tags:
       - training
       requestBody:
@@ -7755,30 +8104,6 @@ paths:
             schema:
               $ref: '#/components/schemas/TrainingCategoryRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TrainingCategory'
-          description: ''
-  /api/training/categories/{id}/:
-    get:
-      operationId: training_categories_retrieve
-      description: ViewSet for managing training categories.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this training category.
-        required: true
-      tags:
-      - training
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -7842,8 +8167,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: training_categories_update
+    get:
+      operationId: training_categories_retrieve
       description: ViewSet for managing training categories.
       parameters:
       - in: path
@@ -7855,18 +8180,6 @@ paths:
         required: true
       tags:
       - training
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TrainingCategoryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/TrainingCategoryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/TrainingCategoryRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -7878,6 +8191,33 @@ paths:
                 $ref: '#/components/schemas/TrainingCategory'
           description: ''
   /api/training/videos/:
+    post:
+      operationId: training_videos_create
+      description: ViewSet for managing training videos.
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingVideoDetail'
+          description: ''
     get:
       operationId: training_videos_list
       description: ViewSet for managing training videos.
@@ -7995,33 +8335,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/TrainingVideoList'
           description: ''
-    post:
-      operationId: training_videos_create
-      description: ViewSet for managing training videos.
-      tags:
-      - training
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TrainingVideoDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/TrainingVideoDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/TrainingVideoDetailRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TrainingVideoDetail'
-          description: ''
   /api/training/videos/analytics/:
     get:
       operationId: training_videos_analytics_retrieve
@@ -8039,8 +8352,8 @@ paths:
                 $ref: '#/components/schemas/TrainingVideoDetail'
           description: ''
   /api/training/videos/{id}/:
-    get:
-      operationId: training_videos_retrieve
+    put:
+      operationId: training_videos_update
       description: ViewSet for managing training videos.
       parameters:
       - in: path
@@ -8052,6 +8365,18 @@ paths:
         required: true
       tags:
       - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -8115,8 +8440,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: training_videos_update
+    get:
+      operationId: training_videos_retrieve
       description: ViewSet for managing training videos.
       parameters:
       - in: path
@@ -8128,18 +8453,6 @@ paths:
         required: true
       tags:
       - training
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TrainingVideoDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/TrainingVideoDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/TrainingVideoDetailRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -8187,6 +8500,33 @@ paths:
                 $ref: '#/components/schemas/TrainingVideoDetail'
           description: ''
   /api/training/campaigns/:
+    post:
+      operationId: training_campaigns_create
+      description: ViewSet for managing security awareness campaigns.
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
     get:
       operationId: training_campaigns_list
       description: ViewSet for managing security awareness campaigns.
@@ -8308,33 +8648,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/SecurityAwarenessCampaignList'
           description: ''
-    post:
-      operationId: training_campaigns_create
-      description: ViewSet for managing security awareness campaigns.
-      tags:
-      - training
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
-          description: ''
   /api/training/campaigns/analytics/:
     get:
       operationId: training_campaigns_analytics_retrieve
@@ -8368,8 +8681,8 @@ paths:
                 $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
           description: ''
   /api/training/campaigns/{id}/:
-    get:
-      operationId: training_campaigns_retrieve
+    put:
+      operationId: training_campaigns_update
       description: ViewSet for managing security awareness campaigns.
       parameters:
       - in: path
@@ -8381,6 +8694,18 @@ paths:
         required: true
       tags:
       - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -8444,8 +8769,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: training_campaigns_update
+    get:
+      operationId: training_campaigns_retrieve
       description: ViewSet for managing security awareness campaigns.
       parameters:
       - in: path
@@ -8457,18 +8782,6 @@ paths:
         required: true
       tags:
       - training
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -8744,6 +9057,32 @@ paths:
                 $ref: '#/components/schemas/VideoView'
           description: ''
   /api/knowledge/categories/:
+    post:
+      operationId: knowledge_categories_create
+      tags:
+      - knowledge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeCategory'
+          description: ''
     get:
       operationId: knowledge_categories_list
       parameters:
@@ -8815,8 +9154,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedKnowledgeCategoryList'
           description: ''
-    post:
-      operationId: knowledge_categories_create
+  /api/knowledge/categories/{id}/:
+    put:
+      operationId: knowledge_categories_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this knowledge category.
+        required: true
       tags:
       - knowledge
       requestBody:
@@ -8831,28 +9178,6 @@ paths:
             schema:
               $ref: '#/components/schemas/KnowledgeCategoryRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KnowledgeCategory'
-          description: ''
-  /api/knowledge/categories/{id}/:
-    get:
-      operationId: knowledge_categories_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this knowledge category.
-        required: true
-      tags:
-      - knowledge
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -8912,8 +9237,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: knowledge_categories_update
+    get:
+      operationId: knowledge_categories_retrieve
       parameters:
       - in: path
         name: id
@@ -8923,18 +9248,6 @@ paths:
         required: true
       tags:
       - knowledge
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/KnowledgeCategoryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/KnowledgeCategoryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/KnowledgeCategoryRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -8946,6 +9259,32 @@ paths:
                 $ref: '#/components/schemas/KnowledgeCategory'
           description: ''
   /api/knowledge/articles/:
+    post:
+      operationId: knowledge_articles_create
+      tags:
+      - knowledge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeArticleDetail'
+          description: ''
     get:
       operationId: knowledge_articles_list
       parameters:
@@ -9043,32 +9382,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedKnowledgeArticleListList'
           description: ''
-    post:
-      operationId: knowledge_articles_create
-      tags:
-      - knowledge
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KnowledgeArticleDetail'
-          description: ''
   /api/knowledge/articles/contextual/:
     get:
       operationId: knowledge_articles_contextual_retrieve
@@ -9086,8 +9399,8 @@ paths:
                 $ref: '#/components/schemas/KnowledgeArticleDetail'
           description: ''
   /api/knowledge/articles/{slug}/:
-    get:
-      operationId: knowledge_articles_retrieve
+    put:
+      operationId: knowledge_articles_update
       parameters:
       - in: path
         name: slug
@@ -9096,6 +9409,18 @@ paths:
         required: true
       tags:
       - knowledge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -9153,8 +9478,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: knowledge_articles_update
+    get:
+      operationId: knowledge_articles_retrieve
       parameters:
       - in: path
         name: slug
@@ -9163,18 +9488,6 @@ paths:
         required: true
       tags:
       - knowledge
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -9214,14 +9527,22 @@ paths:
 
         Returns comprehensive metrics for C-level reporting including risk posture,
         compliance status, vendor management, policy compliance, and training effectiveness.
+      summary: Executive analytics dashboard
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate executive dashboard
   /api/analytics/compliance/:
     get:
       operationId: analytics_compliance_retrieve
@@ -9230,14 +9551,22 @@ paths:
 
         Provides detailed compliance metrics including assessment progress,
         control maturity, and evidence collection statistics.
+      summary: Compliance analytics dashboard
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate compliance dashboard
   /api/analytics/vendor-risk/:
     get:
       operationId: analytics_vendor_risk_retrieve
@@ -9246,14 +9575,22 @@ paths:
 
         Provides vendor risk distribution, contract management metrics,
         and vendor task analytics for procurement and risk teams.
+      summary: Vendor risk analytics dashboard
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate vendor dashboard
   /api/analytics/policy-management/:
     get:
       operationId: analytics_policy_management_retrieve
@@ -9262,14 +9599,22 @@ paths:
 
         Provides policy distribution metrics, acknowledgment rates,
         and compliance tracking for governance teams.
+      summary: Policy management analytics dashboard
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate policy dashboard
   /api/analytics/training-effectiveness/:
     get:
       operationId: analytics_training_effectiveness_retrieve
@@ -9278,14 +9623,22 @@ paths:
 
         Provides training completion rates, user engagement metrics,
         and security awareness campaign performance.
+      summary: Training effectiveness analytics dashboard
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate training dashboard
   /api/analytics/integrated-risk-posture/:
     get:
       operationId: analytics_integrated_risk_posture_retrieve
@@ -9295,14 +9648,22 @@ paths:
         Premium feature providing cross-module risk correlation,
         risk maturity indicators, and comprehensive risk trending.
         Requires advanced reporting subscription tier.
+      summary: Integrated risk posture analytics
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate integrated risk analysis
   /api/analytics/executive-report/:
     get:
       operationId: analytics_executive_report_retrieve
@@ -9312,14 +9673,22 @@ paths:
         Premium feature providing complete analytics package including
         all dashboard data, trends, and cross-module insights formatted
         for executive consumption and reporting.
+      summary: Executive report analytics data
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate executive report
   /api/analytics/operational/:
     get:
       operationId: analytics_operational_retrieve
@@ -9328,14 +9697,22 @@ paths:
 
         Provides actionable metrics focused on operational tasks,
         overdue items, progress tracking, and immediate attention items.
+      summary: Operational analytics dashboard
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to generate operational dashboard
   /api/analytics/operator/usage/:
     get:
       operationId: analytics_operator_usage_retrieve
@@ -9344,14 +9721,31 @@ paths:
 
         Returns aggregate tenant, subscription, module adoption and usage metrics
         without returning tenant-owned content such as document names or policy text.
+      summary: Operator usage dashboard
+      parameters:
+      - in: query
+        name: days
+        schema:
+          type: integer
+      - in: query
+        name: export
+        schema:
+          type: string
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '403':
+          description: Operator access required
   /api/analytics/export/:
     post:
       operationId: analytics_export_create
@@ -9360,14 +9754,38 @@ paths:
 
         Accepts report configuration and queues a background job for
         PDF, Excel, CSV, or JSON export generation.
+      summary: Create analytics report export
       tags:
-      - analytics
+      - Analytics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: {}
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: {}
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: {}
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          description: No response body
+        '202':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '400':
+          description: Invalid report export request
+        '500':
+          description: Failed to create export job
   /api/analytics/reports/:
     get:
       operationId: analytics_reports_retrieve
@@ -9375,14 +9793,27 @@ paths:
         List analytics reports created by the current user.
 
         Returns paginated list of reports with status and metadata.
+      summary: List my analytics reports
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to fetch reports
   /api/analytics/reports/{report_id}/status/:
     get:
       operationId: analytics_reports_status_retrieve
@@ -9391,6 +9822,7 @@ paths:
 
         Returns current status, progress information, and download link
         when completed.
+      summary: Get analytics report status
       parameters:
       - in: path
         name: report_id
@@ -9399,13 +9831,20 @@ paths:
           format: uuid
         required: true
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to check report status
   /api/analytics/reports/{report_id}/download/:
     get:
       operationId: analytics_reports_download_retrieve
@@ -9413,6 +9852,7 @@ paths:
         Download a completed analytics report file.
 
         Serves the generated report file and increments download counter.
+      summary: Download analytics report
       parameters:
       - in: path
         name: report_id
@@ -9421,13 +9861,21 @@ paths:
           format: uuid
         required: true
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          description: Generated report file
+        '400':
+          description: Report is not ready
+        '404':
+          description: Report file not found
+        '410':
+          description: Report has expired
+        '500':
+          description: Failed to download report
   /api/analytics/reports/{report_id}/:
     delete:
       operationId: analytics_reports_destroy
@@ -9435,6 +9883,7 @@ paths:
         Delete an analytics report and its associated file.
 
         Users can only delete their own reports.
+      summary: Delete analytics report
       parameters:
       - in: path
         name: report_id
@@ -9443,13 +9892,15 @@ paths:
           format: uuid
         required: true
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '204':
-          description: No response body
+        '200':
+          description: Report deleted successfully
+        '500':
+          description: Failed to delete report
   /api/analytics/cache/refresh/:
     post:
       operationId: analytics_cache_refresh_create
@@ -9458,14 +9909,22 @@ paths:
 
         Premium feature for forcing immediate cache refresh of
         analytics metrics for improved dashboard performance.
+      summary: Refresh analytics cache
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          description: No response body
+        '202':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Failed to refresh cache
   /api/analytics/health/:
     get:
       operationId: analytics_health_retrieve
@@ -9474,15 +9933,51 @@ paths:
 
         Provides basic system health information and data freshness
         indicators for monitoring and alerting purposes.
+      summary: Analytics health check
       tags:
-      - analytics
+      - Analytics
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '500':
+          description: Analytics service unavailable
   /api/vendors/vendors/:
+    post:
+      operationId: vendors_vendors_create
+      description: Create a new vendor profile with comprehensive vendor information.
+      summary: Create vendor
+      tags:
+      - Vendors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorCreateUpdate'
+          description: ''
     get:
       operationId: vendors_vendors_list
       description: Retrieve a paginated list of vendors with filtering, search, and
@@ -9694,34 +10189,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorList'
           description: ''
-    post:
-      operationId: vendors_vendors_create
-      description: Create a new vendor profile with comprehensive vendor information.
-      summary: Create vendor
-      tags:
-      - Vendors
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorCreateUpdate'
-          description: ''
   /api/vendors/vendors/bulk_create/:
     post:
       operationId: vendors_vendors_bulk_create_create
@@ -9820,11 +10287,10 @@ paths:
                 $ref: '#/components/schemas/VendorSummary'
           description: ''
   /api/vendors/vendors/{id}/:
-    get:
-      operationId: vendors_vendors_retrieve
-      description: Retrieve detailed information about a specific vendor including
-        contacts and services.
-      summary: Get vendor details
+    put:
+      operationId: vendors_vendors_update
+      description: Update an existing vendor profile with new information.
+      summary: Update vendor
       parameters:
       - in: path
         name: id
@@ -9834,6 +10300,18 @@ paths:
         required: true
       tags:
       - Vendors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -9842,7 +10320,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VendorDetail'
+                $ref: '#/components/schemas/VendorCreateUpdate'
           description: ''
     patch:
       operationId: vendors_vendors_partial_update
@@ -9927,10 +10405,11 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: vendors_vendors_update
-      description: Update an existing vendor profile with new information.
-      summary: Update vendor
+    get:
+      operationId: vendors_vendors_retrieve
+      description: Retrieve detailed information about a specific vendor including
+        contacts and services.
+      summary: Get vendor details
       parameters:
       - in: path
         name: id
@@ -9940,18 +10419,6 @@ paths:
         required: true
       tags:
       - Vendors
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -9960,7 +10427,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VendorCreateUpdate'
+                $ref: '#/components/schemas/VendorDetail'
           description: ''
   /api/vendors/vendors/{id}/add_note/:
     post:
@@ -10043,6 +10510,37 @@ paths:
                 $ref: '#/components/schemas/VendorDetail'
           description: ''
   /api/vendors/categories/:
+    post:
+      operationId: vendors_categories_create
+      description: |-
+        **Vendor Category Management**
+
+        Manage vendor categories for classification and organization.
+        Categories help organize vendors by business type, risk level, and compliance requirements.
+      tags:
+      - Vendor Categories
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorCategoryRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorCategory'
+          description: ''
     get:
       operationId: vendors_categories_list
       description: |-
@@ -10077,40 +10575,9 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorCategory'
           description: ''
-    post:
-      operationId: vendors_categories_create
-      description: |-
-        **Vendor Category Management**
-
-        Manage vendor categories for classification and organization.
-        Categories help organize vendors by business type, risk level, and compliance requirements.
-      tags:
-      - Vendor Categories
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorCategoryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorCategoryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorCategoryRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorCategory'
-          description: ''
   /api/vendors/categories/{id}/:
-    get:
-      operationId: vendors_categories_retrieve
+    put:
+      operationId: vendors_categories_update
       description: |-
         **Vendor Category Management**
 
@@ -10125,6 +10592,18 @@ paths:
         required: true
       tags:
       - Vendor Categories
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorCategoryRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -10194,8 +10673,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: vendors_categories_update
+    get:
+      operationId: vendors_categories_retrieve
       description: |-
         **Vendor Category Management**
 
@@ -10210,18 +10689,6 @@ paths:
         required: true
       tags:
       - Vendor Categories
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorCategoryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorCategoryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorCategoryRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -10233,6 +10700,36 @@ paths:
                 $ref: '#/components/schemas/VendorCategory'
           description: ''
   /api/vendors/contacts/:
+    post:
+      operationId: vendors_contacts_create
+      description: |-
+        **Vendor Contact Management**
+
+        Manage contact persons for vendors with different roles and responsibilities.
+      tags:
+      - Vendor Contacts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorContactRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorContactRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorContactRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorContact'
+          description: ''
     get:
       operationId: vendors_contacts_list
       description: |-
@@ -10344,12 +10841,20 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorContact'
           description: ''
-    post:
-      operationId: vendors_contacts_create
+  /api/vendors/contacts/{id}/:
+    put:
+      operationId: vendors_contacts_update
       description: |-
         **Vendor Contact Management**
 
         Manage contact persons for vendors with different roles and responsibilities.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor contact.
+        required: true
       tags:
       - Vendor Contacts
       requestBody:
@@ -10364,32 +10869,6 @@ paths:
             schema:
               $ref: '#/components/schemas/VendorContactRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorContact'
-          description: ''
-  /api/vendors/contacts/{id}/:
-    get:
-      operationId: vendors_contacts_retrieve
-      description: |-
-        **Vendor Contact Management**
-
-        Manage contact persons for vendors with different roles and responsibilities.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor contact.
-        required: true
-      tags:
-      - Vendor Contacts
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -10457,8 +10936,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: vendors_contacts_update
+    get:
+      operationId: vendors_contacts_retrieve
       description: |-
         **Vendor Contact Management**
 
@@ -10472,18 +10951,6 @@ paths:
         required: true
       tags:
       - Vendor Contacts
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorContactRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorContactRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorContactRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -10495,6 +10962,36 @@ paths:
                 $ref: '#/components/schemas/VendorContact'
           description: ''
   /api/vendors/services/:
+    post:
+      operationId: vendors_services_create
+      description: |-
+        **Vendor Service Management**
+
+        Manage services provided by vendors including categorization and risk assessment.
+      tags:
+      - Vendor Services
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorServiceRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorServiceRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorServiceRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorService'
+          description: ''
     get:
       operationId: vendors_services_list
       description: |-
@@ -10670,12 +11167,20 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorService'
           description: ''
-    post:
-      operationId: vendors_services_create
+  /api/vendors/services/{id}/:
+    put:
+      operationId: vendors_services_update
       description: |-
         **Vendor Service Management**
 
         Manage services provided by vendors including categorization and risk assessment.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor service.
+        required: true
       tags:
       - Vendor Services
       requestBody:
@@ -10690,32 +11195,6 @@ paths:
             schema:
               $ref: '#/components/schemas/VendorServiceRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorService'
-          description: ''
-  /api/vendors/services/{id}/:
-    get:
-      operationId: vendors_services_retrieve
-      description: |-
-        **Vendor Service Management**
-
-        Manage services provided by vendors including categorization and risk assessment.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor service.
-        required: true
-      tags:
-      - Vendor Services
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -10783,8 +11262,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: vendors_services_update
+    get:
+      operationId: vendors_services_retrieve
       description: |-
         **Vendor Service Management**
 
@@ -10798,18 +11277,6 @@ paths:
         required: true
       tags:
       - Vendor Services
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorServiceRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorServiceRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorServiceRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -10821,6 +11288,36 @@ paths:
                 $ref: '#/components/schemas/VendorService'
           description: ''
   /api/vendors/notes/:
+    post:
+      operationId: vendors_notes_create
+      description: |-
+        **Vendor Note Management**
+
+        Manage notes and comments about vendors for tracking interactions and decisions.
+      tags:
+      - Vendor Notes
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorNoteRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorNoteRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorNoteRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorNote'
+          description: ''
     get:
       operationId: vendors_notes_list
       description: |-
@@ -10854,12 +11351,20 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorNote'
           description: ''
-    post:
-      operationId: vendors_notes_create
+  /api/vendors/notes/{id}/:
+    put:
+      operationId: vendors_notes_update
       description: |-
         **Vendor Note Management**
 
         Manage notes and comments about vendors for tracking interactions and decisions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor note.
+        required: true
       tags:
       - Vendor Notes
       requestBody:
@@ -10874,32 +11379,6 @@ paths:
             schema:
               $ref: '#/components/schemas/VendorNoteRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorNote'
-          description: ''
-  /api/vendors/notes/{id}/:
-    get:
-      operationId: vendors_notes_retrieve
-      description: |-
-        **Vendor Note Management**
-
-        Manage notes and comments about vendors for tracking interactions and decisions.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor note.
-        required: true
-      tags:
-      - Vendor Notes
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -10967,8 +11446,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: vendors_notes_update
+    get:
+      operationId: vendors_notes_retrieve
       description: |-
         **Vendor Note Management**
 
@@ -10982,18 +11461,6 @@ paths:
         required: true
       tags:
       - Vendor Notes
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorNoteRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorNoteRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorNoteRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -11005,6 +11472,37 @@ paths:
                 $ref: '#/components/schemas/VendorNote'
           description: ''
   /api/vendors/tasks/:
+    post:
+      operationId: vendors_tasks_create
+      description: |-
+        **Vendor Task Management**
+
+        Comprehensive task management for vendor-related activities including contract renewals,
+        security reviews, compliance assessments, and automated task generation.
+      tags:
+      - Vendor Tasks
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorTaskCreateUpdate'
+          description: ''
     get:
       operationId: vendors_tasks_list
       description: |-
@@ -11337,37 +11835,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorTaskList'
           description: ''
-    post:
-      operationId: vendors_tasks_create
-      description: |-
-        **Vendor Task Management**
-
-        Comprehensive task management for vendor-related activities including contract renewals,
-        security reviews, compliance assessments, and automated task generation.
-      tags:
-      - Vendor Tasks
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorTaskCreateUpdate'
-          description: ''
   /api/vendors/tasks/bulk_action/:
     post:
       operationId: vendors_tasks_bulk_action_create
@@ -11504,8 +11971,8 @@ paths:
                 $ref: '#/components/schemas/VendorTaskDetail'
           description: ''
   /api/vendors/tasks/{id}/:
-    get:
-      operationId: vendors_tasks_retrieve
+    put:
+      operationId: vendors_tasks_update
       description: |-
         **Vendor Task Management**
 
@@ -11520,6 +11987,18 @@ paths:
         required: true
       tags:
       - Vendor Tasks
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -11528,7 +12007,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VendorTaskDetail'
+                $ref: '#/components/schemas/VendorTaskCreateUpdate'
           description: ''
     patch:
       operationId: vendors_tasks_partial_update
@@ -11589,8 +12068,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: vendors_tasks_update
+    get:
+      operationId: vendors_tasks_retrieve
       description: |-
         **Vendor Task Management**
 
@@ -11605,18 +12084,6 @@ paths:
         required: true
       tags:
       - Vendor Tasks
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -11625,7 +12092,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VendorTaskCreateUpdate'
+                $ref: '#/components/schemas/VendorTaskDetail'
           description: ''
   /api/vendors/tasks/{id}/update_status/:
     post:
@@ -11664,6 +12131,32 @@ paths:
                 $ref: '#/components/schemas/VendorTaskDetail'
           description: ''
   /api/vuln/targets/:
+    post:
+      operationId: vuln_targets_create
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScanTargetRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanTarget'
+          description: ''
     get:
       operationId: vuln_targets_list
       parameters:
@@ -11721,8 +12214,17 @@ paths:
                 items:
                   $ref: '#/components/schemas/ScanTarget'
           description: ''
-    post:
-      operationId: vuln_targets_create
+  /api/vuln/targets/{id}/:
+    put:
+      operationId: vuln_targets_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan target.
+        required: true
       tags:
       - vuln
       requestBody:
@@ -11737,29 +12239,6 @@ paths:
             schema:
               $ref: '#/components/schemas/ScanTargetRequest'
         required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScanTarget'
-          description: ''
-  /api/vuln/targets/{id}/:
-    get:
-      operationId: vuln_targets_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this scan target.
-        required: true
-      tags:
-      - vuln
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -11821,8 +12300,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: vuln_targets_update
+    get:
+      operationId: vuln_targets_retrieve
       parameters:
       - in: path
         name: id
@@ -11833,18 +12312,6 @@ paths:
         required: true
       tags:
       - vuln
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ScanTargetRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ScanTargetRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ScanTargetRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -11891,6 +12358,32 @@ paths:
                 $ref: '#/components/schemas/ScanTarget'
           description: ''
   /api/vuln/schedules/:
+    post:
+      operationId: vuln_schedules_create
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanSchedule'
+          description: ''
     get:
       operationId: vuln_schedules_list
       parameters:
@@ -11937,32 +12430,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/ScanSchedule'
           description: ''
-    post:
-      operationId: vuln_schedules_create
-      tags:
-      - vuln
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ScanScheduleRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ScanScheduleRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ScanScheduleRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScanSchedule'
-          description: ''
   /api/vuln/schedules/run-due/:
     post:
       operationId: vuln_schedules_run_due_create
@@ -11991,8 +12458,8 @@ paths:
                 $ref: '#/components/schemas/ScanSchedule'
           description: ''
   /api/vuln/schedules/{id}/:
-    get:
-      operationId: vuln_schedules_retrieve
+    put:
+      operationId: vuln_schedules_update
       parameters:
       - in: path
         name: id
@@ -12003,6 +12470,18 @@ paths:
         required: true
       tags:
       - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -12064,8 +12543,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: vuln_schedules_update
+    get:
+      operationId: vuln_schedules_retrieve
       parameters:
       - in: path
         name: id
@@ -12076,18 +12555,6 @@ paths:
         required: true
       tags:
       - vuln
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ScanScheduleRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ScanScheduleRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ScanScheduleRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -12293,28 +12760,6 @@ paths:
                 $ref: '#/components/schemas/VulnerabilityFinding'
           description: ''
   /api/vuln/findings/{id}/:
-    get:
-      operationId: vuln_findings_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this vulnerability finding.
-        required: true
-      tags:
-      - vuln
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VulnerabilityFinding'
-          description: ''
     patch:
       operationId: vuln_findings_partial_update
       parameters:
@@ -12338,6 +12783,28 @@ paths:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/PatchedVulnerabilityFindingRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VulnerabilityFinding'
+          description: ''
+    get:
+      operationId: vuln_findings_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this vulnerability finding.
+        required: true
+      tags:
+      - vuln
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -12465,27 +12932,38 @@ paths:
   /api/billing/billing_portal/:
     get:
       operationId: billing_billing_portal_retrieve
-      description: Create Stripe billing portal session.
+      description: Create a Stripe customer portal session for billing self-service.
+      summary: Create billing portal session
       tags:
-      - billing
+      - Billing
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          description: Billing portal session created
+        '404':
+          description: No billing information found
+        '500':
+          description: Failed to create billing portal session
   /api/billing/cancel_subscription/:
     post:
       operationId: billing_cancel_subscription_create
-      description: Cancel current subscription.
+      description: Cancel the current tenant subscription at the end of the active
+        billing period.
+      summary: Cancel current subscription
       tags:
-      - billing
+      - Billing
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
         '200':
-          description: No response body
+          description: Subscription cancellation scheduled
+        '404':
+          description: No active subscription found
+        '500':
+          description: Failed to cancel subscription
   /api/billing/create_checkout_session/:
     post:
       operationId: billing_create_checkout_session_create
@@ -12569,23 +13047,6 @@ paths:
         '400':
           description: Invalid module or tenant already has a non-trial subscription
   /api/limit-overrides/:
-    get:
-      operationId: limit_overrides_list
-      description: ViewSet for managing limit override requests with approval workflow.
-      tags:
-      - limit-overrides
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/LimitOverrideRequest'
-          description: ''
     post:
       operationId: limit_overrides_create
       description: Create a new limit override request.
@@ -12612,6 +13073,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LimitOverrideCreate'
+          description: ''
+    get:
+      operationId: limit_overrides_list
+      description: ViewSet for managing limit override requests with approval workflow.
+      tags:
+      - limit-overrides
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LimitOverrideRequest'
           description: ''
   /api/limit-overrides/approved_pending_application/:
     get:
@@ -12646,8 +13124,8 @@ paths:
                 $ref: '#/components/schemas/LimitOverrideRequest'
           description: ''
   /api/limit-overrides/{id}/:
-    get:
-      operationId: limit_overrides_retrieve
+    put:
+      operationId: limit_overrides_update
       description: ViewSet for managing limit override requests with approval workflow.
       parameters:
       - in: path
@@ -12658,6 +13136,18 @@ paths:
         required: true
       tags:
       - limit-overrides
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LimitOverrideRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/LimitOverrideRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/LimitOverrideRequestRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -12719,8 +13209,8 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: limit_overrides_update
+    get:
+      operationId: limit_overrides_retrieve
       description: ViewSet for managing limit override requests with approval workflow.
       parameters:
       - in: path
@@ -12731,18 +13221,6 @@ paths:
         required: true
       tags:
       - limit-overrides
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LimitOverrideRequestRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/LimitOverrideRequestRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/LimitOverrideRequestRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -12891,25 +13369,6 @@ paths:
                 $ref: '#/components/schemas/ApprovalAction'
           description: ''
   /api/documents/:
-    get:
-      operationId: documents_list
-      description: Retrieve a paginated list of documents uploaded by users in the
-        current tenant with secure access control.
-      summary: List documents
-      tags:
-      - Documents
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DocumentList'
-          description: ''
     post:
       operationId: documents_create
       description: Upload a new document file to secure tenant-isolated storage with
@@ -12950,6 +13409,25 @@ paths:
           description: Invalid file or data
         '403':
           description: Document limit exceeded for current plan
+    get:
+      operationId: documents_list
+      description: Retrieve a paginated list of documents uploaded by users in the
+        current tenant with secure access control.
+      summary: List documents
+      tags:
+      - Documents
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DocumentList'
+          description: ''
   /api/documents/plan_usage/:
     get:
       operationId: documents_plan_usage_retrieve
@@ -12985,11 +13463,10 @@ paths:
                 $ref: '#/components/schemas/Document'
           description: ''
   /api/documents/{id}/:
-    get:
-      operationId: documents_retrieve
-      description: Retrieve detailed information about a specific document including
-        metadata and access information.
-      summary: Get document details
+    put:
+      operationId: documents_update
+      description: Update document metadata. File cannot be changed after upload.
+      summary: Update document
       parameters:
       - in: path
         name: id
@@ -12999,6 +13476,15 @@ paths:
         required: true
       tags:
       - Documents
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/DocumentRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/DocumentRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -13085,10 +13571,11 @@ paths:
       responses:
         '204':
           description: No response body
-    put:
-      operationId: documents_update
-      description: Update document metadata. File cannot be changed after upload.
-      summary: Update document
+    get:
+      operationId: documents_retrieve
+      description: Retrieve detailed information about a specific document including
+        metadata and access information.
+      summary: Get document details
       parameters:
       - in: path
         name: id
@@ -13098,15 +13585,6 @@ paths:
         required: true
       tags:
       - Documents
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/DocumentRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/DocumentRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -13223,36 +13701,18 @@ paths:
           description: ''
 components:
   schemas:
-    ActionTypeEnum:
+    AnalyticsExportStatusEnum:
       enum:
-      - preventive
-      - detective
-      - corrective
-      - policy
-      - training
-      - technical
-      - assessment
-      - other
+      - pending
+      - processing
+      - completed
+      - failed
       type: string
       description: |-
-        * `preventive` - Preventive Control
-        * `detective` - Detective Control
-        * `corrective` - Corrective Action
-        * `policy` - Policy/Procedure
-        * `training` - Training/Awareness
-        * `technical` - Technical Implementation
-        * `assessment` - Assessment/Review
-        * `other` - Other
-    ApplicabilityEnum:
-      enum:
-      - applicable
-      - not_applicable
-      - to_be_determined
-      type: string
-      description: |-
-        * `applicable` - Applicable
-        * `not_applicable` - Not Applicable
-        * `to_be_determined` - To Be Determined
+        * `pending` - Pending Generation
+        * `processing` - Processing
+        * `completed` - Completed
+        * `failed` - Failed
     ApplicabilityStatusEnum:
       enum:
       - under_review
@@ -13287,6 +13747,17 @@ components:
           type: string
           description: Required for rejections - explain why the request was rejected
           maxLength: 1000
+    ApprovePushChallengeRequest:
+      type: object
+      properties:
+        challenge_id:
+          type: string
+          minLength: 1
+        approved:
+          type: boolean
+      required:
+      - approved
+      - challenge_id
     ArtefactTypeEnum:
       enum:
       - scope_document
@@ -13432,7 +13903,7 @@ components:
           readOnly: true
         status:
           allOf:
-          - $ref: '#/components/schemas/Status62aEnum'
+          - $ref: '#/components/schemas/AnalyticsExportStatusEnum'
           readOnly: true
         generated_file:
           type: integer
@@ -13585,9 +14056,9 @@ components:
         description:
           type: string
         classification:
-          $ref: '#/components/schemas/ClassificationEnum'
+          $ref: '#/components/schemas/DataClassificationEnum'
         criticality:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         lifecycle_status:
           $ref: '#/components/schemas/LifecycleStatusEnum'
         owner:
@@ -13595,6 +14066,7 @@ components:
           nullable: true
         owner_display:
           type: string
+          nullable: true
           readOnly: true
         owner_name:
           type: string
@@ -13677,11 +14149,12 @@ components:
         metadata:
           readOnly: true
         is_review_overdue:
-          type: string
+          type: boolean
           readOnly: true
         days_until_review:
-          type: string
+          type: integer
           readOnly: true
+          nullable: true
         created_by_username:
           type: string
           readOnly: true
@@ -13724,9 +14197,9 @@ components:
         description:
           type: string
         classification:
-          $ref: '#/components/schemas/ClassificationEnum'
+          $ref: '#/components/schemas/DataClassificationEnum'
         criticality:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         lifecycle_status:
           $ref: '#/components/schemas/LifecycleStatusEnum'
         owner:
@@ -13816,9 +14289,9 @@ components:
         asset_type:
           $ref: '#/components/schemas/AssetTypeEnum'
         classification:
-          $ref: '#/components/schemas/ClassificationEnum'
+          $ref: '#/components/schemas/DataClassificationEnum'
         criticality:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         lifecycle_status:
           $ref: '#/components/schemas/LifecycleStatusEnum'
         owner:
@@ -13826,6 +14299,7 @@ components:
           nullable: true
         owner_display:
           type: string
+          nullable: true
           readOnly: true
         owner_name:
           type: string
@@ -13838,19 +14312,20 @@ components:
           format: date
           nullable: true
         is_review_overdue:
-          type: string
+          type: boolean
           readOnly: true
         days_until_review:
-          type: string
+          type: integer
           readOnly: true
+          nullable: true
         linked_risk_count:
-          type: string
+          type: integer
           readOnly: true
         linked_control_count:
-          type: string
+          type: integer
           readOnly: true
         linked_document_count:
-          type: string
+          type: integer
           readOnly: true
       required:
       - asset_id
@@ -14002,7 +14477,7 @@ components:
           type: integer
         default_applicability:
           allOf:
-          - $ref: '#/components/schemas/DefaultApplicabilityEnum'
+          - $ref: '#/components/schemas/RequirementApplicabilityEnum'
           default: to_be_determined
         controls:
           type: array
@@ -14198,6 +14673,38 @@ components:
         * `scheduled` - Scheduled
         * `completed` - Completed
         * `cancelled` - Cancelled
+    CalendarNotificationPreference:
+      type: object
+      properties:
+        email_enabled:
+          type: boolean
+        advance_reminder_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        due_date_enabled:
+          type: boolean
+        overdue_enabled:
+          type: boolean
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - updated_at
+    CalendarNotificationPreferenceRequest:
+      type: object
+      properties:
+        email_enabled:
+          type: boolean
+        advance_reminder_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        due_date_enabled:
+          type: boolean
+        overdue_enabled:
+          type: boolean
     CalendarReminderLog:
       type: object
       properties:
@@ -14280,6 +14787,7 @@ components:
           readOnly: true
         user_name:
           type: string
+          nullable: true
           readOnly: true
         sent_at:
           type: string
@@ -14369,18 +14877,22 @@ components:
         * `security_services` - Security Services
         * `data_processing` - Data Processing
         * `other` - Other
-    ClassificationEnum:
-      enum:
-      - public
-      - internal
-      - confidential
-      - restricted
-      type: string
-      description: |-
-        * `public` - Public
-        * `internal` - Internal
-        * `confidential` - Confidential
-        * `restricted` - Restricted
+    ChangePasswordRequest:
+      type: object
+      properties:
+        old_password:
+          type: string
+          minLength: 1
+        new_password:
+          type: string
+          minLength: 1
+        new_password_confirm:
+          type: string
+          minLength: 1
+      required:
+      - new_password
+      - new_password_confirm
+      - old_password
     ClauseDetail:
       type: object
       description: Detailed clause serializer with full information.
@@ -14425,7 +14937,7 @@ components:
         clause_type:
           $ref: '#/components/schemas/ClauseTypeEnum'
         criticality:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         is_testable:
           type: boolean
           description: Whether this clause can be tested/audited
@@ -14438,10 +14950,12 @@ components:
         external_references:
           description: References to other standards, regulations, or frameworks
         control_count:
-          type: string
+          type: integer
           readOnly: true
         subclauses:
-          type: string
+          type: array
+          items:
+            $ref: '#/components/schemas/ClauseList'
           readOnly: true
         created_at:
           type: string
@@ -14497,7 +15011,7 @@ components:
         clause_type:
           $ref: '#/components/schemas/ClauseTypeEnum'
         criticality:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         is_testable:
           type: boolean
           description: Whether this clause can be tested/audited
@@ -14535,12 +15049,12 @@ components:
         clause_type:
           $ref: '#/components/schemas/ClauseTypeEnum'
         criticality:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         is_testable:
           type: boolean
           description: Whether this clause can be tested/audited
         control_count:
-          type: string
+          type: integer
           readOnly: true
         framework_name:
           type: string
@@ -14578,7 +15092,7 @@ components:
         clause_type:
           $ref: '#/components/schemas/ClauseTypeEnum'
         criticality:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         is_testable:
           type: boolean
           description: Whether this clause can be tested/audited
@@ -14622,6 +15136,15 @@ components:
         * `compliant` - Compliant
         * `non_compliant` - Non-Compliant
         * `accepted_risk` - Accepted Risk
+    ConfirmTOTPRequest:
+      type: object
+      properties:
+        otp_code:
+          type: string
+          minLength: 6
+          maxLength: 6
+      required:
+      - otp_code
     ContactTypeEnum:
       enum:
       - primary
@@ -14663,7 +15186,7 @@ components:
           description: Framework version this assessment was created against
         applicability:
           allOf:
-          - $ref: '#/components/schemas/ApplicabilityEnum'
+          - $ref: '#/components/schemas/RequirementApplicabilityEnum'
           description: |-
             Whether this control applies to the organization
 
@@ -14675,7 +15198,7 @@ components:
           description: Explanation of why the control is/isn't applicable
         status:
           allOf:
-          - $ref: '#/components/schemas/StatusEnum'
+          - $ref: '#/components/schemas/ControlAssessmentStatusEnum'
           description: |-
             Current assessment status
 
@@ -14742,7 +15265,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -14783,7 +15306,7 @@ components:
           description: Framework version this assessment was created against
         applicability:
           allOf:
-          - $ref: '#/components/schemas/ApplicabilityEnum'
+          - $ref: '#/components/schemas/RequirementApplicabilityEnum'
           description: |-
             Whether this control applies to the organization
 
@@ -14795,7 +15318,7 @@ components:
           description: Explanation of why the control is/isn't applicable
         status:
           allOf:
-          - $ref: '#/components/schemas/StatusEnum'
+          - $ref: '#/components/schemas/ControlAssessmentStatusEnum'
           description: |-
             Current assessment status
 
@@ -14862,7 +15385,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -14921,7 +15444,7 @@ components:
           readOnly: true
         applicability:
           allOf:
-          - $ref: '#/components/schemas/ApplicabilityEnum'
+          - $ref: '#/components/schemas/RequirementApplicabilityEnum'
           description: |-
             Whether this control applies to the organization
 
@@ -14933,7 +15456,7 @@ components:
           description: Explanation of why the control is/isn't applicable
         status:
           allOf:
-          - $ref: '#/components/schemas/StatusEnum'
+          - $ref: '#/components/schemas/ControlAssessmentStatusEnum'
           description: |-
             Current assessment status
 
@@ -15018,7 +15541,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -15055,22 +15578,26 @@ components:
           readOnly: true
           description: History of changes to this assessment
         is_overdue:
-          type: string
+          type: boolean
           readOnly: true
         is_complete:
-          type: string
+          type: boolean
           readOnly: true
         completion_percentage:
-          type: string
+          type: number
+          format: double
           readOnly: true
         days_until_due:
-          type: string
+          type: integer
           readOnly: true
+          nullable: true
         evidence_count:
-          type: string
+          type: integer
           readOnly: true
         primary_evidence:
-          type: string
+          allOf:
+          - $ref: '#/components/schemas/ControlEvidence'
+          nullable: true
           readOnly: true
         created_by_username:
           type: string
@@ -15116,7 +15643,7 @@ components:
           description: The control being assessed
         applicability:
           allOf:
-          - $ref: '#/components/schemas/ApplicabilityEnum'
+          - $ref: '#/components/schemas/RequirementApplicabilityEnum'
           description: |-
             Whether this control applies to the organization
 
@@ -15128,7 +15655,7 @@ components:
           description: Explanation of why the control is/isn't applicable
         status:
           allOf:
-          - $ref: '#/components/schemas/StatusEnum'
+          - $ref: '#/components/schemas/ControlAssessmentStatusEnum'
           description: |-
             Current assessment status
 
@@ -15195,7 +15722,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -15252,7 +15779,7 @@ components:
           readOnly: true
         applicability:
           allOf:
-          - $ref: '#/components/schemas/ApplicabilityEnum'
+          - $ref: '#/components/schemas/RequirementApplicabilityEnum'
           description: |-
             Whether this control applies to the organization
 
@@ -15261,7 +15788,7 @@ components:
             * `to_be_determined` - To Be Determined
         status:
           allOf:
-          - $ref: '#/components/schemas/StatusEnum'
+          - $ref: '#/components/schemas/ControlAssessmentStatusEnum'
           description: |-
             Current assessment status
 
@@ -15294,17 +15821,19 @@ components:
           nullable: true
           description: Target completion date for this assessment
         completion_percentage:
-          type: string
+          type: number
+          format: double
           readOnly: true
         is_overdue:
-          type: string
+          type: boolean
           readOnly: true
         is_complete:
-          type: string
+          type: boolean
           readOnly: true
         days_until_due:
-          type: string
+          type: integer
           readOnly: true
+          nullable: true
         risk_rating:
           description: |-
             Risk level if this control is not properly implemented
@@ -15314,7 +15843,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -15323,10 +15852,12 @@ components:
           nullable: true
           description: Compliance score (0-100) for this control
         evidence_count:
-          type: string
+          type: integer
+          description: Get count of evidence linked to this assessment.
           readOnly: true
         has_primary_evidence:
-          type: string
+          type: boolean
+          description: Check if assessment has primary evidence.
           readOnly: true
         created_at:
           type: string
@@ -15353,6 +15884,24 @@ components:
       - is_overdue
       - reviewer_name
       - updated_at
+    ControlAssessmentStatusEnum:
+      enum:
+      - not_started
+      - pending
+      - in_progress
+      - under_review
+      - complete
+      - not_applicable
+      - deferred
+      type: string
+      description: |-
+        * `not_started` - Not Started
+        * `pending` - Pending
+        * `in_progress` - In Progress
+        * `under_review` - Under Review
+        * `complete` - Complete
+        * `not_applicable` - Not Applicable
+        * `deferred` - Deferred
     ControlCreateUpdate:
       type: object
       description: Serializer for creating and updating controls.
@@ -15379,7 +15928,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status949Enum'
+          $ref: '#/components/schemas/ControlStatusEnum'
         control_owner:
           type: integer
           nullable: true
@@ -15402,7 +15951,7 @@ components:
           nullable: true
         last_test_result:
           oneOf:
-          - $ref: '#/components/schemas/LastTestResultEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         effectiveness_rating:
           description: |-
@@ -15413,7 +15962,7 @@ components:
             * `largely_effective` - Largely Effective
             * `fully_effective` - Fully Effective
           oneOf:
-          - $ref: '#/components/schemas/EffectivenessRatingEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         evidence_requirements:
           type: string
@@ -15429,7 +15978,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         remediation_plan:
           type: string
@@ -15472,7 +16021,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status949Enum'
+          $ref: '#/components/schemas/ControlStatusEnum'
         control_owner:
           type: integer
           nullable: true
@@ -15495,7 +16044,7 @@ components:
           nullable: true
         last_test_result:
           oneOf:
-          - $ref: '#/components/schemas/LastTestResultEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         effectiveness_rating:
           description: |-
@@ -15506,7 +16055,7 @@ components:
             * `largely_effective` - Largely Effective
             * `fully_effective` - Fully Effective
           oneOf:
-          - $ref: '#/components/schemas/EffectivenessRatingEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         evidence_requirements:
           type: string
@@ -15522,7 +16071,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         remediation_plan:
           type: string
@@ -15571,7 +16120,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status949Enum'
+          $ref: '#/components/schemas/ControlStatusEnum'
         control_owner:
           type: integer
           nullable: true
@@ -15597,7 +16146,7 @@ components:
           nullable: true
         last_test_result:
           oneOf:
-          - $ref: '#/components/schemas/LastTestResultEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         effectiveness_rating:
           description: |-
@@ -15608,7 +16157,7 @@ components:
             * `largely_effective` - Largely Effective
             * `fully_effective` - Fully Effective
           oneOf:
-          - $ref: '#/components/schemas/EffectivenessRatingEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         evidence_requirements:
           type: string
@@ -15624,7 +16173,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         remediation_plan:
           type: string
@@ -15635,13 +16184,15 @@ components:
         change_log:
           description: History of changes to this control
         is_active:
-          type: string
+          type: boolean
           readOnly: true
         needs_testing:
-          type: string
+          type: boolean
           readOnly: true
         framework_coverage:
-          type: string
+          type: array
+          items:
+            $ref: '#/components/schemas/FrameworkCoverageItem'
           readOnly: true
         evidence:
           type: array
@@ -15710,7 +16261,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status949Enum'
+          $ref: '#/components/schemas/ControlStatusEnum'
         control_owner:
           type: integer
           nullable: true
@@ -15733,7 +16284,7 @@ components:
           nullable: true
         last_test_result:
           oneOf:
-          - $ref: '#/components/schemas/LastTestResultEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         effectiveness_rating:
           description: |-
@@ -15744,7 +16295,7 @@ components:
             * `largely_effective` - Largely Effective
             * `fully_effective` - Fully Effective
           oneOf:
-          - $ref: '#/components/schemas/EffectivenessRatingEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         evidence_requirements:
           type: string
@@ -15760,7 +16311,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         remediation_plan:
           type: string
@@ -15777,6 +16328,18 @@ components:
       - control_type
       - description
       - name
+    ControlEffectivenessRatingEnum:
+      enum:
+      - not_effective
+      - partially_effective
+      - largely_effective
+      - fully_effective
+      type: string
+      description: |-
+        * `not_effective` - Not Effective
+        * `partially_effective` - Partially Effective
+        * `largely_effective` - Largely Effective
+        * `fully_effective` - Fully Effective
     ControlEvidence:
       type: object
       description: Serializer for control evidence.
@@ -15789,7 +16352,7 @@ components:
           description: Evidence title or description
           maxLength: 200
         evidence_type:
-          $ref: '#/components/schemas/EvidenceTypeEnum'
+          $ref: '#/components/schemas/ControlEvidenceTypeEnum'
         description:
           type: string
           description: Additional evidence description
@@ -15869,7 +16432,7 @@ components:
           description: Evidence title or description
           maxLength: 200
         evidence_type:
-          $ref: '#/components/schemas/EvidenceTypeEnum'
+          $ref: '#/components/schemas/ControlEvidenceTypeEnum'
         description:
           type: string
           description: Additional evidence description
@@ -15906,6 +16469,28 @@ components:
       required:
       - evidence_type
       - title
+    ControlEvidenceTypeEnum:
+      enum:
+      - document
+      - screenshot
+      - log_file
+      - report
+      - certificate
+      - approval
+      - test_result
+      - meeting_notes
+      - other
+      type: string
+      description: |-
+        * `document` - Document/Policy
+        * `screenshot` - Screenshot
+        * `log_file` - Log File
+        * `report` - Report
+        * `certificate` - Certificate
+        * `approval` - Approval/Sign-off
+        * `test_result` - Test Result
+        * `meeting_notes` - Meeting Notes
+        * `other` - Other
     ControlList:
       type: object
       description: Lightweight serializer for control listings.
@@ -15927,7 +16512,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status949Enum'
+          $ref: '#/components/schemas/ControlStatusEnum'
         control_owner_name:
           type: string
           readOnly: true
@@ -15940,7 +16525,7 @@ components:
             * `largely_effective` - Largely Effective
             * `fully_effective` - Fully Effective
           oneOf:
-          - $ref: '#/components/schemas/EffectivenessRatingEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         last_tested_date:
           type: string
@@ -15955,19 +16540,21 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         is_active:
-          type: string
+          type: boolean
           readOnly: true
         needs_testing:
-          type: string
+          type: boolean
           readOnly: true
         framework_coverage:
-          type: string
+          type: array
+          items:
+            $ref: '#/components/schemas/FrameworkCoverageItem'
           readOnly: true
         clause_count:
-          type: string
+          type: integer
           readOnly: true
         version:
           type: string
@@ -16002,7 +16589,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status949Enum'
+          $ref: '#/components/schemas/ControlStatusEnum'
         effectiveness_rating:
           description: |-
             Current effectiveness assessment
@@ -16012,7 +16599,7 @@ components:
             * `largely_effective` - Largely Effective
             * `fully_effective` - Fully Effective
           oneOf:
-          - $ref: '#/components/schemas/EffectivenessRatingEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         last_tested_date:
           type: string
@@ -16027,7 +16614,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         version:
           type: string
@@ -16037,6 +16624,26 @@ components:
       - control_id
       - control_type
       - name
+    ControlStatusEnum:
+      enum:
+      - planned
+      - in_progress
+      - implemented
+      - testing
+      - active
+      - remediation
+      - disabled
+      - retired
+      type: string
+      description: |-
+        * `planned` - Planned
+        * `in_progress` - In Progress
+        * `implemented` - Implemented
+        * `testing` - Under Testing
+        * `active` - Active
+        * `remediation` - Needs Remediation
+        * `disabled` - Disabled
+        * `retired` - Retired
     ControlTypeEnum:
       enum:
       - preventive
@@ -16067,48 +16674,6 @@ components:
         * `internal` - Internal
         * `confidential` - Confidential
         * `restricted` - Restricted
-    DefaultActionTypeEnum:
-      enum:
-      - preventive
-      - detective
-      - corrective
-      - policy
-      - training
-      - technical
-      - assessment
-      - other
-      type: string
-      description: |-
-        * `preventive` - Preventive Control
-        * `detective` - Detective Control
-        * `corrective` - Corrective Action
-        * `policy` - Policy/Procedure
-        * `training` - Training/Awareness
-        * `technical` - Technical Implementation
-        * `assessment` - Assessment/Review
-        * `other` - Other
-    DefaultApplicabilityEnum:
-      enum:
-      - applicable
-      - not_applicable
-      - to_be_determined
-      type: string
-      description: |-
-        * `applicable` - Applicable
-        * `not_applicable` - Not Applicable
-        * `to_be_determined` - To Be Determined
-    DefaultPriorityEnum:
-      enum:
-      - low
-      - medium
-      - high
-      - critical
-      type: string
-      description: |-
-        * `low` - Low
-        * `medium` - Medium
-        * `high` - High
-        * `critical` - Critical
     DeliveryStatusEnum:
       enum:
       - sent
@@ -16125,6 +16690,16 @@ components:
         * `clicked` - Clicked
         * `bounced` - Bounced
         * `failed` - Failed
+    DeviceTypeEnum:
+      enum:
+      - ios
+      - android
+      - web
+      type: string
+      description: |-
+        * `ios` - ios
+        * `android` - android
+        * `web` - web
     DifficultyLevelEnum:
       enum:
       - beginner
@@ -16135,6 +16710,30 @@ components:
         * `beginner` - Beginner
         * `intermediate` - Intermediate
         * `advanced` - Advanced
+    DisableTwoFactorMethodEnum:
+      enum:
+      - email
+      - totp
+      - push
+      - all
+      type: string
+      description: |-
+        * `email` - email
+        * `totp` - totp
+        * `push` - push
+        * `all` - all
+    DisableTwoFactorRequest:
+      type: object
+      properties:
+        password:
+          type: string
+          minLength: 1
+        method:
+          allOf:
+          - $ref: '#/components/schemas/DisableTwoFactorMethodEnum'
+          default: all
+      required:
+      - password
     Document:
       type: object
       description: Serializer for document uploads with file validation and metadata.
@@ -16153,7 +16752,9 @@ components:
           description: Upload documents (PDF, DOC, XLS, etc.)
         file_url:
           type: string
+          format: uri
           readOnly: true
+          nullable: true
         file_name:
           type: string
           readOnly: true
@@ -16271,18 +16872,41 @@ components:
         * `template` - Template
         * `sample` - Sample
         * `other` - Other
-    EffectivenessRatingEnum:
+    EnableTwoFactorMethodEnum:
       enum:
-      - not_effective
-      - partially_effective
-      - largely_effective
-      - fully_effective
+      - email
+      - totp
+      - push
       type: string
       description: |-
-        * `not_effective` - Not Effective
-        * `partially_effective` - Partially Effective
-        * `largely_effective` - Largely Effective
-        * `fully_effective` - Fully Effective
+        * `email` - email
+        * `totp` - totp
+        * `push` - push
+    EnableTwoFactorRequest:
+      type: object
+      properties:
+        password:
+          type: string
+          minLength: 1
+        method:
+          $ref: '#/components/schemas/EnableTwoFactorMethodEnum'
+        email:
+          type: string
+          format: email
+          minLength: 1
+        device_token:
+          type: string
+          minLength: 1
+        device_name:
+          type: string
+          minLength: 1
+        device_type:
+          $ref: '#/components/schemas/DeviceTypeEnum'
+        push_service:
+          $ref: '#/components/schemas/PushServiceEnum'
+      required:
+      - method
+      - password
     EventTypeEnum:
       enum:
       - deadline
@@ -16297,48 +16921,6 @@ components:
         * `meeting` - Meeting
         * `training` - Training
         * `custom` - Custom
-    EvidenceTypeA14Enum:
-      enum:
-      - document
-      - screenshot
-      - report
-      - certificate
-      - configuration
-      - training_record
-      - audit_log
-      - other
-      type: string
-      description: |-
-        * `document` - Document/Policy
-        * `screenshot` - Screenshot
-        * `report` - Report/Analysis
-        * `certificate` - Certificate
-        * `configuration` - Configuration File
-        * `training_record` - Training Record
-        * `audit_log` - Audit Log
-        * `other` - Other
-    EvidenceTypeEnum:
-      enum:
-      - document
-      - screenshot
-      - log_file
-      - report
-      - certificate
-      - approval
-      - test_result
-      - meeting_notes
-      - other
-      type: string
-      description: |-
-        * `document` - Document/Policy
-        * `screenshot` - Screenshot
-        * `log_file` - Log File
-        * `report` - Report
-        * `certificate` - Certificate
-        * `approval` - Approval/Sign-off
-        * `test_result` - Test Result
-        * `meeting_notes` - Meeting Notes
-        * `other` - Other
     ExportFormatEnum:
       enum:
       - xlsx
@@ -16347,6 +16929,19 @@ components:
       description: |-
         * `xlsx` - Excel workbook
         * `csv_zip` - CSV archive
+    FrameworkCoverageItem:
+      type: object
+      properties:
+        id:
+          type: integer
+        short_name:
+          type: string
+        name:
+          type: string
+      required:
+      - id
+      - name
+      - short_name
     FrameworkDetail:
       type: object
       description: Detailed framework serializer with full information.
@@ -16400,19 +16995,19 @@ components:
           nullable: true
           description: Date when this version expires
         status:
-          $ref: '#/components/schemas/StatusFa2Enum'
+          $ref: '#/components/schemas/FrameworkStatusEnum'
         is_mandatory:
           type: boolean
           description: Whether compliance with this framework is mandatory for the
             organization
         clause_count:
-          type: string
+          type: integer
           readOnly: true
         control_count:
-          type: string
+          type: integer
           readOnly: true
         is_active:
-          type: string
+          type: boolean
           readOnly: true
         created_by_username:
           type: string
@@ -16503,7 +17098,7 @@ components:
           nullable: true
           description: Date when this version expires
         status:
-          $ref: '#/components/schemas/StatusFa2Enum'
+          $ref: '#/components/schemas/FrameworkStatusEnum'
         is_mandatory:
           type: boolean
           description: Whether compliance with this framework is mandatory for the
@@ -16537,7 +17132,7 @@ components:
         framework_type:
           $ref: '#/components/schemas/FrameworkTypeEnum'
         status:
-          $ref: '#/components/schemas/StatusFa2Enum'
+          $ref: '#/components/schemas/FrameworkStatusEnum'
         is_mandatory:
           type: boolean
           description: Whether compliance with this framework is mandatory for the
@@ -16547,13 +17142,13 @@ components:
           format: date
           description: Date when this version became effective
         clause_count:
-          type: string
+          type: integer
           readOnly: true
         control_count:
-          type: string
+          type: integer
           readOnly: true
         is_active:
-          type: string
+          type: boolean
           readOnly: true
         issuing_organization:
           type: string
@@ -16643,6 +17238,18 @@ components:
       - mapping_type
       - source_clause
       - target_clause
+    FrameworkStatusEnum:
+      enum:
+      - draft
+      - active
+      - deprecated
+      - archived
+      type: string
+      description: |-
+        * `draft` - Draft
+        * `active` - Active
+        * `deprecated` - Deprecated
+        * `archived` - Archived
     FrameworkTypeEnum:
       enum:
       - security
@@ -16845,7 +17452,7 @@ components:
           maxLength: 80
         tags: {}
         status:
-          $ref: '#/components/schemas/StatusDaeEnum'
+          $ref: '#/components/schemas/KnowledgeArticleStatusEnum'
         content_scope:
           $ref: '#/components/schemas/ContentScopeEnum'
         sort_order:
@@ -16911,7 +17518,7 @@ components:
           maxLength: 80
         tags: {}
         status:
-          $ref: '#/components/schemas/StatusDaeEnum'
+          $ref: '#/components/schemas/KnowledgeArticleStatusEnum'
         content_scope:
           $ref: '#/components/schemas/ContentScopeEnum'
         sort_order:
@@ -16952,7 +17559,7 @@ components:
           maxLength: 80
         tags: {}
         status:
-          $ref: '#/components/schemas/StatusDaeEnum'
+          $ref: '#/components/schemas/KnowledgeArticleStatusEnum'
         content_scope:
           $ref: '#/components/schemas/ContentScopeEnum'
         sort_order:
@@ -16975,6 +17582,16 @@ components:
       - slug
       - title
       - updated_at
+    KnowledgeArticleStatusEnum:
+      enum:
+      - draft
+      - published
+      - archived
+      type: string
+      description: |-
+        * `draft` - Draft
+        * `published` - Published
+        * `archived` - Archived
     KnowledgeCategory:
       type: object
       properties:
@@ -17045,18 +17662,6 @@ components:
       required:
       - name
       - slug
-    LastTestResultEnum:
-      enum:
-      - not_effective
-      - partially_effective
-      - largely_effective
-      - fully_effective
-      type: string
-      description: |-
-        * `not_effective` - Not Effective
-        * `partially_effective` - Partially Effective
-        * `largely_effective` - Largely Effective
-        * `fully_effective` - Fully Effective
     LifecycleStateEnum:
       enum:
       - template
@@ -17183,7 +17788,7 @@ components:
           nullable: true
           description: When should temporary limits expire?
         status:
-          $ref: '#/components/schemas/Status8f5Enum'
+          $ref: '#/components/schemas/LimitOverrideStatusEnum'
         status_display:
           type: string
           readOnly: true
@@ -17313,7 +17918,7 @@ components:
           nullable: true
           description: When should temporary limits expire?
         status:
-          $ref: '#/components/schemas/Status8f5Enum'
+          $ref: '#/components/schemas/LimitOverrideStatusEnum'
         first_approval_notes:
           type: string
         second_approval_notes:
@@ -17325,6 +17930,20 @@ components:
       - current_limit
       - limit_type
       - requested_limit
+    LimitOverrideStatusEnum:
+      enum:
+      - pending
+      - approved
+      - rejected
+      - applied
+      - expired
+      type: string
+      description: |-
+        * `pending` - Pending Review
+        * `approved` - Approved
+        * `rejected` - Rejected
+        * `applied` - Applied
+        * `expired` - Expired
     LimitTypeEnum:
       enum:
       - max_users
@@ -17349,6 +17968,18 @@ components:
       required:
       - password
       - username
+    LowMediumHighCriticalEnum:
+      enum:
+      - low
+      - medium
+      - high
+      - critical
+      type: string
+      description: |-
+        * `low` - Low
+        * `medium` - Medium
+        * `high` - High
+        * `critical` - Critical
     ManagementReview:
       type: object
       properties:
@@ -17534,6 +18165,21 @@ components:
         * `defined` - Defined
         * `managed` - Managed
         * `optimized` - Optimized
+    ModuleCatalogItem:
+      type: object
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        enabled:
+          type: boolean
+      required:
+      - description
+      - key
+      - name
     ModuleEnum:
       enum:
       - policy
@@ -17646,7 +18292,7 @@ components:
             type: integer
         metadata: {}
         is_overdue:
-          type: string
+          type: boolean
           readOnly: true
         created_at:
           type: string
@@ -17764,20 +18410,6 @@ components:
         * `verification` - Verification
         * `closed` - Closed
         * `accepted` - Accepted
-    NoteType679Enum:
-      enum:
-      - progress
-      - issue
-      - completion
-      - status_change
-      - general
-      type: string
-      description: |-
-        * `progress` - Progress Update
-        * `issue` - Issue/Blocker
-        * `completion` - Completion
-        * `status_change` - Status Change
-        * `general` - General
     PaginatedAssetListList:
       type: object
       required:
@@ -17994,9 +18626,9 @@ components:
         description:
           type: string
         classification:
-          $ref: '#/components/schemas/ClassificationEnum'
+          $ref: '#/components/schemas/DataClassificationEnum'
         criticality:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         lifecycle_status:
           $ref: '#/components/schemas/LifecycleStatusEnum'
         owner:
@@ -18123,7 +18755,7 @@ components:
         clause_type:
           $ref: '#/components/schemas/ClauseTypeEnum'
         criticality:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         is_testable:
           type: boolean
           description: Whether this clause can be tested/audited
@@ -18148,7 +18780,7 @@ components:
           description: Framework version this assessment was created against
         applicability:
           allOf:
-          - $ref: '#/components/schemas/ApplicabilityEnum'
+          - $ref: '#/components/schemas/RequirementApplicabilityEnum'
           description: |-
             Whether this control applies to the organization
 
@@ -18160,7 +18792,7 @@ components:
           description: Explanation of why the control is/isn't applicable
         status:
           allOf:
-          - $ref: '#/components/schemas/StatusEnum'
+          - $ref: '#/components/schemas/ControlAssessmentStatusEnum'
           description: |-
             Current assessment status
 
@@ -18227,7 +18859,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         compliance_score:
           type: integer
@@ -18282,7 +18914,7 @@ components:
         automation_level:
           $ref: '#/components/schemas/AutomationLevelEnum'
         status:
-          $ref: '#/components/schemas/Status949Enum'
+          $ref: '#/components/schemas/ControlStatusEnum'
         control_owner:
           type: integer
           nullable: true
@@ -18305,7 +18937,7 @@ components:
           nullable: true
         last_test_result:
           oneOf:
-          - $ref: '#/components/schemas/LastTestResultEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         effectiveness_rating:
           description: |-
@@ -18316,7 +18948,7 @@ components:
             * `largely_effective` - Largely Effective
             * `fully_effective` - Fully Effective
           oneOf:
-          - $ref: '#/components/schemas/EffectivenessRatingEnum'
+          - $ref: '#/components/schemas/ControlEffectivenessRatingEnum'
           - $ref: '#/components/schemas/BlankEnum'
         evidence_requirements:
           type: string
@@ -18332,7 +18964,7 @@ components:
             * `high` - High
             * `critical` - Critical
           oneOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           - $ref: '#/components/schemas/BlankEnum'
         remediation_plan:
           type: string
@@ -18351,7 +18983,7 @@ components:
           description: Evidence title or description
           maxLength: 200
         evidence_type:
-          $ref: '#/components/schemas/EvidenceTypeEnum'
+          $ref: '#/components/schemas/ControlEvidenceTypeEnum'
         description:
           type: string
           description: Additional evidence description
@@ -18460,7 +19092,7 @@ components:
           nullable: true
           description: Date when this version expires
         status:
-          $ref: '#/components/schemas/StatusFa2Enum'
+          $ref: '#/components/schemas/FrameworkStatusEnum'
         is_mandatory:
           type: boolean
           description: Whether compliance with this framework is mandatory for the
@@ -18556,7 +19188,7 @@ components:
           maxLength: 80
         tags: {}
         status:
-          $ref: '#/components/schemas/StatusDaeEnum'
+          $ref: '#/components/schemas/KnowledgeArticleStatusEnum'
         content_scope:
           $ref: '#/components/schemas/ContentScopeEnum'
         sort_order:
@@ -18616,7 +19248,7 @@ components:
           nullable: true
           description: When should temporary limits expire?
         status:
-          $ref: '#/components/schemas/Status8f5Enum'
+          $ref: '#/components/schemas/LimitOverrideStatusEnum'
         first_approval_notes:
           type: string
         second_approval_notes:
@@ -18861,7 +19493,7 @@ components:
         compliance_status:
           $ref: '#/components/schemas/ComplianceStatusEnum'
         priority:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         owner:
           type: integer
           nullable: true
@@ -18904,13 +19536,13 @@ components:
           type: string
           minLength: 1
         action_type:
-          $ref: '#/components/schemas/ActionTypeEnum'
+          $ref: '#/components/schemas/RiskActionTypeEnum'
         assigned_to:
           type: integer
           nullable: true
           description: Person responsible for completing this action
         priority:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         start_date:
           type: string
           format: date
@@ -19032,7 +19664,7 @@ components:
           minimum: 1
           description: Likelihood level (1=Very Low, 5=Very High)
         status:
-          $ref: '#/components/schemas/StatusDb9Enum'
+          $ref: '#/components/schemas/RiskStatusEnum'
         treatment_strategy:
           oneOf:
           - $ref: '#/components/schemas/TreatmentStrategyEnum'
@@ -19213,6 +19845,23 @@ components:
           $ref: '#/components/schemas/DifficultyLevelEnum'
         is_published:
           type: boolean
+    PatchedUserProfileRequest:
+      type: object
+      properties:
+        email:
+          title: Email address
+          oneOf:
+          - type: string
+            format: email
+            maxLength: 254
+          - type: string
+            maxLength: 0
+        first_name:
+          type: string
+          maxLength: 150
+        last_name:
+          type: string
+          maxLength: 150
     PatchedVendorCategoryRequest:
       type: object
       description: Serializer for vendor categories.
@@ -19332,11 +19981,11 @@ components:
           type: string
           maxLength: 100
         status:
-          $ref: '#/components/schemas/StatusAb0Enum'
+          $ref: '#/components/schemas/VendorStatusEnum'
         vendor_type:
           $ref: '#/components/schemas/VendorTypeEnum'
         risk_level:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         risk_score:
           type: string
           format: decimal
@@ -19527,9 +20176,9 @@ components:
           nullable: true
           description: Optional start date for the task
         priority:
-          $ref: '#/components/schemas/Priority0aeEnum'
+          $ref: '#/components/schemas/VendorTaskPriorityEnum'
         status:
-          $ref: '#/components/schemas/Status8b3Enum'
+          $ref: '#/components/schemas/VendorTaskStatusEnum'
         assigned_to:
           type: integer
           nullable: true
@@ -19608,7 +20257,9 @@ components:
           type: boolean
         included_modules: {}
         module_catalog:
-          type: string
+          type: array
+          items:
+            $ref: '#/components/schemas/ModuleCatalogItem'
           readOnly: true
       required:
       - id
@@ -19627,7 +20278,7 @@ components:
           type: integer
         user_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
         policy_version:
           type: string
@@ -19677,6 +20328,18 @@ components:
       - policy_version_details
       - user
       - user_details
+    PolicyApprovalStatusEnum:
+      enum:
+      - draft
+      - under_review
+      - approved
+      - archived
+      type: string
+      description: |-
+        * `draft` - Draft
+        * `under_review` - Under Review
+        * `approved` - Approved
+        * `archived` - Archived
     PolicyCategory:
       type: object
       description: Serializer for policy categories.
@@ -19697,7 +20360,8 @@ components:
           description: Hex color code for visual identification
           maxLength: 7
         policies_count:
-          type: string
+          type: integer
+          description: Get count of policies in this category.
           readOnly: true
         created_at:
           type: string
@@ -19843,13 +20507,13 @@ components:
         policy_type:
           $ref: '#/components/schemas/PolicyTypeEnum'
         status:
-          $ref: '#/components/schemas/StatusD38Enum'
+          $ref: '#/components/schemas/PolicyApprovalStatusEnum'
         owner:
           type: integer
           description: Policy owner/manager responsible for this policy
         owner_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
         approver:
           type: integer
@@ -19857,7 +20521,7 @@ components:
           description: User who approved this policy
         approver_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
         review_frequency_months:
           type: integer
@@ -19894,7 +20558,21 @@ components:
           type: boolean
           readOnly: true
         acknowledgment_stats:
-          type: string
+          type: object
+          properties:
+            total_acknowledgments:
+              type: integer
+            total_distributions:
+              type: integer
+            pending_acknowledgments:
+              type: integer
+            acknowledgment_rate:
+              type: number
+              format: float
+          required:
+          - total_acknowledgments
+          - pending_acknowledgments
+          - acknowledgment_rate
           readOnly: true
         created_at:
           type: string
@@ -19906,7 +20584,7 @@ components:
           readOnly: true
         created_by_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
       required:
       - acknowledgment_stats
@@ -19940,7 +20618,7 @@ components:
         policy_type:
           $ref: '#/components/schemas/PolicyTypeEnum'
         status:
-          $ref: '#/components/schemas/StatusD38Enum'
+          $ref: '#/components/schemas/PolicyApprovalStatusEnum'
         owner:
           type: integer
           description: Policy owner/manager responsible for this policy
@@ -19995,14 +20673,14 @@ components:
           type: integer
         distributed_to_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
         distributed_by:
           type: integer
           nullable: true
         distributed_by_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
         distributed_at:
           type: string
@@ -20067,7 +20745,7 @@ components:
         policy_type:
           $ref: '#/components/schemas/PolicyTypeEnum'
         status:
-          $ref: '#/components/schemas/StatusD38Enum'
+          $ref: '#/components/schemas/PolicyApprovalStatusEnum'
         category_name:
           type: string
           readOnly: true
@@ -20076,7 +20754,7 @@ components:
           readOnly: true
         owner_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
         current_version:
           allOf:
@@ -20101,10 +20779,12 @@ components:
           minimum: 0
           description: How long acknowledgments remain valid (days)
         versions_count:
-          type: string
+          type: integer
+          description: Get count of versions for this policy.
           readOnly: true
         acknowledgment_count:
-          type: string
+          type: integer
+          description: Get count of acknowledgments for current version.
           readOnly: true
         is_due_for_review:
           type: boolean
@@ -20142,7 +20822,7 @@ components:
         policy_type:
           $ref: '#/components/schemas/PolicyTypeEnum'
         status:
-          $ref: '#/components/schemas/StatusD38Enum'
+          $ref: '#/components/schemas/PolicyApprovalStatusEnum'
         review_frequency_months:
           type: integer
           maximum: 2147483647
@@ -20177,6 +20857,33 @@ components:
         * `standard` - Standard
         * `guideline` - Guideline
         * `framework` - Framework
+    PolicyUserBasic:
+      type: object
+      description: Basic user information for policy context.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        email:
+          type: string
+          format: email
+          readOnly: true
+          title: Email address
+        first_name:
+          type: string
+          readOnly: true
+        last_name:
+          type: string
+          readOnly: true
+        full_name:
+          type: string
+          readOnly: true
+      required:
+      - email
+      - first_name
+      - full_name
+      - id
+      - last_name
     PolicyVersionDetail:
       type: object
       description: Detailed serializer for policy versions.
@@ -20267,7 +20974,8 @@ components:
           readOnly: true
           nullable: true
         acknowledgments_count:
-          type: string
+          type: integer
+          description: Get count of acknowledgments for this version.
           readOnly: true
         created_at:
           type: string
@@ -20275,15 +20983,15 @@ components:
           readOnly: true
         created_by_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
         approved_by_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
         finalized_by_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
       required:
       - acknowledgments_count
@@ -20435,11 +21143,11 @@ components:
           nullable: true
         created_by_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
         approved_by_details:
           allOf:
-          - $ref: '#/components/schemas/UserBasic'
+          - $ref: '#/components/schemas/PolicyUserBasic'
           readOnly: true
       required:
       - approved_by_details
@@ -20515,20 +21223,45 @@ components:
         * `email` - Email
         * `phone` - Phone
         * `mobile` - Mobile
-    Priority0aeEnum:
+    PrimaryMethodEnum:
       enum:
-      - low
-      - medium
-      - high
-      - urgent
-      - critical
+      - email
+      - totp
+      - push
       type: string
       description: |-
-        * `low` - Low Priority
-        * `medium` - Medium Priority
-        * `high` - High Priority
-        * `urgent` - Urgent
-        * `critical` - Critical
+        * `email` - Email OTP
+        * `totp` - Authenticator App
+        * `push` - Push Notification
+    PushServiceEnum:
+      enum:
+      - fcm
+      - apns
+      - web_push
+      type: string
+      description: |-
+        * `fcm` - fcm
+        * `apns` - apns
+        * `web_push` - web_push
+    RegisterPushDeviceRequest:
+      type: object
+      properties:
+        device_token:
+          type: string
+          minLength: 1
+        device_name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        device_type:
+          $ref: '#/components/schemas/DeviceTypeEnum'
+        push_service:
+          $ref: '#/components/schemas/PushServiceEnum'
+      required:
+      - device_name
+      - device_token
+      - device_type
+      - push_service
     RegisterRequest:
       type: object
       properties:
@@ -20595,7 +21328,7 @@ components:
         compliance_status:
           $ref: '#/components/schemas/ComplianceStatusEnum'
         priority:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         owner:
           type: integer
           nullable: true
@@ -20672,7 +21405,7 @@ components:
         compliance_status:
           $ref: '#/components/schemas/ComplianceStatusEnum'
         priority:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         owner:
           type: integer
           nullable: true
@@ -20742,6 +21475,16 @@ components:
         * `evidence_portfolio` - Evidence Portfolio Report
         * `compliance_gap` - Compliance Gap Analysis
         * `risk_analytics` - Risk Analytics & Integration Report
+    RequirementApplicabilityEnum:
+      enum:
+      - applicable
+      - not_applicable
+      - to_be_determined
+      type: string
+      description: |-
+        * `applicable` - Applicable
+        * `not_applicable` - Not Applicable
+        * `to_be_determined` - To Be Determined
     RiskActionBulkCreateRequest:
       type: object
       description: Serializer for bulk creating risk actions.
@@ -20753,11 +21496,11 @@ components:
           nullable: true
         default_priority:
           allOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           default: medium
         default_action_type:
           allOf:
-          - $ref: '#/components/schemas/DefaultActionTypeEnum'
+          - $ref: '#/components/schemas/RiskActionTypeEnum'
           default: other
         actions:
           type: array
@@ -20783,13 +21526,13 @@ components:
         description:
           type: string
         action_type:
-          $ref: '#/components/schemas/ActionTypeEnum'
+          $ref: '#/components/schemas/RiskActionTypeEnum'
         assigned_to:
           type: integer
           nullable: true
           description: Person responsible for completing this action
         priority:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         start_date:
           type: string
           format: date
@@ -20846,13 +21589,13 @@ components:
           type: string
           minLength: 1
         action_type:
-          $ref: '#/components/schemas/ActionTypeEnum'
+          $ref: '#/components/schemas/RiskActionTypeEnum'
         assigned_to:
           type: integer
           nullable: true
           description: Person responsible for completing this action
         priority:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         start_date:
           type: string
           format: date
@@ -20912,7 +21655,7 @@ components:
         description:
           type: string
         action_type:
-          $ref: '#/components/schemas/ActionTypeEnum'
+          $ref: '#/components/schemas/RiskActionTypeEnum'
         risk:
           type: integer
         risk_id:
@@ -20928,7 +21671,8 @@ components:
           type: string
           readOnly: true
         risk_summary:
-          type: string
+          allOf:
+          - $ref: '#/components/schemas/RiskActionRiskSummary'
           readOnly: true
         assigned_to:
           allOf:
@@ -20938,9 +21682,9 @@ components:
           type: string
           readOnly: true
         status:
-          $ref: '#/components/schemas/StatusF58Enum'
+          $ref: '#/components/schemas/RiskActionStatusEnum'
         priority:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         priority_color:
           type: string
           readOnly: true
@@ -21062,13 +21806,15 @@ components:
         description:
           type: string
         evidence_type:
-          $ref: '#/components/schemas/EvidenceTypeA14Enum'
+          $ref: '#/components/schemas/RiskActionEvidenceTypeEnum'
         file:
           type: string
           format: uri
           nullable: true
         file_url:
           type: string
+          format: uri
+          nullable: true
           readOnly: true
         external_link:
           description: Link to external evidence or system
@@ -21133,7 +21879,7 @@ components:
         description:
           type: string
         evidence_type:
-          $ref: '#/components/schemas/EvidenceTypeA14Enum'
+          $ref: '#/components/schemas/RiskActionEvidenceTypeEnum'
         file:
           type: string
           format: binary
@@ -21151,6 +21897,26 @@ components:
           format: date
       required:
       - title
+    RiskActionEvidenceTypeEnum:
+      enum:
+      - document
+      - screenshot
+      - report
+      - certificate
+      - configuration
+      - training_record
+      - audit_log
+      - other
+      type: string
+      description: |-
+        * `document` - Document/Policy
+        * `screenshot` - Screenshot
+        * `report` - Report/Analysis
+        * `certificate` - Certificate
+        * `configuration` - Configuration File
+        * `training_record` - Training Record
+        * `audit_log` - Audit Log
+        * `other` - Other
     RiskActionList:
       type: object
       description: Serializer for Risk Action list view with essential fields.
@@ -21168,7 +21934,7 @@ components:
         description:
           type: string
         action_type:
-          $ref: '#/components/schemas/ActionTypeEnum'
+          $ref: '#/components/schemas/RiskActionTypeEnum'
         risk:
           type: integer
         risk_id:
@@ -21191,9 +21957,9 @@ components:
           type: string
           readOnly: true
         status:
-          $ref: '#/components/schemas/StatusF58Enum'
+          $ref: '#/components/schemas/RiskActionStatusEnum'
         priority:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         priority_color:
           type: string
           readOnly: true
@@ -21265,7 +22031,7 @@ components:
         note:
           type: string
         note_type:
-          $ref: '#/components/schemas/NoteType679Enum'
+          $ref: '#/components/schemas/RiskActionNoteTypeEnum'
         progress_percentage:
           type: integer
           maximum: 100
@@ -21297,7 +22063,7 @@ components:
           type: string
           minLength: 1
         note_type:
-          $ref: '#/components/schemas/NoteType679Enum'
+          $ref: '#/components/schemas/RiskActionNoteTypeEnum'
         progress_percentage:
           type: integer
           maximum: 100
@@ -21306,6 +22072,20 @@ components:
           description: Progress percentage at time of note
       required:
       - note
+    RiskActionNoteTypeEnum:
+      enum:
+      - progress
+      - issue
+      - completion
+      - status_change
+      - general
+      type: string
+      description: |-
+        * `progress` - Progress Update
+        * `issue` - Issue/Blocker
+        * `completion` - Completion
+        * `status_change` - Status Change
+        * `general` - General
     RiskActionReminderConfiguration:
       type: object
       description: Serializer for risk action reminder configuration.
@@ -21418,12 +22198,55 @@ components:
         silence_cancelled:
           type: boolean
           description: Stop sending reminders for cancelled actions
+    RiskActionRiskSummary:
+      type: object
+      properties:
+        id:
+          type: integer
+        risk_id:
+          type: string
+        title:
+          type: string
+        risk_level:
+          type: string
+        risk_level_display:
+          type: string
+        status:
+          type: string
+        status_display:
+          type: string
+        risk_owner:
+          type: string
+          nullable: true
+      required:
+      - id
+      - risk_id
+      - risk_level
+      - risk_level_display
+      - risk_owner
+      - status
+      - status_display
+      - title
+    RiskActionStatusEnum:
+      enum:
+      - pending
+      - in_progress
+      - completed
+      - cancelled
+      - deferred
+      type: string
+      description: |-
+        * `pending` - Pending
+        * `in_progress` - In Progress
+        * `completed` - Completed
+        * `cancelled` - Cancelled
+        * `deferred` - Deferred
     RiskActionStatusUpdateRequest:
       type: object
       description: Serializer for updating risk action status with optional note.
       properties:
         status:
-          $ref: '#/components/schemas/StatusF58Enum'
+          $ref: '#/components/schemas/RiskActionStatusEnum'
         progress_percentage:
           type: integer
           maximum: 100
@@ -21480,6 +22303,26 @@ components:
       - overdue_actions
       - overdue_count
       - total_actions
+    RiskActionTypeEnum:
+      enum:
+      - preventive
+      - detective
+      - corrective
+      - policy
+      - training
+      - technical
+      - assessment
+      - other
+      type: string
+      description: |-
+        * `preventive` - Preventive Control
+        * `detective` - Detective Control
+        * `corrective` - Corrective Action
+        * `policy` - Policy/Procedure
+        * `training` - Training/Awareness
+        * `technical` - Technical Implementation
+        * `assessment` - Assessment/Review
+        * `other` - Other
     RiskCategory:
       type: object
       description: Serializer for Risk Categories.
@@ -21497,7 +22340,8 @@ components:
           description: Hex color code for UI display
           maxLength: 7
         risk_count:
-          type: string
+          type: integer
+          description: Get count of risks in this category.
           readOnly: true
         created_at:
           type: string
@@ -21553,7 +22397,7 @@ components:
           minimum: 1
           description: Likelihood level (1=Very Low, 5=Very High)
         status:
-          $ref: '#/components/schemas/StatusDb9Enum'
+          $ref: '#/components/schemas/RiskStatusEnum'
         treatment_strategy:
           oneOf:
           - $ref: '#/components/schemas/TreatmentStrategyEnum'
@@ -21611,7 +22455,7 @@ components:
           minimum: 1
           description: Likelihood level (1=Very Low, 5=Very High)
         status:
-          $ref: '#/components/schemas/StatusDb9Enum'
+          $ref: '#/components/schemas/RiskStatusEnum'
         treatment_strategy:
           oneOf:
           - $ref: '#/components/schemas/TreatmentStrategyEnum'
@@ -21672,7 +22516,7 @@ components:
           description: Likelihood level (1=Very Low, 5=Very High)
         risk_level:
           allOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           readOnly: true
           description: |-
             Calculated risk level
@@ -21688,7 +22532,7 @@ components:
           type: string
           readOnly: true
         status:
-          $ref: '#/components/schemas/StatusDb9Enum'
+          $ref: '#/components/schemas/RiskStatusEnum'
         status_display:
           type: string
           readOnly: true
@@ -21837,7 +22681,7 @@ components:
           description: Likelihood level (1=Very Low, 5=Very High)
         risk_level:
           allOf:
-          - $ref: '#/components/schemas/DefaultPriorityEnum'
+          - $ref: '#/components/schemas/LowMediumHighCriticalEnum'
           readOnly: true
           description: |-
             Calculated risk level
@@ -21853,7 +22697,7 @@ components:
           type: string
           readOnly: true
         status:
-          $ref: '#/components/schemas/StatusDb9Enum'
+          $ref: '#/components/schemas/RiskStatusEnum'
         status_display:
           type: string
           readOnly: true
@@ -22036,12 +22880,32 @@ components:
         * `treatment` - Treatment
         * `review` - Review
         * `status_change` - Status Change
+    RiskStatusEnum:
+      enum:
+      - identified
+      - assessed
+      - treatment_planned
+      - treatment_in_progress
+      - mitigated
+      - accepted
+      - transferred
+      - closed
+      type: string
+      description: |-
+        * `identified` - Identified
+        * `assessed` - Assessed
+        * `treatment_planned` - Treatment Planned
+        * `treatment_in_progress` - Treatment in Progress
+        * `mitigated` - Mitigated
+        * `accepted` - Accepted
+        * `transferred` - Transferred
+        * `closed` - Closed
     RiskStatusUpdateRequest:
       type: object
       description: Serializer for updating risk status with optional notes.
       properties:
         status:
-          $ref: '#/components/schemas/StatusDb9Enum'
+          $ref: '#/components/schemas/RiskStatusEnum'
         treatment_strategy:
           $ref: '#/components/schemas/TreatmentStrategyEnum'
         treatment_description:
@@ -22414,10 +23278,39 @@ components:
           type: integer
           readOnly: true
         created_by_details:
-          type: string
+          type: object
+          nullable: true
+          properties:
+            id:
+              type: string
+            name:
+              type: string
+            email:
+              type: string
+              format: email
           readOnly: true
         target_users_details:
-          type: string
+          type: object
+          properties:
+            type:
+              type: string
+            count:
+              type: integer
+            users:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  email:
+                    type: string
+                    format: email
+          required:
+          - type
+          - count
           readOnly: true
         total_sent:
           type: integer
@@ -22429,16 +23322,38 @@ components:
           type: integer
           readOnly: true
         open_rate:
-          type: string
+          type: number
+          format: double
           readOnly: true
         click_rate:
-          type: string
+          type: number
+          format: double
           readOnly: true
         recent_deliveries:
-          type: string
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
           readOnly: true
         analytics:
-          type: string
+          type: object
+          properties:
+            recent_sent:
+              type: integer
+            recent_opened:
+              type: integer
+            recent_clicked:
+              type: integer
+            recent_bounced:
+              type: integer
+            recent_failed:
+              type: integer
+          required:
+          - recent_sent
+          - recent_opened
+          - recent_clicked
+          - recent_bounced
+          - recent_failed
           readOnly: true
         created_at:
           type: string
@@ -22548,10 +23463,11 @@ components:
           type: boolean
           description: If False, only send to specific users or groups
         target_users_count:
-          type: string
+          type: integer
           readOnly: true
         created_by_name:
           type: string
+          nullable: true
           readOnly: true
         total_sent:
           type: integer
@@ -22566,10 +23482,12 @@ components:
           maximum: 2147483647
           minimum: 0
         open_rate:
-          type: string
+          type: number
+          format: double
           readOnly: true
         click_rate:
-          type: string
+          type: number
+          format: double
           readOnly: true
         status:
           type: string
@@ -22607,170 +23525,14 @@ components:
         * `biweekly` - Bi-weekly
         * `monthly` - Monthly
         * `quarterly` - Quarterly
-    Status62aEnum:
-      enum:
-      - pending
-      - processing
-      - completed
-      - failed
-      type: string
-      description: |-
-        * `pending` - Pending Generation
-        * `processing` - Processing
-        * `completed` - Completed
-        * `failed` - Failed
-    Status8b3Enum:
-      enum:
-      - pending
-      - in_progress
-      - completed
-      - overdue
-      - cancelled
-      - on_hold
-      type: string
-      description: |-
-        * `pending` - Pending
-        * `in_progress` - In Progress
-        * `completed` - Completed
-        * `overdue` - Overdue
-        * `cancelled` - Cancelled
-        * `on_hold` - On Hold
-    Status8f5Enum:
-      enum:
-      - pending
-      - approved
-      - rejected
-      - applied
-      - expired
-      type: string
-      description: |-
-        * `pending` - Pending Review
-        * `approved` - Approved
-        * `rejected` - Rejected
-        * `applied` - Applied
-        * `expired` - Expired
-    Status949Enum:
-      enum:
-      - planned
-      - in_progress
-      - implemented
-      - testing
-      - active
-      - remediation
-      - disabled
-      - retired
-      type: string
-      description: |-
-        * `planned` - Planned
-        * `in_progress` - In Progress
-        * `implemented` - Implemented
-        * `testing` - Under Testing
-        * `active` - Active
-        * `remediation` - Needs Remediation
-        * `disabled` - Disabled
-        * `retired` - Retired
-    StatusAb0Enum:
-      enum:
-      - active
-      - inactive
-      - under_review
-      - approved
-      - suspended
-      - terminated
-      type: string
-      description: |-
-        * `active` - Active
-        * `inactive` - Inactive
-        * `under_review` - Under Review
-        * `approved` - Approved
-        * `suspended` - Suspended
-        * `terminated` - Terminated
-    StatusD38Enum:
-      enum:
-      - draft
-      - under_review
-      - approved
-      - archived
-      type: string
-      description: |-
-        * `draft` - Draft
-        * `under_review` - Under Review
-        * `approved` - Approved
-        * `archived` - Archived
-    StatusDaeEnum:
-      enum:
-      - draft
-      - published
-      - archived
-      type: string
-      description: |-
-        * `draft` - Draft
-        * `published` - Published
-        * `archived` - Archived
-    StatusDb9Enum:
-      enum:
-      - identified
-      - assessed
-      - treatment_planned
-      - treatment_in_progress
-      - mitigated
-      - accepted
-      - transferred
-      - closed
-      type: string
-      description: |-
-        * `identified` - Identified
-        * `assessed` - Assessed
-        * `treatment_planned` - Treatment Planned
-        * `treatment_in_progress` - Treatment in Progress
-        * `mitigated` - Mitigated
-        * `accepted` - Accepted
-        * `transferred` - Transferred
-        * `closed` - Closed
-    StatusEnum:
-      enum:
-      - not_started
-      - pending
-      - in_progress
-      - under_review
-      - complete
-      - not_applicable
-      - deferred
-      type: string
-      description: |-
-        * `not_started` - Not Started
-        * `pending` - Pending
-        * `in_progress` - In Progress
-        * `under_review` - Under Review
-        * `complete` - Complete
-        * `not_applicable` - Not Applicable
-        * `deferred` - Deferred
-    StatusF58Enum:
-      enum:
-      - pending
-      - in_progress
-      - completed
-      - cancelled
-      - deferred
-      type: string
-      description: |-
-        * `pending` - Pending
-        * `in_progress` - In Progress
-        * `completed` - Completed
-        * `cancelled` - Cancelled
-        * `deferred` - Deferred
-    StatusFa2Enum:
-      enum:
-      - draft
-      - active
-      - deprecated
-      - archived
-      type: string
-      description: |-
-        * `draft` - Draft
-        * `active` - Active
-        * `deprecated` - Deprecated
-        * `archived` - Archived
+    SetupTOTPRequest:
+      type: object
+      properties:
+        password:
+          type: string
+          minLength: 1
+      required:
+      - password
     Subscription:
       type: object
       description: Serializer for subscriptions.
@@ -22798,14 +23560,18 @@ components:
         enabled_modules:
           description: Explicit module grants for this subscription
         enabled_module_keys:
-          type: string
+          type: array
+          items:
+            type: string
           readOnly: true
         trial_module:
           type: string
           description: Single module selected for a trial subscription
           maxLength: 40
         module_catalog:
-          type: string
+          type: array
+          items:
+            $ref: '#/components/schemas/ModuleCatalogItem'
           readOnly: true
         current_period_start:
           type: string
@@ -23145,7 +23911,7 @@ components:
           readOnly: true
         status:
           allOf:
-          - $ref: '#/components/schemas/Status62aEnum'
+          - $ref: '#/components/schemas/AnalyticsExportStatusEnum'
           readOnly: true
         generated_file:
           type: integer
@@ -23158,6 +23924,8 @@ components:
           readOnly: true
         download_url:
           type: string
+          format: uri
+          nullable: true
           readOnly: true
         generation_started_at:
           type: string
@@ -23242,7 +24010,7 @@ components:
         is_active:
           type: boolean
         videos_count:
-          type: string
+          type: integer
           readOnly: true
         created_at:
           type: string
@@ -23310,6 +24078,7 @@ components:
           maxLength: 100
         embed_url:
           type: string
+          format: uri
           readOnly: true
         duration_minutes:
           type: integer
@@ -23330,7 +24099,16 @@ components:
           type: integer
           readOnly: true
         created_by_details:
-          type: string
+          type: object
+          nullable: true
+          properties:
+            id:
+              type: string
+            name:
+              type: string
+            email:
+              type: string
+              format: email
           readOnly: true
         view_count:
           type: integer
@@ -23432,6 +24210,7 @@ components:
           nullable: true
         created_by_name:
           type: string
+          nullable: true
           readOnly: true
         view_count:
           type: integer
@@ -23465,6 +24244,36 @@ components:
         * `accept` - Accept
         * `transfer` - Transfer
         * `avoid` - Avoid
+    TwoFactorStatus:
+      type: object
+      properties:
+        email_enabled:
+          type: boolean
+          readOnly: true
+        totp_enabled:
+          type: boolean
+          readOnly: true
+        push_enabled:
+          type: boolean
+          readOnly: true
+        email:
+          type: string
+          format: email
+          readOnly: true
+        push_devices:
+          type: array
+          items: {}
+          readOnly: true
+        primary_method:
+          type: string
+          readOnly: true
+      required:
+      - email
+      - email_enabled
+      - primary_method
+      - push_devices
+      - push_enabled
+      - totp_enabled
     UrgencyEnum:
       enum:
       - low
@@ -23510,6 +24319,32 @@ components:
       - id
       - last_name
       - username
+    UserPreferences:
+      type: object
+      properties:
+        primary_method:
+          $ref: '#/components/schemas/PrimaryMethodEnum'
+        fallback_methods:
+          description: Ordered list of fallback methods
+        require_2fa_for_sensitive_actions:
+          type: boolean
+        remember_device_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+    UserPreferencesRequest:
+      type: object
+      properties:
+        primary_method:
+          $ref: '#/components/schemas/PrimaryMethodEnum'
+        fallback_methods:
+          description: Ordered list of fallback methods
+        require_2fa_for_sensitive_actions:
+          type: boolean
+        remember_device_days:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
     UserProfile:
       type: object
       properties:
@@ -23775,11 +24610,11 @@ components:
           type: string
           maxLength: 100
         status:
-          $ref: '#/components/schemas/StatusAb0Enum'
+          $ref: '#/components/schemas/VendorStatusEnum'
         vendor_type:
           $ref: '#/components/schemas/VendorTypeEnum'
         risk_level:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         risk_score:
           type: string
           format: decimal
@@ -23911,11 +24746,11 @@ components:
           type: string
           maxLength: 100
         status:
-          $ref: '#/components/schemas/StatusAb0Enum'
+          $ref: '#/components/schemas/VendorStatusEnum'
         vendor_type:
           $ref: '#/components/schemas/VendorTypeEnum'
         risk_level:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         risk_score:
           type: string
           format: decimal
@@ -24059,7 +24894,7 @@ components:
           type: string
           readOnly: true
         status:
-          $ref: '#/components/schemas/StatusAb0Enum'
+          $ref: '#/components/schemas/VendorStatusEnum'
         status_display:
           type: string
           readOnly: true
@@ -24069,7 +24904,7 @@ components:
           type: string
           readOnly: true
         risk_level:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         risk_level_display:
           type: string
           readOnly: true
@@ -24248,7 +25083,7 @@ components:
           type: string
           readOnly: true
         status:
-          $ref: '#/components/schemas/StatusAb0Enum'
+          $ref: '#/components/schemas/VendorStatusEnum'
         status_display:
           type: string
           readOnly: true
@@ -24258,7 +25093,7 @@ components:
           type: string
           readOnly: true
         risk_level:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         risk_level_display:
           type: string
           readOnly: true
@@ -24344,11 +25179,11 @@ components:
           nullable: true
           description: Primary vendor category for classification
         status:
-          $ref: '#/components/schemas/StatusAb0Enum'
+          $ref: '#/components/schemas/VendorStatusEnum'
         vendor_type:
           $ref: '#/components/schemas/VendorTypeEnum'
         risk_level:
-          $ref: '#/components/schemas/DefaultPriorityEnum'
+          $ref: '#/components/schemas/LowMediumHighCriticalEnum'
         risk_score:
           type: string
           format: decimal
@@ -24590,6 +25425,22 @@ components:
           nullable: true
       required:
       - name
+    VendorStatusEnum:
+      enum:
+      - active
+      - inactive
+      - under_review
+      - approved
+      - suspended
+      - terminated
+      type: string
+      description: |-
+        * `active` - Active
+        * `inactive` - Inactive
+        * `under_review` - Under Review
+        * `approved` - Approved
+        * `suspended` - Suspended
+        * `terminated` - Terminated
     VendorSummary:
       type: object
       description: Serializer for vendor summary statistics.
@@ -24681,11 +25532,11 @@ components:
         action:
           $ref: '#/components/schemas/VendorTaskBulkActionActionEnum'
         status:
-          $ref: '#/components/schemas/Status8b3Enum'
+          $ref: '#/components/schemas/VendorTaskStatusEnum'
         assigned_to:
           type: integer
         priority:
-          $ref: '#/components/schemas/Priority0aeEnum'
+          $ref: '#/components/schemas/VendorTaskPriorityEnum'
         notes:
           type: string
       required:
@@ -24736,9 +25587,9 @@ components:
           nullable: true
           description: Optional start date for the task
         priority:
-          $ref: '#/components/schemas/Priority0aeEnum'
+          $ref: '#/components/schemas/VendorTaskPriorityEnum'
         status:
-          $ref: '#/components/schemas/Status8b3Enum'
+          $ref: '#/components/schemas/VendorTaskStatusEnum'
         assigned_to:
           type: integer
           nullable: true
@@ -24817,9 +25668,9 @@ components:
           nullable: true
           description: Optional start date for the task
         priority:
-          $ref: '#/components/schemas/Priority0aeEnum'
+          $ref: '#/components/schemas/VendorTaskPriorityEnum'
         status:
-          $ref: '#/components/schemas/Status8b3Enum'
+          $ref: '#/components/schemas/VendorTaskStatusEnum'
         assigned_to:
           type: integer
           nullable: true
@@ -24916,12 +25767,12 @@ components:
           nullable: true
           description: Actual completion timestamp
         priority:
-          $ref: '#/components/schemas/Priority0aeEnum'
+          $ref: '#/components/schemas/VendorTaskPriorityEnum'
         priority_display:
           type: string
           readOnly: true
         status:
-          $ref: '#/components/schemas/Status8b3Enum'
+          $ref: '#/components/schemas/VendorTaskStatusEnum'
         status_display:
           type: string
           readOnly: true
@@ -25085,9 +25936,9 @@ components:
           nullable: true
           description: Actual completion timestamp
         priority:
-          $ref: '#/components/schemas/Priority0aeEnum'
+          $ref: '#/components/schemas/VendorTaskPriorityEnum'
         status:
-          $ref: '#/components/schemas/Status8b3Enum'
+          $ref: '#/components/schemas/VendorTaskStatusEnum'
         assigned_to:
           type: integer
           nullable: true
@@ -25186,12 +26037,12 @@ components:
           format: date
           description: Date when the task is due for completion
         priority:
-          $ref: '#/components/schemas/Priority0aeEnum'
+          $ref: '#/components/schemas/VendorTaskPriorityEnum'
         priority_display:
           type: string
           readOnly: true
         status:
-          $ref: '#/components/schemas/Status8b3Enum'
+          $ref: '#/components/schemas/VendorTaskStatusEnum'
         status_display:
           type: string
           readOnly: true
@@ -25240,6 +26091,20 @@ components:
       - vendor
       - vendor_id
       - vendor_name
+    VendorTaskPriorityEnum:
+      enum:
+      - low
+      - medium
+      - high
+      - urgent
+      - critical
+      type: string
+      description: |-
+        * `low` - Low Priority
+        * `medium` - Medium Priority
+        * `high` - High Priority
+        * `urgent` - Urgent
+        * `critical` - Critical
     VendorTaskReminderRequest:
       type: object
       description: Serializer for task reminder operations.
@@ -25260,12 +26125,28 @@ components:
             format: email
             minLength: 1
           description: Additional email addresses to include
+    VendorTaskStatusEnum:
+      enum:
+      - pending
+      - in_progress
+      - completed
+      - overdue
+      - cancelled
+      - on_hold
+      type: string
+      description: |-
+        * `pending` - Pending
+        * `in_progress` - In Progress
+        * `completed` - Completed
+        * `overdue` - Overdue
+        * `cancelled` - Cancelled
+        * `on_hold` - On Hold
     VendorTaskStatusUpdateRequest:
       type: object
       description: Serializer for updating task status.
       properties:
         status:
-          $ref: '#/components/schemas/Status8b3Enum'
+          $ref: '#/components/schemas/VendorTaskStatusEnum'
         completion_notes:
           type: string
       required:

--- a/app/training/serializers.py
+++ b/app/training/serializers.py
@@ -5,6 +5,7 @@ REST API serializers for security awareness training.
 """
 
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from .models import (
@@ -31,7 +32,7 @@ class TrainingCategorySerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ['created_at', 'updated_at']
 
-    def get_videos_count(self, obj):
+    def get_videos_count(self, obj) -> int:
         return obj.videos.filter(is_published=True).count()
 
 
@@ -51,7 +52,7 @@ class TrainingVideoListSerializer(serializers.ModelSerializer):
             'created_at', 'updated_at'
         ]
 
-    def get_created_by_name(self, obj):
+    def get_created_by_name(self, obj) -> str | None:
         if obj.created_by:
             return f"{obj.created_by.first_name} {obj.created_by.last_name}".strip() or obj.created_by.email
         return None
@@ -62,7 +63,7 @@ class TrainingVideoDetailSerializer(serializers.ModelSerializer):
 
     category_details = TrainingCategorySerializer(source='category', read_only=True)
     created_by_details = serializers.SerializerMethodField()
-    embed_url = serializers.ReadOnlyField()
+    embed_url = serializers.URLField(read_only=True)
 
     class Meta:
         model = TrainingVideo
@@ -75,6 +76,15 @@ class TrainingVideoDetailSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ['created_by', 'view_count', 'published_at', 'created_at', 'updated_at']
 
+    @extend_schema_field({
+        'type': 'object',
+        'nullable': True,
+        'properties': {
+            'id': {'type': 'string'},
+            'name': {'type': 'string'},
+            'email': {'type': 'string', 'format': 'email'},
+        },
+    })
     def get_created_by_details(self, obj):
         if obj.created_by:
             return {
@@ -95,6 +105,8 @@ class SecurityAwarenessCampaignListSerializer(serializers.ModelSerializer):
     created_by_name = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
     target_users_count = serializers.SerializerMethodField()
+    open_rate = serializers.FloatField(read_only=True)
+    click_rate = serializers.FloatField(read_only=True)
 
     class Meta:
         model = SecurityAwarenessCampaign
@@ -106,12 +118,12 @@ class SecurityAwarenessCampaignListSerializer(serializers.ModelSerializer):
             'click_rate', 'status', 'created_at', 'updated_at'
         ]
 
-    def get_created_by_name(self, obj):
+    def get_created_by_name(self, obj) -> str | None:
         if obj.created_by:
             return f"{obj.created_by.first_name} {obj.created_by.last_name}".strip() or obj.created_by.email
         return None
 
-    def get_status(self, obj):
+    def get_status(self, obj) -> str:
         if not obj.is_active:
             return 'inactive'
         elif obj.end_date and obj.end_date < timezone.now():
@@ -123,7 +135,7 @@ class SecurityAwarenessCampaignListSerializer(serializers.ModelSerializer):
         else:
             return 'active'
 
-    def get_target_users_count(self, obj):
+    def get_target_users_count(self, obj) -> int:
         if obj.send_to_all_users:
             return User.objects.filter(is_active=True).count()
         return obj.target_users.count()
@@ -136,6 +148,8 @@ class SecurityAwarenessCampaignDetailSerializer(serializers.ModelSerializer):
     target_users_details = serializers.SerializerMethodField()
     recent_deliveries = serializers.SerializerMethodField()
     analytics = serializers.SerializerMethodField()
+    open_rate = serializers.FloatField(read_only=True)
+    click_rate = serializers.FloatField(read_only=True)
 
     class Meta:
         model = SecurityAwarenessCampaign
@@ -153,6 +167,15 @@ class SecurityAwarenessCampaignDetailSerializer(serializers.ModelSerializer):
             'open_rate', 'click_rate', 'created_at', 'updated_at'
         ]
 
+    @extend_schema_field({
+        'type': 'object',
+        'nullable': True,
+        'properties': {
+            'id': {'type': 'string'},
+            'name': {'type': 'string'},
+            'email': {'type': 'string', 'format': 'email'},
+        },
+    })
     def get_created_by_details(self, obj):
         if obj.created_by:
             return {
@@ -162,6 +185,25 @@ class SecurityAwarenessCampaignDetailSerializer(serializers.ModelSerializer):
             }
         return None
 
+    @extend_schema_field({
+        'type': 'object',
+        'properties': {
+            'type': {'type': 'string'},
+            'count': {'type': 'integer'},
+            'users': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'id': {'type': 'string'},
+                        'name': {'type': 'string'},
+                        'email': {'type': 'string', 'format': 'email'},
+                    },
+                },
+            },
+        },
+        'required': ['type', 'count'],
+    })
     def get_target_users_details(self, obj):
         if obj.send_to_all_users:
             return {'type': 'all_users', 'count': User.objects.filter(is_active=True).count()}
@@ -180,6 +222,7 @@ class SecurityAwarenessCampaignDetailSerializer(serializers.ModelSerializer):
                 ]
             }
 
+    @extend_schema_field(serializers.ListField(child=serializers.DictField()))
     def get_recent_deliveries(self, obj):
         recent = obj.deliveries.select_related('user')[:5]
         return [
@@ -194,6 +237,23 @@ class SecurityAwarenessCampaignDetailSerializer(serializers.ModelSerializer):
             for delivery in recent
         ]
 
+    @extend_schema_field({
+        'type': 'object',
+        'properties': {
+            'recent_sent': {'type': 'integer'},
+            'recent_opened': {'type': 'integer'},
+            'recent_clicked': {'type': 'integer'},
+            'recent_bounced': {'type': 'integer'},
+            'recent_failed': {'type': 'integer'},
+        },
+        'required': [
+            'recent_sent',
+            'recent_opened',
+            'recent_clicked',
+            'recent_bounced',
+            'recent_failed',
+        ],
+    })
     def get_analytics(self, obj):
         from django.utils import timezone
         from datetime import timedelta
@@ -231,7 +291,7 @@ class CampaignDeliverySerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ['sent_at']
 
-    def get_user_name(self, obj):
+    def get_user_name(self, obj) -> str | None:
         if obj.user:
             return f"{obj.user.first_name} {obj.user.last_name}".strip() or obj.user.email
         return None

--- a/frontend/src/lib/api/generated/schema.d.ts
+++ b/frontend/src/lib/api/generated/schema.d.ts
@@ -53,6 +53,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /**
+         * Logout current user
+         * @description End the current authenticated session.
+         */
         post: operations["auth_logout_create"];
         delete?: never;
         options?: never;
@@ -67,12 +71,14 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Get authenticated user profile */
         get: operations["auth_profile_retrieve"];
         put?: never;
         post?: never;
         delete?: never;
         options?: never;
         head?: never;
+        /** Update authenticated user profile */
         patch: operations["auth_profile_partial_update"];
         trace?: never;
     };
@@ -85,6 +91,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Change authenticated user password */
         post: operations["auth_change_password_create"];
         delete?: never;
         options?: never;
@@ -119,7 +126,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description Get comprehensive 2FA status for current user */
+        /**
+         * Get two-factor authentication status
+         * @description Get comprehensive 2FA status for current user
+         */
         get: operations["auth_2fa_status_retrieve"];
         put?: never;
         post?: never;
@@ -138,7 +148,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description Enable 2FA for current user - supports email, TOTP, and push */
+        /**
+         * Enable two-factor authentication
+         * @description Enable 2FA for current user - supports email, TOTP, and push
+         */
         post: operations["auth_2fa_enable_create"];
         delete?: never;
         options?: never;
@@ -155,7 +168,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description Disable 2FA methods for current user */
+        /**
+         * Disable two-factor authentication
+         * @description Disable 2FA methods for current user
+         */
         post: operations["auth_2fa_disable_create"];
         delete?: never;
         options?: never;
@@ -192,7 +208,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description Generate QR code for TOTP setup using enhanced pyotp service */
+        /**
+         * Set up TOTP two-factor authentication
+         * @description Generate QR code for TOTP setup using enhanced pyotp service
+         */
         post: operations["auth_2fa_setup_totp_create"];
         delete?: never;
         options?: never;
@@ -209,7 +228,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description Confirm TOTP setup with verification code using enhanced service */
+        /**
+         * Confirm TOTP setup
+         * @description Confirm TOTP setup with verification code using enhanced service
+         */
         post: operations["auth_2fa_confirm_totp_create"];
         delete?: never;
         options?: never;
@@ -226,7 +248,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description Register a new push notification device */
+        /**
+         * Register push notification device
+         * @description Register a new push notification device
+         */
         post: operations["auth_2fa_register_push_create"];
         delete?: never;
         options?: never;
@@ -243,7 +268,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description Approve or deny a push notification challenge */
+        /**
+         * Approve or deny push challenge
+         * @description Approve or deny a push notification challenge
+         */
         post: operations["auth_2fa_approve_push_create"];
         delete?: never;
         options?: never;
@@ -258,10 +286,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description Get user 2FA preferences */
+        /**
+         * Get two-factor preferences
+         * @description Get user 2FA preferences
+         */
         get: operations["auth_2fa_preferences_retrieve"];
         put?: never;
-        /** @description Update user 2FA preferences */
+        /**
+         * Update two-factor preferences
+         * @description Update user 2FA preferences
+         */
         post: operations["auth_2fa_preferences_create"];
         delete?: never;
         options?: never;
@@ -428,7 +462,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get: operations["calendar_preferences_retrieve"];
+        get: operations["calendar_preferences_list"];
         put?: never;
         post: operations["calendar_preferences_create"];
         delete?: never;
@@ -2259,6 +2293,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Risk action overview analytics
          * @description Get risk action overview statistics and progress metrics.
          *
          *     Provides:
@@ -2284,6 +2319,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Risk action progress analytics
          * @description Get detailed risk action progress and effectiveness analysis.
          *
          *     Provides:
@@ -2309,6 +2345,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Risk category analytics
          * @description Get detailed analysis for specific risk category or all categories.
          *
          *     Query Parameters:
@@ -2336,6 +2373,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Risk-control integration analytics
          * @description Get risk-control integration analysis (basic version).
          *
          *     Provides:
@@ -2362,14 +2400,8 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * @description Get comprehensive risk analytics dashboard data.
-         *
-         *     Returns complete dashboard dataset including:
-         *     - Risk overview statistics
-         *     - Risk action progress metrics
-         *     - Heat map visualization data
-         *     - Trend analysis and forecasting
-         *     - Executive summary metrics
+         * Risk Analytics Dashboard
+         * @description Access comprehensive risk analytics, trends, and reporting data for management dashboards and executive reporting.
          */
         get: operations["risk_analytics_dashboard_retrieve"];
         put?: never;
@@ -2388,6 +2420,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Executive risk summary analytics
          * @description Get executive-level risk summary for leadership reporting.
          *
          *     Provides high-level metrics including:
@@ -2414,6 +2447,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Risk heat map analytics
          * @description Get risk heat map data for impact vs likelihood visualization.
          *
          *     Returns matrix data showing:
@@ -2439,6 +2473,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Risk overview analytics
          * @description Get risk overview statistics including counts, distributions, and key metrics.
          *
          *     Provides:
@@ -2464,6 +2499,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Risk trend analytics
          * @description Get risk trend analysis over specified time period.
          *
          *     Query Parameters:
@@ -3412,6 +3448,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Executive analytics dashboard
          * @description Executive dashboard with high-level KPIs across all modules.
          *
          *     Returns comprehensive metrics for C-level reporting including risk posture,
@@ -3434,6 +3471,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Compliance analytics dashboard
          * @description Compliance-focused dashboard with framework completion rates and control effectiveness.
          *
          *     Provides detailed compliance metrics including assessment progress,
@@ -3456,6 +3494,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Vendor risk analytics dashboard
          * @description Vendor management and risk assessment dashboard.
          *
          *     Provides vendor risk distribution, contract management metrics,
@@ -3478,6 +3517,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Policy management analytics dashboard
          * @description Policy management and acknowledgment tracking dashboard.
          *
          *     Provides policy distribution metrics, acknowledgment rates,
@@ -3500,6 +3540,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Training effectiveness analytics dashboard
          * @description Training program effectiveness and engagement dashboard.
          *
          *     Provides training completion rates, user engagement metrics,
@@ -3522,6 +3563,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Integrated risk posture analytics
          * @description Integrated risk posture analysis across all modules.
          *
          *     Premium feature providing cross-module risk correlation,
@@ -3545,6 +3587,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Executive report analytics data
          * @description Comprehensive executive report data for leadership presentations.
          *
          *     Premium feature providing complete analytics package including
@@ -3568,6 +3611,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Operational analytics dashboard
          * @description Operational dashboard for day-to-day management and monitoring.
          *
          *     Provides actionable metrics focused on operational tasks,
@@ -3590,6 +3634,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Operator usage dashboard
          * @description Operator-only product analytics across tenants.
          *
          *     Returns aggregate tenant, subscription, module adoption and usage metrics
@@ -3614,6 +3659,7 @@ export interface paths {
         get?: never;
         put?: never;
         /**
+         * Create analytics report export
          * @description Create an async export job for analytics reports.
          *
          *     Accepts report configuration and queues a background job for
@@ -3634,6 +3680,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * List my analytics reports
          * @description List analytics reports created by the current user.
          *
          *     Returns paginated list of reports with status and metadata.
@@ -3655,6 +3702,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Get analytics report status
          * @description Check the status of an analytics report generation job.
          *
          *     Returns current status, progress information, and download link
@@ -3677,6 +3725,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Download analytics report
          * @description Download a completed analytics report file.
          *
          *     Serves the generated report file and increments download counter.
@@ -3701,6 +3750,7 @@ export interface paths {
         put?: never;
         post?: never;
         /**
+         * Delete analytics report
          * @description Delete an analytics report and its associated file.
          *
          *     Users can only delete their own reports.
@@ -3721,6 +3771,7 @@ export interface paths {
         get?: never;
         put?: never;
         /**
+         * Refresh analytics cache
          * @description Manually trigger analytics metrics cache refresh.
          *
          *     Premium feature for forcing immediate cache refresh of
@@ -3741,6 +3792,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Analytics health check
          * @description Health check endpoint for analytics service availability.
          *
          *     Provides basic system health information and data freshness
@@ -4693,7 +4745,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description Create Stripe billing portal session. */
+        /**
+         * Create billing portal session
+         * @description Create a Stripe customer portal session for billing self-service.
+         */
         get: operations["billing_billing_portal_retrieve"];
         put?: never;
         post?: never;
@@ -4712,7 +4767,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description Cancel current subscription. */
+        /**
+         * Cancel current subscription
+         * @description Cancel the current tenant subscription at the end of the active billing period.
+         */
         post: operations["billing_cancel_subscription_create"];
         delete?: never;
         options?: never;
@@ -5119,24 +5177,13 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         /**
-         * @description * `preventive` - Preventive Control
-         *     * `detective` - Detective Control
-         *     * `corrective` - Corrective Action
-         *     * `policy` - Policy/Procedure
-         *     * `training` - Training/Awareness
-         *     * `technical` - Technical Implementation
-         *     * `assessment` - Assessment/Review
-         *     * `other` - Other
+         * @description * `pending` - Pending Generation
+         *     * `processing` - Processing
+         *     * `completed` - Completed
+         *     * `failed` - Failed
          * @enum {string}
          */
-        ActionTypeEnum: "preventive" | "detective" | "corrective" | "policy" | "training" | "technical" | "assessment" | "other";
-        /**
-         * @description * `applicable` - Applicable
-         *     * `not_applicable` - Not Applicable
-         *     * `to_be_determined` - To Be Determined
-         * @enum {string}
-         */
-        ApplicabilityEnum: "applicable" | "not_applicable" | "to_be_determined";
+        AnalyticsExportStatusEnum: "pending" | "processing" | "completed" | "failed";
         /**
          * @description * `under_review` - Under Review
          *     * `applicable` - Applicable
@@ -5157,6 +5204,10 @@ export interface components {
             notes?: string;
             /** @description Required for rejections - explain why the request was rejected */
             rejection_reason?: string;
+        };
+        ApprovePushChallengeRequest: {
+            challenge_id: string;
+            approved: boolean;
         };
         /**
          * @description * `scope_document` - Scope Document
@@ -5227,7 +5278,7 @@ export interface components {
             readonly requested_by_name: string;
             /** Format: date-time */
             readonly requested_at: string;
-            readonly status: components["schemas"]["Status62aEnum"];
+            readonly status: components["schemas"]["AnalyticsExportStatusEnum"];
             /** @description Generated PDF report file */
             readonly generated_file: number | null;
             readonly generated_file_details: components["schemas"]["Document"];
@@ -5287,11 +5338,11 @@ export interface components {
             name: string;
             asset_type?: components["schemas"]["AssetTypeEnum"];
             description?: string;
-            classification?: components["schemas"]["ClassificationEnum"];
-            criticality?: components["schemas"]["DefaultPriorityEnum"];
+            classification?: components["schemas"]["DataClassificationEnum"];
+            criticality?: components["schemas"]["LowMediumHighCriticalEnum"];
             lifecycle_status?: components["schemas"]["LifecycleStatusEnum"];
             owner?: number | null;
-            readonly owner_display: string;
+            readonly owner_display: string | null;
             owner_name?: string;
             custodian?: string;
             location?: string;
@@ -5321,8 +5372,8 @@ export interface components {
             readonly source_row: number | null;
             readonly source_checksum: string;
             readonly metadata: unknown;
-            readonly is_review_overdue: string;
-            readonly days_until_review: string;
+            readonly is_review_overdue: boolean;
+            readonly days_until_review: number | null;
             readonly created_by_username: string;
             /** Format: date-time */
             readonly created_at: string;
@@ -5334,8 +5385,8 @@ export interface components {
             name: string;
             asset_type?: components["schemas"]["AssetTypeEnum"];
             description?: string;
-            classification?: components["schemas"]["ClassificationEnum"];
-            criticality?: components["schemas"]["DefaultPriorityEnum"];
+            classification?: components["schemas"]["DataClassificationEnum"];
+            criticality?: components["schemas"]["LowMediumHighCriticalEnum"];
             lifecycle_status?: components["schemas"]["LifecycleStatusEnum"];
             owner?: number | null;
             owner_name?: string;
@@ -5368,20 +5419,20 @@ export interface components {
             asset_id: string;
             name: string;
             asset_type?: components["schemas"]["AssetTypeEnum"];
-            classification?: components["schemas"]["ClassificationEnum"];
-            criticality?: components["schemas"]["DefaultPriorityEnum"];
+            classification?: components["schemas"]["DataClassificationEnum"];
+            criticality?: components["schemas"]["LowMediumHighCriticalEnum"];
             lifecycle_status?: components["schemas"]["LifecycleStatusEnum"];
             owner?: number | null;
-            readonly owner_display: string;
+            readonly owner_display: string | null;
             owner_name?: string;
             location?: string;
             /** Format: date */
             next_review_date?: string | null;
-            readonly is_review_overdue: string;
-            readonly days_until_review: string;
-            readonly linked_risk_count: string;
-            readonly linked_control_count: string;
-            readonly linked_document_count: string;
+            readonly is_review_overdue: boolean;
+            readonly days_until_review: number | null;
+            readonly linked_risk_count: number;
+            readonly linked_control_count: number;
+            readonly linked_document_count: number;
         };
         AssetReviewReminderLog: {
             readonly id: number;
@@ -5452,7 +5503,7 @@ export interface components {
             default_due_date?: string;
             default_assigned_to?: number;
             /** @default to_be_determined */
-            default_applicability: components["schemas"]["DefaultApplicabilityEnum"];
+            default_applicability: components["schemas"]["RequirementApplicabilityEnum"];
             /** @description Specific control IDs to create assessments for. If empty, creates for all framework controls. */
             controls?: number[];
         };
@@ -5535,6 +5586,20 @@ export interface components {
          * @enum {string}
          */
         CalendarEventStatusEnum: "scheduled" | "completed" | "cancelled";
+        CalendarNotificationPreference: {
+            email_enabled?: boolean;
+            advance_reminder_days?: number;
+            due_date_enabled?: boolean;
+            overdue_enabled?: boolean;
+            /** Format: date-time */
+            readonly updated_at: string;
+        };
+        CalendarNotificationPreferenceRequest: {
+            email_enabled?: boolean;
+            advance_reminder_days?: number;
+            due_date_enabled?: boolean;
+            overdue_enabled?: boolean;
+        };
         CalendarReminderLog: {
             readonly id: number;
             readonly source_type: string;
@@ -5567,7 +5632,7 @@ export interface components {
             readonly campaign_name: string;
             user: number;
             readonly user_email: string;
-            readonly user_name: string;
+            readonly user_name: string | null;
             /** Format: date-time */
             readonly sent_at: string;
             /** Format: date-time */
@@ -5607,14 +5672,11 @@ export interface components {
          * @enum {string}
          */
         CategoryEnum: "it_services" | "cloud_hosting" | "software_licensing" | "consulting" | "support_maintenance" | "professional_services" | "managed_services" | "security_services" | "data_processing" | "other";
-        /**
-         * @description * `public` - Public
-         *     * `internal` - Internal
-         *     * `confidential` - Confidential
-         *     * `restricted` - Restricted
-         * @enum {string}
-         */
-        ClassificationEnum: "public" | "internal" | "confidential" | "restricted";
+        ChangePasswordRequest: {
+            old_password: string;
+            new_password: string;
+            new_password_confirm: string;
+        };
         /** @description Detailed clause serializer with full information. */
         ClauseDetail: {
             readonly id: number;
@@ -5634,7 +5696,7 @@ export interface components {
             /** @description Display order within framework */
             sort_order?: number;
             clause_type?: components["schemas"]["ClauseTypeEnum"];
-            criticality?: components["schemas"]["DefaultPriorityEnum"];
+            criticality?: components["schemas"]["LowMediumHighCriticalEnum"];
             /** @description Whether this clause can be tested/audited */
             is_testable?: boolean;
             /** @description Guidance on how to implement this clause */
@@ -5643,8 +5705,8 @@ export interface components {
             testing_procedures?: string;
             /** @description References to other standards, regulations, or frameworks */
             external_references?: unknown;
-            readonly control_count: string;
-            readonly subclauses: string;
+            readonly control_count: number;
+            readonly subclauses: components["schemas"]["ClauseList"][];
             /** Format: date-time */
             readonly created_at: string;
             /** Format: date-time */
@@ -5664,7 +5726,7 @@ export interface components {
             /** @description Display order within framework */
             sort_order?: number;
             clause_type?: components["schemas"]["ClauseTypeEnum"];
-            criticality?: components["schemas"]["DefaultPriorityEnum"];
+            criticality?: components["schemas"]["LowMediumHighCriticalEnum"];
             /** @description Whether this clause can be tested/audited */
             is_testable?: boolean;
             /** @description Guidance on how to implement this clause */
@@ -5683,10 +5745,10 @@ export interface components {
             /** @description Clause title or heading */
             title: string;
             clause_type?: components["schemas"]["ClauseTypeEnum"];
-            criticality?: components["schemas"]["DefaultPriorityEnum"];
+            criticality?: components["schemas"]["LowMediumHighCriticalEnum"];
             /** @description Whether this clause can be tested/audited */
             is_testable?: boolean;
-            readonly control_count: string;
+            readonly control_count: number;
             readonly framework_name: string;
             readonly framework_short_name: string;
             /** @description Display order within framework */
@@ -5699,7 +5761,7 @@ export interface components {
             /** @description Clause title or heading */
             title: string;
             clause_type?: components["schemas"]["ClauseTypeEnum"];
-            criticality?: components["schemas"]["DefaultPriorityEnum"];
+            criticality?: components["schemas"]["LowMediumHighCriticalEnum"];
             /** @description Whether this clause can be tested/audited */
             is_testable?: boolean;
             /** @description Display order within framework */
@@ -5725,6 +5787,9 @@ export interface components {
          * @enum {string}
          */
         ComplianceStatusEnum: "not_started" | "in_progress" | "compliant" | "non_compliant" | "accepted_risk";
+        ConfirmTOTPRequest: {
+            otp_code: string;
+        };
         /**
          * @description * `primary` - Primary Contact
          *     * `billing` - Billing Contact
@@ -5756,7 +5821,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `to_be_determined` - To Be Determined
              */
-            applicability?: components["schemas"]["ApplicabilityEnum"];
+            applicability?: components["schemas"]["RequirementApplicabilityEnum"];
             /** @description Explanation of why the control is/isn't applicable */
             applicability_rationale?: string;
             /**
@@ -5770,7 +5835,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `deferred` - Deferred
              */
-            status?: components["schemas"]["StatusEnum"];
+            status?: components["schemas"]["ControlAssessmentStatusEnum"];
             /**
              * @description Current implementation status of the control
              *
@@ -5815,7 +5880,7 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             /** @description Compliance score (0-100) for this control */
             compliance_score?: number | null;
             /** @description General notes and observations about this assessment */
@@ -5845,7 +5910,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `to_be_determined` - To Be Determined
              */
-            applicability?: components["schemas"]["ApplicabilityEnum"];
+            applicability?: components["schemas"]["RequirementApplicabilityEnum"];
             /** @description Explanation of why the control is/isn't applicable */
             applicability_rationale?: string;
             /**
@@ -5859,7 +5924,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `deferred` - Deferred
              */
-            status?: components["schemas"]["StatusEnum"];
+            status?: components["schemas"]["ControlAssessmentStatusEnum"];
             /**
              * @description Current implementation status of the control
              *
@@ -5904,7 +5969,7 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             /** @description Compliance score (0-100) for this control */
             compliance_score?: number | null;
             /** @description General notes and observations about this assessment */
@@ -5940,7 +6005,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `to_be_determined` - To Be Determined
              */
-            applicability?: components["schemas"]["ApplicabilityEnum"];
+            applicability?: components["schemas"]["RequirementApplicabilityEnum"];
             /** @description Explanation of why the control is/isn't applicable */
             applicability_rationale?: string;
             /**
@@ -5954,7 +6019,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `deferred` - Deferred
              */
-            status?: components["schemas"]["StatusEnum"];
+            status?: components["schemas"]["ControlAssessmentStatusEnum"];
             /**
              * @description Current implementation status of the control
              *
@@ -6011,7 +6076,7 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             /** @description Compliance score (0-100) for this control */
             compliance_score?: number | null;
             /** @description General notes and observations about this assessment */
@@ -6032,12 +6097,13 @@ export interface components {
             readonly version: number;
             /** @description History of changes to this assessment */
             readonly change_log: unknown;
-            readonly is_overdue: string;
-            readonly is_complete: string;
-            readonly completion_percentage: string;
-            readonly days_until_due: string;
-            readonly evidence_count: string;
-            readonly primary_evidence: string;
+            readonly is_overdue: boolean;
+            readonly is_complete: boolean;
+            /** Format: double */
+            readonly completion_percentage: number;
+            readonly days_until_due: number | null;
+            readonly evidence_count: number;
+            readonly primary_evidence: components["schemas"]["ControlEvidence"] | null;
             readonly created_by_username: string;
             /** Format: date-time */
             readonly created_at: string;
@@ -6055,7 +6121,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `to_be_determined` - To Be Determined
              */
-            applicability?: components["schemas"]["ApplicabilityEnum"];
+            applicability?: components["schemas"]["RequirementApplicabilityEnum"];
             /** @description Explanation of why the control is/isn't applicable */
             applicability_rationale?: string;
             /**
@@ -6069,7 +6135,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `deferred` - Deferred
              */
-            status?: components["schemas"]["StatusEnum"];
+            status?: components["schemas"]["ControlAssessmentStatusEnum"];
             /**
              * @description Current implementation status of the control
              *
@@ -6114,7 +6180,7 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             /** @description Compliance score (0-100) for this control */
             compliance_score?: number | null;
             /** @description General notes and observations about this assessment */
@@ -6149,7 +6215,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `to_be_determined` - To Be Determined
              */
-            applicability?: components["schemas"]["ApplicabilityEnum"];
+            applicability?: components["schemas"]["RequirementApplicabilityEnum"];
             /**
              * @description Current assessment status
              *
@@ -6161,7 +6227,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `deferred` - Deferred
              */
-            status?: components["schemas"]["StatusEnum"];
+            status?: components["schemas"]["ControlAssessmentStatusEnum"];
             /**
              * @description Current implementation status of the control
              *
@@ -6178,10 +6244,11 @@ export interface components {
              * @description Target completion date for this assessment
              */
             due_date?: string | null;
-            readonly completion_percentage: string;
-            readonly is_overdue: string;
-            readonly is_complete: string;
-            readonly days_until_due: string;
+            /** Format: double */
+            readonly completion_percentage: number;
+            readonly is_overdue: boolean;
+            readonly is_complete: boolean;
+            readonly days_until_due: number | null;
             /**
              * @description Risk level if this control is not properly implemented
              *
@@ -6190,16 +6257,29 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             /** @description Compliance score (0-100) for this control */
             compliance_score?: number | null;
-            readonly evidence_count: string;
-            readonly has_primary_evidence: string;
+            /** @description Get count of evidence linked to this assessment. */
+            readonly evidence_count: number;
+            /** @description Check if assessment has primary evidence. */
+            readonly has_primary_evidence: boolean;
             /** Format: date-time */
             readonly created_at: string;
             /** Format: date-time */
             readonly updated_at: string;
         };
+        /**
+         * @description * `not_started` - Not Started
+         *     * `pending` - Pending
+         *     * `in_progress` - In Progress
+         *     * `under_review` - Under Review
+         *     * `complete` - Complete
+         *     * `not_applicable` - Not Applicable
+         *     * `deferred` - Deferred
+         * @enum {string}
+         */
+        ControlAssessmentStatusEnum: "not_started" | "pending" | "in_progress" | "under_review" | "complete" | "not_applicable" | "deferred";
         /** @description Serializer for creating and updating controls. */
         ControlCreateUpdate: {
             /** @description Unique control identifier */
@@ -6212,7 +6292,7 @@ export interface components {
             clauses: number[];
             control_type: components["schemas"]["ControlTypeEnum"];
             automation_level?: components["schemas"]["AutomationLevelEnum"];
-            status?: components["schemas"]["Status949Enum"];
+            status?: components["schemas"]["ControlStatusEnum"];
             /** @description Person responsible for this control */
             control_owner?: number | null;
             /** @description Business unit or department responsible */
@@ -6223,7 +6303,7 @@ export interface components {
             frequency?: string;
             /** Format: date */
             last_tested_date?: string | null;
-            last_test_result?: components["schemas"]["LastTestResultEnum"] | components["schemas"]["BlankEnum"];
+            last_test_result?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /**
              * @description Current effectiveness assessment
              *
@@ -6232,7 +6312,7 @@ export interface components {
              *     * `largely_effective` - Largely Effective
              *     * `fully_effective` - Fully Effective
              */
-            effectiveness_rating?: components["schemas"]["EffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
+            effectiveness_rating?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /** @description What evidence is needed to demonstrate this control's effectiveness */
             evidence_requirements?: string;
             /** @description Links to related policies, procedures, and documentation */
@@ -6245,7 +6325,7 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             /** @description Plan for addressing control deficiencies */
             remediation_plan?: string;
             version?: string;
@@ -6262,7 +6342,7 @@ export interface components {
             clauses: number[];
             control_type: components["schemas"]["ControlTypeEnum"];
             automation_level?: components["schemas"]["AutomationLevelEnum"];
-            status?: components["schemas"]["Status949Enum"];
+            status?: components["schemas"]["ControlStatusEnum"];
             /** @description Person responsible for this control */
             control_owner?: number | null;
             /** @description Business unit or department responsible */
@@ -6273,7 +6353,7 @@ export interface components {
             frequency?: string;
             /** Format: date */
             last_tested_date?: string | null;
-            last_test_result?: components["schemas"]["LastTestResultEnum"] | components["schemas"]["BlankEnum"];
+            last_test_result?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /**
              * @description Current effectiveness assessment
              *
@@ -6282,7 +6362,7 @@ export interface components {
              *     * `largely_effective` - Largely Effective
              *     * `fully_effective` - Fully Effective
              */
-            effectiveness_rating?: components["schemas"]["EffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
+            effectiveness_rating?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /** @description What evidence is needed to demonstrate this control's effectiveness */
             evidence_requirements?: string;
             /** @description Links to related policies, procedures, and documentation */
@@ -6295,7 +6375,7 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             /** @description Plan for addressing control deficiencies */
             remediation_plan?: string;
             version?: string;
@@ -6314,7 +6394,7 @@ export interface components {
             readonly clauses_detail: components["schemas"]["ClauseList"][];
             control_type: components["schemas"]["ControlTypeEnum"];
             automation_level?: components["schemas"]["AutomationLevelEnum"];
-            status?: components["schemas"]["Status949Enum"];
+            status?: components["schemas"]["ControlStatusEnum"];
             /** @description Person responsible for this control */
             control_owner?: number | null;
             readonly control_owner_name: string;
@@ -6326,7 +6406,7 @@ export interface components {
             frequency?: string;
             /** Format: date */
             last_tested_date?: string | null;
-            last_test_result?: components["schemas"]["LastTestResultEnum"] | components["schemas"]["BlankEnum"];
+            last_test_result?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /**
              * @description Current effectiveness assessment
              *
@@ -6335,7 +6415,7 @@ export interface components {
              *     * `largely_effective` - Largely Effective
              *     * `fully_effective` - Fully Effective
              */
-            effectiveness_rating?: components["schemas"]["EffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
+            effectiveness_rating?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /** @description What evidence is needed to demonstrate this control's effectiveness */
             evidence_requirements?: string;
             /** @description Links to related policies, procedures, and documentation */
@@ -6348,15 +6428,15 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             /** @description Plan for addressing control deficiencies */
             remediation_plan?: string;
             version?: string;
             /** @description History of changes to this control */
             change_log?: unknown;
-            readonly is_active: string;
-            readonly needs_testing: string;
-            readonly framework_coverage: string;
+            readonly is_active: boolean;
+            readonly needs_testing: boolean;
+            readonly framework_coverage: components["schemas"]["FrameworkCoverageItem"][];
             readonly evidence: components["schemas"]["ControlEvidence"][];
             readonly template_documents: components["schemas"]["TemplateDocumentSummary"][];
             readonly created_by_username: string;
@@ -6377,7 +6457,7 @@ export interface components {
             clauses: number[];
             control_type: components["schemas"]["ControlTypeEnum"];
             automation_level?: components["schemas"]["AutomationLevelEnum"];
-            status?: components["schemas"]["Status949Enum"];
+            status?: components["schemas"]["ControlStatusEnum"];
             /** @description Person responsible for this control */
             control_owner?: number | null;
             /** @description Business unit or department responsible */
@@ -6388,7 +6468,7 @@ export interface components {
             frequency?: string;
             /** Format: date */
             last_tested_date?: string | null;
-            last_test_result?: components["schemas"]["LastTestResultEnum"] | components["schemas"]["BlankEnum"];
+            last_test_result?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /**
              * @description Current effectiveness assessment
              *
@@ -6397,7 +6477,7 @@ export interface components {
              *     * `largely_effective` - Largely Effective
              *     * `fully_effective` - Fully Effective
              */
-            effectiveness_rating?: components["schemas"]["EffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
+            effectiveness_rating?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /** @description What evidence is needed to demonstrate this control's effectiveness */
             evidence_requirements?: string;
             /** @description Links to related policies, procedures, and documentation */
@@ -6410,19 +6490,27 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             /** @description Plan for addressing control deficiencies */
             remediation_plan?: string;
             version?: string;
             /** @description History of changes to this control */
             change_log?: unknown;
         };
+        /**
+         * @description * `not_effective` - Not Effective
+         *     * `partially_effective` - Partially Effective
+         *     * `largely_effective` - Largely Effective
+         *     * `fully_effective` - Fully Effective
+         * @enum {string}
+         */
+        ControlEffectivenessRatingEnum: "not_effective" | "partially_effective" | "largely_effective" | "fully_effective";
         /** @description Serializer for control evidence. */
         ControlEvidence: {
             readonly id: number;
             /** @description Evidence title or description */
             title: string;
-            evidence_type: components["schemas"]["EvidenceTypeEnum"];
+            evidence_type: components["schemas"]["ControlEvidenceTypeEnum"];
             /** @description Additional evidence description */
             description?: string;
             /** @description Associated document file */
@@ -6456,7 +6544,7 @@ export interface components {
         ControlEvidenceRequest: {
             /** @description Evidence title or description */
             title: string;
-            evidence_type: components["schemas"]["EvidenceTypeEnum"];
+            evidence_type: components["schemas"]["ControlEvidenceTypeEnum"];
             /** @description Additional evidence description */
             description?: string;
             /** @description Associated document file */
@@ -6476,6 +6564,19 @@ export interface components {
             validated_by?: number | null;
             validation_notes?: string;
         };
+        /**
+         * @description * `document` - Document/Policy
+         *     * `screenshot` - Screenshot
+         *     * `log_file` - Log File
+         *     * `report` - Report
+         *     * `certificate` - Certificate
+         *     * `approval` - Approval/Sign-off
+         *     * `test_result` - Test Result
+         *     * `meeting_notes` - Meeting Notes
+         *     * `other` - Other
+         * @enum {string}
+         */
+        ControlEvidenceTypeEnum: "document" | "screenshot" | "log_file" | "report" | "certificate" | "approval" | "test_result" | "meeting_notes" | "other";
         /** @description Lightweight serializer for control listings. */
         ControlList: {
             readonly id: number;
@@ -6485,7 +6586,7 @@ export interface components {
             name: string;
             control_type: components["schemas"]["ControlTypeEnum"];
             automation_level?: components["schemas"]["AutomationLevelEnum"];
-            status?: components["schemas"]["Status949Enum"];
+            status?: components["schemas"]["ControlStatusEnum"];
             readonly control_owner_name: string;
             /**
              * @description Current effectiveness assessment
@@ -6495,7 +6596,7 @@ export interface components {
              *     * `largely_effective` - Largely Effective
              *     * `fully_effective` - Fully Effective
              */
-            effectiveness_rating?: components["schemas"]["EffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
+            effectiveness_rating?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /** Format: date */
             last_tested_date?: string | null;
             /**
@@ -6506,11 +6607,11 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
-            readonly is_active: string;
-            readonly needs_testing: string;
-            readonly framework_coverage: string;
-            readonly clause_count: string;
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
+            readonly is_active: boolean;
+            readonly needs_testing: boolean;
+            readonly framework_coverage: components["schemas"]["FrameworkCoverageItem"][];
+            readonly clause_count: number;
             version?: string;
         };
         /** @description Lightweight serializer for control listings. */
@@ -6521,7 +6622,7 @@ export interface components {
             name: string;
             control_type: components["schemas"]["ControlTypeEnum"];
             automation_level?: components["schemas"]["AutomationLevelEnum"];
-            status?: components["schemas"]["Status949Enum"];
+            status?: components["schemas"]["ControlStatusEnum"];
             /**
              * @description Current effectiveness assessment
              *
@@ -6530,7 +6631,7 @@ export interface components {
              *     * `largely_effective` - Largely Effective
              *     * `fully_effective` - Fully Effective
              */
-            effectiveness_rating?: components["schemas"]["EffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
+            effectiveness_rating?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /** Format: date */
             last_tested_date?: string | null;
             /**
@@ -6541,9 +6642,21 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             version?: string;
         };
+        /**
+         * @description * `planned` - Planned
+         *     * `in_progress` - In Progress
+         *     * `implemented` - Implemented
+         *     * `testing` - Under Testing
+         *     * `active` - Active
+         *     * `remediation` - Needs Remediation
+         *     * `disabled` - Disabled
+         *     * `retired` - Retired
+         * @enum {string}
+         */
+        ControlStatusEnum: "planned" | "in_progress" | "implemented" | "testing" | "active" | "remediation" | "disabled" | "retired";
         /**
          * @description * `preventive` - Preventive Control
          *     * `detective` - Detective Control
@@ -6564,33 +6677,6 @@ export interface components {
          */
         DataClassificationEnum: "public" | "internal" | "confidential" | "restricted";
         /**
-         * @description * `preventive` - Preventive Control
-         *     * `detective` - Detective Control
-         *     * `corrective` - Corrective Action
-         *     * `policy` - Policy/Procedure
-         *     * `training` - Training/Awareness
-         *     * `technical` - Technical Implementation
-         *     * `assessment` - Assessment/Review
-         *     * `other` - Other
-         * @enum {string}
-         */
-        DefaultActionTypeEnum: "preventive" | "detective" | "corrective" | "policy" | "training" | "technical" | "assessment" | "other";
-        /**
-         * @description * `applicable` - Applicable
-         *     * `not_applicable` - Not Applicable
-         *     * `to_be_determined` - To Be Determined
-         * @enum {string}
-         */
-        DefaultApplicabilityEnum: "applicable" | "not_applicable" | "to_be_determined";
-        /**
-         * @description * `low` - Low
-         *     * `medium` - Medium
-         *     * `high` - High
-         *     * `critical` - Critical
-         * @enum {string}
-         */
-        DefaultPriorityEnum: "low" | "medium" | "high" | "critical";
-        /**
          * @description * `sent` - Sent
          *     * `delivered` - Delivered
          *     * `opened` - Opened
@@ -6601,12 +6687,32 @@ export interface components {
          */
         DeliveryStatusEnum: "sent" | "delivered" | "opened" | "clicked" | "bounced" | "failed";
         /**
+         * @description * `ios` - ios
+         *     * `android` - android
+         *     * `web` - web
+         * @enum {string}
+         */
+        DeviceTypeEnum: "ios" | "android" | "web";
+        /**
          * @description * `beginner` - Beginner
          *     * `intermediate` - Intermediate
          *     * `advanced` - Advanced
          * @enum {string}
          */
         DifficultyLevelEnum: "beginner" | "intermediate" | "advanced";
+        /**
+         * @description * `email` - email
+         *     * `totp` - totp
+         *     * `push` - push
+         *     * `all` - all
+         * @enum {string}
+         */
+        DisableTwoFactorMethodEnum: "email" | "totp" | "push" | "all";
+        DisableTwoFactorRequest: {
+            password: string;
+            /** @default all */
+            method: components["schemas"]["DisableTwoFactorMethodEnum"];
+        };
         /** @description Serializer for document uploads with file validation and metadata. */
         Document: {
             readonly id: number;
@@ -6617,7 +6723,8 @@ export interface components {
              * @description Upload documents (PDF, DOC, XLS, etc.)
              */
             file: string;
-            readonly file_url: string;
+            /** Format: uri */
+            readonly file_url: string | null;
             readonly file_name: string;
             readonly uploaded_by: string;
             /** Format: date-time */
@@ -6671,13 +6778,22 @@ export interface components {
          */
         DocumentTypeEnum: "policy" | "standard" | "procedure" | "mandatory_document" | "risk_register" | "asset_register" | "framework_spreadsheet" | "template" | "sample" | "other";
         /**
-         * @description * `not_effective` - Not Effective
-         *     * `partially_effective` - Partially Effective
-         *     * `largely_effective` - Largely Effective
-         *     * `fully_effective` - Fully Effective
+         * @description * `email` - email
+         *     * `totp` - totp
+         *     * `push` - push
          * @enum {string}
          */
-        EffectivenessRatingEnum: "not_effective" | "partially_effective" | "largely_effective" | "fully_effective";
+        EnableTwoFactorMethodEnum: "email" | "totp" | "push";
+        EnableTwoFactorRequest: {
+            password: string;
+            method: components["schemas"]["EnableTwoFactorMethodEnum"];
+            /** Format: email */
+            email?: string;
+            device_token?: string;
+            device_name?: string;
+            device_type?: components["schemas"]["DeviceTypeEnum"];
+            push_service?: components["schemas"]["PushServiceEnum"];
+        };
         /**
          * @description * `deadline` - Deadline
          *     * `review` - Review
@@ -6688,36 +6804,16 @@ export interface components {
          */
         EventTypeEnum: "deadline" | "review" | "meeting" | "training" | "custom";
         /**
-         * @description * `document` - Document/Policy
-         *     * `screenshot` - Screenshot
-         *     * `report` - Report/Analysis
-         *     * `certificate` - Certificate
-         *     * `configuration` - Configuration File
-         *     * `training_record` - Training Record
-         *     * `audit_log` - Audit Log
-         *     * `other` - Other
-         * @enum {string}
-         */
-        EvidenceTypeA14Enum: "document" | "screenshot" | "report" | "certificate" | "configuration" | "training_record" | "audit_log" | "other";
-        /**
-         * @description * `document` - Document/Policy
-         *     * `screenshot` - Screenshot
-         *     * `log_file` - Log File
-         *     * `report` - Report
-         *     * `certificate` - Certificate
-         *     * `approval` - Approval/Sign-off
-         *     * `test_result` - Test Result
-         *     * `meeting_notes` - Meeting Notes
-         *     * `other` - Other
-         * @enum {string}
-         */
-        EvidenceTypeEnum: "document" | "screenshot" | "log_file" | "report" | "certificate" | "approval" | "test_result" | "meeting_notes" | "other";
-        /**
          * @description * `xlsx` - Excel workbook
          *     * `csv_zip` - CSV archive
          * @enum {string}
          */
         ExportFormatEnum: "xlsx" | "csv_zip";
+        FrameworkCoverageItem: {
+            id: number;
+            short_name: string;
+            name: string;
+        };
         /** @description Detailed framework serializer with full information. */
         FrameworkDetail: {
             readonly id: number;
@@ -6749,12 +6845,12 @@ export interface components {
              * @description Date when this version expires
              */
             expiry_date?: string | null;
-            status?: components["schemas"]["StatusFa2Enum"];
+            status?: components["schemas"]["FrameworkStatusEnum"];
             /** @description Whether compliance with this framework is mandatory for the organization */
             is_mandatory?: boolean;
-            readonly clause_count: string;
-            readonly control_count: string;
-            readonly is_active: string;
+            readonly clause_count: number;
+            readonly control_count: number;
+            readonly is_active: boolean;
             readonly created_by_username: string;
             /** Format: date-time */
             readonly created_at: string;
@@ -6795,7 +6891,7 @@ export interface components {
              * @description Date when this version expires
              */
             expiry_date?: string | null;
-            status?: components["schemas"]["StatusFa2Enum"];
+            status?: components["schemas"]["FrameworkStatusEnum"];
             /** @description Whether compliance with this framework is mandatory for the organization */
             is_mandatory?: boolean;
         };
@@ -6812,7 +6908,7 @@ export interface components {
              */
             version: string;
             framework_type?: components["schemas"]["FrameworkTypeEnum"];
-            status?: components["schemas"]["StatusFa2Enum"];
+            status?: components["schemas"]["FrameworkStatusEnum"];
             /** @description Whether compliance with this framework is mandatory for the organization */
             is_mandatory?: boolean;
             /**
@@ -6820,9 +6916,9 @@ export interface components {
              * @description Date when this version became effective
              */
             effective_date: string;
-            readonly clause_count: string;
-            readonly control_count: string;
-            readonly is_active: string;
+            readonly clause_count: number;
+            readonly control_count: number;
+            readonly is_active: boolean;
             /** @description Organization that issued/maintains this framework */
             issuing_organization: string;
         };
@@ -6855,6 +6951,14 @@ export interface components {
             /** @description Confidence percentage (0-100) in this mapping */
             confidence_level?: number;
         };
+        /**
+         * @description * `draft` - Draft
+         *     * `active` - Active
+         *     * `deprecated` - Deprecated
+         *     * `archived` - Archived
+         * @enum {string}
+         */
+        FrameworkStatusEnum: "draft" | "active" | "deprecated" | "archived";
         /**
          * @description * `security` - Security Framework
          *     * `privacy` - Privacy Framework
@@ -6942,7 +7046,7 @@ export interface components {
             module_key?: components["schemas"]["ModuleKeyEnum"] | components["schemas"]["BlankEnum"];
             workflow_key?: string;
             tags?: unknown;
-            status?: components["schemas"]["StatusDaeEnum"];
+            status?: components["schemas"]["KnowledgeArticleStatusEnum"];
             content_scope?: components["schemas"]["ContentScopeEnum"];
             sort_order?: number;
             /** Format: date-time */
@@ -6963,7 +7067,7 @@ export interface components {
             module_key?: components["schemas"]["ModuleKeyEnum"] | components["schemas"]["BlankEnum"];
             workflow_key?: string;
             tags?: unknown;
-            status?: components["schemas"]["StatusDaeEnum"];
+            status?: components["schemas"]["KnowledgeArticleStatusEnum"];
             content_scope?: components["schemas"]["ContentScopeEnum"];
             sort_order?: number;
         };
@@ -6977,7 +7081,7 @@ export interface components {
             module_key?: components["schemas"]["ModuleKeyEnum"] | components["schemas"]["BlankEnum"];
             workflow_key?: string;
             tags?: unknown;
-            status?: components["schemas"]["StatusDaeEnum"];
+            status?: components["schemas"]["KnowledgeArticleStatusEnum"];
             content_scope?: components["schemas"]["ContentScopeEnum"];
             sort_order?: number;
             /** Format: date-time */
@@ -6985,6 +7089,13 @@ export interface components {
             /** Format: date-time */
             readonly updated_at: string;
         };
+        /**
+         * @description * `draft` - Draft
+         *     * `published` - Published
+         *     * `archived` - Archived
+         * @enum {string}
+         */
+        KnowledgeArticleStatusEnum: "draft" | "published" | "archived";
         KnowledgeCategory: {
             readonly id: number;
             name: string;
@@ -7007,14 +7118,6 @@ export interface components {
             sort_order?: number;
             is_active?: boolean;
         };
-        /**
-         * @description * `not_effective` - Not Effective
-         *     * `partially_effective` - Partially Effective
-         *     * `largely_effective` - Largely Effective
-         *     * `fully_effective` - Fully Effective
-         * @enum {string}
-         */
-        LastTestResultEnum: "not_effective" | "partially_effective" | "largely_effective" | "fully_effective";
         /**
          * @description * `template` - Template
          *     * `draft` - Draft
@@ -7083,7 +7186,7 @@ export interface components {
              * @description When should temporary limits expire?
              */
             expires_at?: string | null;
-            status?: components["schemas"]["Status8f5Enum"];
+            status?: components["schemas"]["LimitOverrideStatusEnum"];
             readonly status_display: string;
             /** @description User who requested the override */
             readonly requested_by: string;
@@ -7128,11 +7231,20 @@ export interface components {
              * @description When should temporary limits expire?
              */
             expires_at?: string | null;
-            status?: components["schemas"]["Status8f5Enum"];
+            status?: components["schemas"]["LimitOverrideStatusEnum"];
             first_approval_notes?: string;
             second_approval_notes?: string;
             rejection_reason?: string;
         };
+        /**
+         * @description * `pending` - Pending Review
+         *     * `approved` - Approved
+         *     * `rejected` - Rejected
+         *     * `applied` - Applied
+         *     * `expired` - Expired
+         * @enum {string}
+         */
+        LimitOverrideStatusEnum: "pending" | "approved" | "rejected" | "applied" | "expired";
         /**
          * @description * `max_users` - Maximum Users
          *     * `max_documents` - Maximum Documents
@@ -7145,6 +7257,14 @@ export interface components {
             username: string;
             password: string;
         };
+        /**
+         * @description * `low` - Low
+         *     * `medium` - Medium
+         *     * `high` - High
+         *     * `critical` - Critical
+         * @enum {string}
+         */
+        LowMediumHighCriticalEnum: "low" | "medium" | "high" | "critical";
         ManagementReview: {
             readonly id: number;
             readonly review_id: string;
@@ -7225,6 +7345,12 @@ export interface components {
          * @enum {string}
          */
         MaturityLevelEnum: "ad_hoc" | "repeatable" | "defined" | "managed" | "optimized";
+        ModuleCatalogItem: {
+            key: string;
+            name: string;
+            description: string;
+            enabled?: boolean;
+        };
         /**
          * @description * `policy` - Policy
          *     * `standard` - Standard
@@ -7278,7 +7404,7 @@ export interface components {
             linked_risks?: number[];
             linked_documents?: number[];
             metadata?: unknown;
-            readonly is_overdue: string;
+            readonly is_overdue: boolean;
             /** Format: date-time */
             readonly created_at: string;
             /** Format: date-time */
@@ -7333,15 +7459,6 @@ export interface components {
          * @enum {string}
          */
         NonConformityStatusEnum: "open" | "root_cause_review" | "corrective_action" | "verification" | "closed" | "accepted";
-        /**
-         * @description * `progress` - Progress Update
-         *     * `issue` - Issue/Blocker
-         *     * `completion` - Completion
-         *     * `status_change` - Status Change
-         *     * `general` - General
-         * @enum {string}
-         */
-        NoteType679Enum: "progress" | "issue" | "completion" | "status_change" | "general";
         PaginatedAssetListList: {
             /** @example 123 */
             count: number;
@@ -7473,8 +7590,8 @@ export interface components {
             name?: string;
             asset_type?: components["schemas"]["AssetTypeEnum"];
             description?: string;
-            classification?: components["schemas"]["ClassificationEnum"];
-            criticality?: components["schemas"]["DefaultPriorityEnum"];
+            classification?: components["schemas"]["DataClassificationEnum"];
+            criticality?: components["schemas"]["LowMediumHighCriticalEnum"];
             lifecycle_status?: components["schemas"]["LifecycleStatusEnum"];
             owner?: number | null;
             owner_name?: string;
@@ -7527,7 +7644,7 @@ export interface components {
             /** @description Display order within framework */
             sort_order?: number;
             clause_type?: components["schemas"]["ClauseTypeEnum"];
-            criticality?: components["schemas"]["DefaultPriorityEnum"];
+            criticality?: components["schemas"]["LowMediumHighCriticalEnum"];
             /** @description Whether this clause can be tested/audited */
             is_testable?: boolean;
             /** @description Guidance on how to implement this clause */
@@ -7550,7 +7667,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `to_be_determined` - To Be Determined
              */
-            applicability?: components["schemas"]["ApplicabilityEnum"];
+            applicability?: components["schemas"]["RequirementApplicabilityEnum"];
             /** @description Explanation of why the control is/isn't applicable */
             applicability_rationale?: string;
             /**
@@ -7564,7 +7681,7 @@ export interface components {
              *     * `not_applicable` - Not Applicable
              *     * `deferred` - Deferred
              */
-            status?: components["schemas"]["StatusEnum"];
+            status?: components["schemas"]["ControlAssessmentStatusEnum"];
             /**
              * @description Current implementation status of the control
              *
@@ -7609,7 +7726,7 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             /** @description Compliance score (0-100) for this control */
             compliance_score?: number | null;
             /** @description General notes and observations about this assessment */
@@ -7638,7 +7755,7 @@ export interface components {
             clauses?: number[];
             control_type?: components["schemas"]["ControlTypeEnum"];
             automation_level?: components["schemas"]["AutomationLevelEnum"];
-            status?: components["schemas"]["Status949Enum"];
+            status?: components["schemas"]["ControlStatusEnum"];
             /** @description Person responsible for this control */
             control_owner?: number | null;
             /** @description Business unit or department responsible */
@@ -7649,7 +7766,7 @@ export interface components {
             frequency?: string;
             /** Format: date */
             last_tested_date?: string | null;
-            last_test_result?: components["schemas"]["LastTestResultEnum"] | components["schemas"]["BlankEnum"];
+            last_test_result?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /**
              * @description Current effectiveness assessment
              *
@@ -7658,7 +7775,7 @@ export interface components {
              *     * `largely_effective` - Largely Effective
              *     * `fully_effective` - Fully Effective
              */
-            effectiveness_rating?: components["schemas"]["EffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
+            effectiveness_rating?: components["schemas"]["ControlEffectivenessRatingEnum"] | components["schemas"]["BlankEnum"];
             /** @description What evidence is needed to demonstrate this control's effectiveness */
             evidence_requirements?: string;
             /** @description Links to related policies, procedures, and documentation */
@@ -7671,7 +7788,7 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            risk_rating?: components["schemas"]["DefaultPriorityEnum"] | components["schemas"]["BlankEnum"];
+            risk_rating?: components["schemas"]["LowMediumHighCriticalEnum"] | components["schemas"]["BlankEnum"];
             /** @description Plan for addressing control deficiencies */
             remediation_plan?: string;
             version?: string;
@@ -7680,7 +7797,7 @@ export interface components {
         PatchedControlEvidenceRequest: {
             /** @description Evidence title or description */
             title?: string;
-            evidence_type?: components["schemas"]["EvidenceTypeEnum"];
+            evidence_type?: components["schemas"]["ControlEvidenceTypeEnum"];
             /** @description Additional evidence description */
             description?: string;
             /** @description Associated document file */
@@ -7743,7 +7860,7 @@ export interface components {
              * @description Date when this version expires
              */
             expiry_date?: string | null;
-            status?: components["schemas"]["StatusFa2Enum"];
+            status?: components["schemas"]["FrameworkStatusEnum"];
             /** @description Whether compliance with this framework is mandatory for the organization */
             is_mandatory?: boolean;
         };
@@ -7783,7 +7900,7 @@ export interface components {
             module_key?: components["schemas"]["ModuleKeyEnum"] | components["schemas"]["BlankEnum"];
             workflow_key?: string;
             tags?: unknown;
-            status?: components["schemas"]["StatusDaeEnum"];
+            status?: components["schemas"]["KnowledgeArticleStatusEnum"];
             content_scope?: components["schemas"]["ContentScopeEnum"];
             sort_order?: number;
         };
@@ -7810,7 +7927,7 @@ export interface components {
              * @description When should temporary limits expire?
              */
             expires_at?: string | null;
-            status?: components["schemas"]["Status8f5Enum"];
+            status?: components["schemas"]["LimitOverrideStatusEnum"];
             first_approval_notes?: string;
             second_approval_notes?: string;
             rejection_reason?: string;
@@ -7940,7 +8057,7 @@ export interface components {
             description?: string;
             applicability_status?: components["schemas"]["ApplicabilityStatusEnum"];
             compliance_status?: components["schemas"]["ComplianceStatusEnum"];
-            priority?: components["schemas"]["DefaultPriorityEnum"];
+            priority?: components["schemas"]["LowMediumHighCriticalEnum"];
             owner?: number | null;
             /** Format: date */
             next_review_date?: string | null;
@@ -7956,10 +8073,10 @@ export interface components {
             risk?: number;
             title?: string;
             description?: string;
-            action_type?: components["schemas"]["ActionTypeEnum"];
+            action_type?: components["schemas"]["RiskActionTypeEnum"];
             /** @description Person responsible for completing this action */
             assigned_to?: number | null;
-            priority?: components["schemas"]["DefaultPriorityEnum"];
+            priority?: components["schemas"]["LowMediumHighCriticalEnum"];
             /** Format: date */
             start_date?: string | null;
             /**
@@ -8031,7 +8148,7 @@ export interface components {
             impact?: number;
             /** @description Likelihood level (1=Very Low, 5=Very High) */
             likelihood?: number;
-            status?: components["schemas"]["StatusDb9Enum"];
+            status?: components["schemas"]["RiskStatusEnum"];
             treatment_strategy?: components["schemas"]["TreatmentStrategyEnum"] | components["schemas"]["BlankEnum"];
             /** @description Description of the treatment approach */
             treatment_description?: string;
@@ -8122,6 +8239,12 @@ export interface components {
             difficulty_level?: components["schemas"]["DifficultyLevelEnum"];
             is_published?: boolean;
         };
+        PatchedUserProfileRequest: {
+            /** Email address */
+            email?: string;
+            first_name?: string;
+            last_name?: string;
+        };
         /** @description Serializer for vendor categories. */
         PatchedVendorCategoryRequest: {
             name?: string;
@@ -8177,9 +8300,9 @@ export interface components {
             state_province?: string;
             postal_code?: string;
             country?: string;
-            status?: components["schemas"]["StatusAb0Enum"];
+            status?: components["schemas"]["VendorStatusEnum"];
             vendor_type?: components["schemas"]["VendorTypeEnum"];
-            risk_level?: components["schemas"]["DefaultPriorityEnum"];
+            risk_level?: components["schemas"]["LowMediumHighCriticalEnum"];
             /**
              * Format: decimal
              * @description Calculated risk score (0-100)
@@ -8307,8 +8430,8 @@ export interface components {
              * @description Optional start date for the task
              */
             start_date?: string | null;
-            priority?: components["schemas"]["Priority0aeEnum"];
-            status?: components["schemas"]["Status8b3Enum"];
+            priority?: components["schemas"]["VendorTaskPriorityEnum"];
+            status?: components["schemas"]["VendorTaskStatusEnum"];
             /** @description User responsible for completing this task */
             assigned_to?: number | null;
             /** @description Days before due date to send reminders (e.g., [30, 14, 7, 1]) */
@@ -8350,14 +8473,14 @@ export interface components {
             has_advanced_reporting?: boolean;
             has_priority_support?: boolean;
             included_modules?: unknown;
-            readonly module_catalog: string;
+            readonly module_catalog: components["schemas"]["ModuleCatalogItem"][];
         };
         /** @description Serializer for policy acknowledgments. */
         PolicyAcknowledgment: {
             /** Format: uuid */
             readonly id: string;
             user: number;
-            readonly user_details: components["schemas"]["UserBasic"];
+            readonly user_details: components["schemas"]["PolicyUserBasic"];
             /** Format: uuid */
             policy_version: string;
             readonly policy_version_details: components["schemas"]["PolicyVersionList"];
@@ -8377,6 +8500,14 @@ export interface components {
             readonly is_expired: boolean;
             readonly is_valid: boolean;
         };
+        /**
+         * @description * `draft` - Draft
+         *     * `under_review` - Under Review
+         *     * `approved` - Approved
+         *     * `archived` - Archived
+         * @enum {string}
+         */
+        PolicyApprovalStatusEnum: "draft" | "under_review" | "approved" | "archived";
         /** @description Serializer for policy categories. */
         PolicyCategory: {
             /** Format: uuid */
@@ -8387,7 +8518,8 @@ export interface components {
             description?: string;
             /** @description Hex color code for visual identification */
             color?: string;
-            readonly policies_count: string;
+            /** @description Get count of policies in this category. */
+            readonly policies_count: number;
             /** Format: date-time */
             readonly created_at: string;
             /** Format: date-time */
@@ -8460,13 +8592,13 @@ export interface components {
             category: string;
             readonly category_details: components["schemas"]["PolicyCategory"];
             policy_type?: components["schemas"]["PolicyTypeEnum"];
-            status?: components["schemas"]["StatusD38Enum"];
+            status?: components["schemas"]["PolicyApprovalStatusEnum"];
             /** @description Policy owner/manager responsible for this policy */
             owner: number;
-            readonly owner_details: components["schemas"]["UserBasic"];
+            readonly owner_details: components["schemas"]["PolicyUserBasic"];
             /** @description User who approved this policy */
             approver?: number | null;
-            readonly approver_details: components["schemas"]["UserBasic"];
+            readonly approver_details: components["schemas"]["PolicyUserBasic"];
             /** @description How often this policy should be reviewed (in months) */
             review_frequency_months?: number;
             /**
@@ -8482,12 +8614,18 @@ export interface components {
             readonly current_version: components["schemas"]["PolicyVersionList"];
             readonly latest_version: components["schemas"]["PolicyVersionList"];
             readonly is_due_for_review: boolean;
-            readonly acknowledgment_stats: string;
+            readonly acknowledgment_stats: {
+                total_acknowledgments: number;
+                total_distributions?: number;
+                pending_acknowledgments: number;
+                /** Format: float */
+                acknowledgment_rate: number;
+            };
             /** Format: date-time */
             readonly created_at: string;
             /** Format: date-time */
             readonly updated_at: string;
-            readonly created_by_details: components["schemas"]["UserBasic"];
+            readonly created_by_details: components["schemas"]["PolicyUserBasic"];
         };
         /** @description Detailed serializer for policies. */
         PolicyDetailRequest: {
@@ -8496,7 +8634,7 @@ export interface components {
             /** Format: uuid */
             category: string;
             policy_type?: components["schemas"]["PolicyTypeEnum"];
-            status?: components["schemas"]["StatusD38Enum"];
+            status?: components["schemas"]["PolicyApprovalStatusEnum"];
             /** @description Policy owner/manager responsible for this policy */
             owner: number;
             /** @description User who approved this policy */
@@ -8523,9 +8661,9 @@ export interface components {
             readonly policy_title: string;
             readonly policy_code: string;
             distributed_to: number;
-            readonly distributed_to_details: components["schemas"]["UserBasic"];
+            readonly distributed_to_details: components["schemas"]["PolicyUserBasic"];
             distributed_by?: number | null;
-            readonly distributed_by_details: components["schemas"]["UserBasic"];
+            readonly distributed_by_details: components["schemas"]["PolicyUserBasic"];
             /** Format: date-time */
             readonly distributed_at: string;
             notification_sent?: boolean;
@@ -8548,10 +8686,10 @@ export interface components {
             /** @description Policy title */
             title: string;
             policy_type?: components["schemas"]["PolicyTypeEnum"];
-            status?: components["schemas"]["StatusD38Enum"];
+            status?: components["schemas"]["PolicyApprovalStatusEnum"];
             readonly category_name: string;
             readonly category_color: string;
-            readonly owner_details: components["schemas"]["UserBasic"];
+            readonly owner_details: components["schemas"]["PolicyUserBasic"];
             readonly current_version: components["schemas"]["PolicyVersionList"];
             /** @description How often this policy should be reviewed (in months) */
             review_frequency_months?: number;
@@ -8564,8 +8702,10 @@ export interface components {
             requires_acknowledgment?: boolean;
             /** @description How long acknowledgments remain valid (days) */
             acknowledgment_validity_days?: number;
-            readonly versions_count: string;
-            readonly acknowledgment_count: string;
+            /** @description Get count of versions for this policy. */
+            readonly versions_count: number;
+            /** @description Get count of acknowledgments for current version. */
+            readonly acknowledgment_count: number;
             readonly is_due_for_review: boolean;
             /** Format: date-time */
             readonly created_at: string;
@@ -8577,7 +8717,7 @@ export interface components {
             /** @description Policy title */
             title: string;
             policy_type?: components["schemas"]["PolicyTypeEnum"];
-            status?: components["schemas"]["StatusD38Enum"];
+            status?: components["schemas"]["PolicyApprovalStatusEnum"];
             /** @description How often this policy should be reviewed (in months) */
             review_frequency_months?: number;
             /**
@@ -8599,6 +8739,18 @@ export interface components {
          * @enum {string}
          */
         PolicyTypeEnum: "procedure" | "policy" | "standard" | "guideline" | "framework";
+        /** @description Basic user information for policy context. */
+        PolicyUserBasic: {
+            readonly id: number;
+            /**
+             * Email address
+             * Format: email
+             */
+            readonly email: string;
+            readonly first_name: string;
+            readonly last_name: string;
+            readonly full_name: string;
+        };
         /** @description Detailed serializer for policy versions. */
         PolicyVersionDetail: {
             /** Format: uuid */
@@ -8655,12 +8807,13 @@ export interface components {
             expiry_date?: string | null;
             /** Format: date-time */
             readonly finalized_at: string | null;
-            readonly acknowledgments_count: string;
+            /** @description Get count of acknowledgments for this version. */
+            readonly acknowledgments_count: number;
             /** Format: date-time */
             readonly created_at: string;
-            readonly created_by_details: components["schemas"]["UserBasic"];
-            readonly approved_by_details: components["schemas"]["UserBasic"];
-            readonly finalized_by_details: components["schemas"]["UserBasic"];
+            readonly created_by_details: components["schemas"]["PolicyUserBasic"];
+            readonly approved_by_details: components["schemas"]["PolicyUserBasic"];
+            readonly finalized_by_details: components["schemas"]["PolicyUserBasic"];
         };
         /** @description Detailed serializer for policy versions. */
         PolicyVersionDetailRequest: {
@@ -8747,8 +8900,8 @@ export interface components {
             readonly created_at: string;
             /** Format: date-time */
             finalized_at?: string | null;
-            readonly created_by_details: components["schemas"]["UserBasic"];
-            readonly approved_by_details: components["schemas"]["UserBasic"];
+            readonly created_by_details: components["schemas"]["PolicyUserBasic"];
+            readonly approved_by_details: components["schemas"]["PolicyUserBasic"];
         };
         /** @description List serializer for policy versions. */
         PolicyVersionListRequest: {
@@ -8794,14 +8947,25 @@ export interface components {
          */
         PreferredCommunicationEnum: "email" | "phone" | "mobile";
         /**
-         * @description * `low` - Low Priority
-         *     * `medium` - Medium Priority
-         *     * `high` - High Priority
-         *     * `urgent` - Urgent
-         *     * `critical` - Critical
+         * @description * `email` - Email OTP
+         *     * `totp` - Authenticator App
+         *     * `push` - Push Notification
          * @enum {string}
          */
-        Priority0aeEnum: "low" | "medium" | "high" | "urgent" | "critical";
+        PrimaryMethodEnum: "email" | "totp" | "push";
+        /**
+         * @description * `fcm` - fcm
+         *     * `apns` - apns
+         *     * `web_push` - web_push
+         * @enum {string}
+         */
+        PushServiceEnum: "fcm" | "apns" | "web_push";
+        RegisterPushDeviceRequest: {
+            device_token: string;
+            device_name: string;
+            device_type: components["schemas"]["DeviceTypeEnum"];
+            push_service: components["schemas"]["PushServiceEnum"];
+        };
         RegisterRequest: {
             /** @description Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only. */
             username: string;
@@ -8823,7 +8987,7 @@ export interface components {
             description?: string;
             applicability_status?: components["schemas"]["ApplicabilityStatusEnum"];
             compliance_status?: components["schemas"]["ComplianceStatusEnum"];
-            priority?: components["schemas"]["DefaultPriorityEnum"];
+            priority?: components["schemas"]["LowMediumHighCriticalEnum"];
             owner?: number | null;
             readonly owner_username: string;
             /** Format: date */
@@ -8849,7 +9013,7 @@ export interface components {
             description?: string;
             applicability_status?: components["schemas"]["ApplicabilityStatusEnum"];
             compliance_status?: components["schemas"]["ComplianceStatusEnum"];
-            priority?: components["schemas"]["DefaultPriorityEnum"];
+            priority?: components["schemas"]["LowMediumHighCriticalEnum"];
             owner?: number | null;
             /** Format: date */
             next_review_date?: string | null;
@@ -8885,14 +9049,21 @@ export interface components {
          * @enum {string}
          */
         ReportTypeEnum: "assessment_summary" | "detailed_assessment" | "evidence_portfolio" | "compliance_gap" | "risk_analytics";
+        /**
+         * @description * `applicable` - Applicable
+         *     * `not_applicable` - Not Applicable
+         *     * `to_be_determined` - To Be Determined
+         * @enum {string}
+         */
+        RequirementApplicabilityEnum: "applicable" | "not_applicable" | "to_be_determined";
         /** @description Serializer for bulk creating risk actions. */
         RiskActionBulkCreateRequest: {
             risk: number;
             assigned_to?: number | null;
             /** @default medium */
-            default_priority: components["schemas"]["DefaultPriorityEnum"];
+            default_priority: components["schemas"]["LowMediumHighCriticalEnum"];
             /** @default other */
-            default_action_type: components["schemas"]["DefaultActionTypeEnum"];
+            default_action_type: components["schemas"]["RiskActionTypeEnum"];
             /** @description List of action dictionaries with title, description, and optional overrides */
             actions: {
                 [key: string]: unknown;
@@ -8903,10 +9074,10 @@ export interface components {
             risk: number;
             title: string;
             description: string;
-            action_type?: components["schemas"]["ActionTypeEnum"];
+            action_type?: components["schemas"]["RiskActionTypeEnum"];
             /** @description Person responsible for completing this action */
             assigned_to?: number | null;
-            priority?: components["schemas"]["DefaultPriorityEnum"];
+            priority?: components["schemas"]["LowMediumHighCriticalEnum"];
             /** Format: date */
             start_date?: string | null;
             /**
@@ -8938,10 +9109,10 @@ export interface components {
             risk: number;
             title: string;
             description: string;
-            action_type?: components["schemas"]["ActionTypeEnum"];
+            action_type?: components["schemas"]["RiskActionTypeEnum"];
             /** @description Person responsible for completing this action */
             assigned_to?: number | null;
-            priority?: components["schemas"]["DefaultPriorityEnum"];
+            priority?: components["schemas"]["LowMediumHighCriticalEnum"];
             /** Format: date */
             start_date?: string | null;
             /**
@@ -8975,17 +9146,17 @@ export interface components {
             readonly action_id: string;
             title: string;
             description: string;
-            action_type?: components["schemas"]["ActionTypeEnum"];
+            action_type?: components["schemas"]["RiskActionTypeEnum"];
             risk: number;
             readonly risk_id: string;
             readonly risk_title: string;
             readonly risk_level: string;
             readonly risk_level_display: string;
-            readonly risk_summary: string;
+            readonly risk_summary: components["schemas"]["RiskActionRiskSummary"];
             readonly assigned_to: components["schemas"]["UserBasic"];
             readonly assigned_to_name: string;
-            status?: components["schemas"]["StatusF58Enum"];
-            priority?: components["schemas"]["DefaultPriorityEnum"];
+            status?: components["schemas"]["RiskActionStatusEnum"];
+            priority?: components["schemas"]["LowMediumHighCriticalEnum"];
             readonly priority_color: string;
             readonly status_color: string;
             /** Format: date */
@@ -9032,10 +9203,11 @@ export interface components {
             readonly id: number;
             title: string;
             description?: string;
-            evidence_type?: components["schemas"]["EvidenceTypeA14Enum"];
+            evidence_type?: components["schemas"]["RiskActionEvidenceTypeEnum"];
             /** Format: uri */
             file?: string | null;
-            readonly file_url: string;
+            /** Format: uri */
+            readonly file_url: string | null;
             /** @description Link to external evidence or system */
             external_link?: string;
             readonly is_validated: boolean;
@@ -9055,7 +9227,7 @@ export interface components {
         RiskActionEvidenceCreateUpdateRequest: {
             title: string;
             description?: string;
-            evidence_type?: components["schemas"]["EvidenceTypeA14Enum"];
+            evidence_type?: components["schemas"]["RiskActionEvidenceTypeEnum"];
             /** Format: binary */
             file?: string | null;
             /** @description Link to external evidence or system */
@@ -9063,6 +9235,18 @@ export interface components {
             /** Format: date */
             evidence_date?: string;
         };
+        /**
+         * @description * `document` - Document/Policy
+         *     * `screenshot` - Screenshot
+         *     * `report` - Report/Analysis
+         *     * `certificate` - Certificate
+         *     * `configuration` - Configuration File
+         *     * `training_record` - Training Record
+         *     * `audit_log` - Audit Log
+         *     * `other` - Other
+         * @enum {string}
+         */
+        RiskActionEvidenceTypeEnum: "document" | "screenshot" | "report" | "certificate" | "configuration" | "training_record" | "audit_log" | "other";
         /** @description Serializer for Risk Action list view with essential fields. */
         RiskActionList: {
             readonly id: number;
@@ -9070,7 +9254,7 @@ export interface components {
             readonly action_id: string;
             title: string;
             description: string;
-            action_type?: components["schemas"]["ActionTypeEnum"];
+            action_type?: components["schemas"]["RiskActionTypeEnum"];
             risk: number;
             readonly risk_id: string;
             readonly risk_title: string;
@@ -9079,8 +9263,8 @@ export interface components {
             /** @description Person responsible for completing this action */
             assigned_to?: number | null;
             readonly assigned_to_name: string;
-            status?: components["schemas"]["StatusF58Enum"];
-            priority?: components["schemas"]["DefaultPriorityEnum"];
+            status?: components["schemas"]["RiskActionStatusEnum"];
+            priority?: components["schemas"]["LowMediumHighCriticalEnum"];
             readonly priority_color: string;
             readonly status_color: string;
             /** Format: date */
@@ -9106,7 +9290,7 @@ export interface components {
         RiskActionNote: {
             readonly id: number;
             note: string;
-            note_type?: components["schemas"]["NoteType679Enum"];
+            note_type?: components["schemas"]["RiskActionNoteTypeEnum"];
             /** @description Progress percentage at time of note */
             progress_percentage?: number | null;
             /** Format: date-time */
@@ -9117,10 +9301,19 @@ export interface components {
         /** @description Serializer for creating risk action notes. */
         RiskActionNoteCreateRequest: {
             note: string;
-            note_type?: components["schemas"]["NoteType679Enum"];
+            note_type?: components["schemas"]["RiskActionNoteTypeEnum"];
             /** @description Progress percentage at time of note */
             progress_percentage?: number | null;
         };
+        /**
+         * @description * `progress` - Progress Update
+         *     * `issue` - Issue/Blocker
+         *     * `completion` - Completion
+         *     * `status_change` - Status Change
+         *     * `general` - General
+         * @enum {string}
+         */
+        RiskActionNoteTypeEnum: "progress" | "issue" | "completion" | "status_change" | "general";
         /** @description Serializer for risk action reminder configuration. */
         RiskActionReminderConfiguration: {
             readonly id: number;
@@ -9187,9 +9380,28 @@ export interface components {
             /** @description Stop sending reminders for cancelled actions */
             silence_cancelled?: boolean;
         };
+        RiskActionRiskSummary: {
+            id: number;
+            risk_id: string;
+            title: string;
+            risk_level: string;
+            risk_level_display: string;
+            status: string;
+            status_display: string;
+            risk_owner: string | null;
+        };
+        /**
+         * @description * `pending` - Pending
+         *     * `in_progress` - In Progress
+         *     * `completed` - Completed
+         *     * `cancelled` - Cancelled
+         *     * `deferred` - Deferred
+         * @enum {string}
+         */
+        RiskActionStatusEnum: "pending" | "in_progress" | "completed" | "cancelled" | "deferred";
         /** @description Serializer for updating risk action status with optional note. */
         RiskActionStatusUpdateRequest: {
-            status: components["schemas"]["StatusF58Enum"];
+            status: components["schemas"]["RiskActionStatusEnum"];
             progress_percentage?: number;
             note?: string;
         };
@@ -9211,6 +9423,18 @@ export interface components {
             readonly due_soon_actions: components["schemas"]["RiskActionList"][];
             readonly high_priority_actions: components["schemas"]["RiskActionList"][];
         };
+        /**
+         * @description * `preventive` - Preventive Control
+         *     * `detective` - Detective Control
+         *     * `corrective` - Corrective Action
+         *     * `policy` - Policy/Procedure
+         *     * `training` - Training/Awareness
+         *     * `technical` - Technical Implementation
+         *     * `assessment` - Assessment/Review
+         *     * `other` - Other
+         * @enum {string}
+         */
+        RiskActionTypeEnum: "preventive" | "detective" | "corrective" | "policy" | "training" | "technical" | "assessment" | "other";
         /** @description Serializer for Risk Categories. */
         RiskCategory: {
             readonly id: number;
@@ -9218,7 +9442,8 @@ export interface components {
             description?: string;
             /** @description Hex color code for UI display */
             color?: string;
-            readonly risk_count: string;
+            /** @description Get count of risks in this category. */
+            readonly risk_count: number;
             /** Format: date-time */
             readonly created_at: string;
             /** Format: date-time */
@@ -9240,7 +9465,7 @@ export interface components {
             impact: number;
             /** @description Likelihood level (1=Very Low, 5=Very High) */
             likelihood: number;
-            status?: components["schemas"]["StatusDb9Enum"];
+            status?: components["schemas"]["RiskStatusEnum"];
             treatment_strategy?: components["schemas"]["TreatmentStrategyEnum"] | components["schemas"]["BlankEnum"];
             /** @description Description of the treatment approach */
             treatment_description?: string;
@@ -9265,7 +9490,7 @@ export interface components {
             impact: number;
             /** @description Likelihood level (1=Very Low, 5=Very High) */
             likelihood: number;
-            status?: components["schemas"]["StatusDb9Enum"];
+            status?: components["schemas"]["RiskStatusEnum"];
             treatment_strategy?: components["schemas"]["TreatmentStrategyEnum"] | components["schemas"]["BlankEnum"];
             /** @description Description of the treatment approach */
             treatment_description?: string;
@@ -9300,10 +9525,10 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            readonly risk_level: components["schemas"]["DefaultPriorityEnum"];
+            readonly risk_level: components["schemas"]["LowMediumHighCriticalEnum"];
             readonly risk_level_display: string;
             readonly risk_level_color: string;
-            status?: components["schemas"]["StatusDb9Enum"];
+            status?: components["schemas"]["RiskStatusEnum"];
             readonly status_display: string;
             readonly status_display_color: string;
             treatment_strategy?: components["schemas"]["TreatmentStrategyEnum"] | components["schemas"]["BlankEnum"];
@@ -9359,10 +9584,10 @@ export interface components {
              *     * `high` - High
              *     * `critical` - Critical
              */
-            readonly risk_level: components["schemas"]["DefaultPriorityEnum"];
+            readonly risk_level: components["schemas"]["LowMediumHighCriticalEnum"];
             readonly risk_level_display: string;
             readonly risk_level_color: string;
-            status?: components["schemas"]["StatusDb9Enum"];
+            status?: components["schemas"]["RiskStatusEnum"];
             readonly status_display: string;
             readonly status_display_color: string;
             category?: number | null;
@@ -9431,9 +9656,21 @@ export interface components {
          * @enum {string}
          */
         RiskNoteNoteTypeEnum: "general" | "assessment" | "treatment" | "review" | "status_change";
+        /**
+         * @description * `identified` - Identified
+         *     * `assessed` - Assessed
+         *     * `treatment_planned` - Treatment Planned
+         *     * `treatment_in_progress` - Treatment in Progress
+         *     * `mitigated` - Mitigated
+         *     * `accepted` - Accepted
+         *     * `transferred` - Transferred
+         *     * `closed` - Closed
+         * @enum {string}
+         */
+        RiskStatusEnum: "identified" | "assessed" | "treatment_planned" | "treatment_in_progress" | "mitigated" | "accepted" | "transferred" | "closed";
         /** @description Serializer for updating risk status with optional notes. */
         RiskStatusUpdateRequest: {
-            status: components["schemas"]["StatusDb9Enum"];
+            status: components["schemas"]["RiskStatusEnum"];
             treatment_strategy?: components["schemas"]["TreatmentStrategyEnum"];
             treatment_description?: string;
             note?: string;
@@ -9601,15 +9838,39 @@ export interface components {
             /** @description Specific users to receive this campaign (if not sending to all) */
             target_users?: number[];
             readonly created_by: number;
-            readonly created_by_details: string;
-            readonly target_users_details: string;
+            readonly created_by_details: {
+                id?: string;
+                name?: string;
+                /** Format: email */
+                email?: string;
+            } | null;
+            readonly target_users_details: {
+                type: string;
+                count: number;
+                users?: {
+                    id?: string;
+                    name?: string;
+                    /** Format: email */
+                    email?: string;
+                }[];
+            };
             readonly total_sent: number;
             readonly total_opened: number;
             readonly total_clicked: number;
-            readonly open_rate: string;
-            readonly click_rate: string;
-            readonly recent_deliveries: string;
-            readonly analytics: string;
+            /** Format: double */
+            readonly open_rate: number;
+            /** Format: double */
+            readonly click_rate: number;
+            readonly recent_deliveries: {
+                [key: string]: unknown;
+            }[];
+            readonly analytics: {
+                recent_sent: number;
+                recent_opened: number;
+                recent_clicked: number;
+                recent_bounced: number;
+                recent_failed: number;
+            };
             /** Format: date-time */
             readonly created_at: string;
             /** Format: date-time */
@@ -9652,13 +9913,15 @@ export interface components {
             next_send_date: string;
             /** @description If False, only send to specific users or groups */
             send_to_all_users?: boolean;
-            readonly target_users_count: string;
-            readonly created_by_name: string;
+            readonly target_users_count: number;
+            readonly created_by_name: string | null;
             total_sent?: number;
             total_opened?: number;
             total_clicked?: number;
-            readonly open_rate: string;
-            readonly click_rate: string;
+            /** Format: double */
+            readonly open_rate: number;
+            /** Format: double */
+            readonly click_rate: number;
             readonly status: string;
             /** Format: date-time */
             readonly created_at: string;
@@ -9673,110 +9936,9 @@ export interface components {
          * @enum {string}
          */
         SendFrequencyEnum: "weekly" | "biweekly" | "monthly" | "quarterly";
-        /**
-         * @description * `pending` - Pending Generation
-         *     * `processing` - Processing
-         *     * `completed` - Completed
-         *     * `failed` - Failed
-         * @enum {string}
-         */
-        Status62aEnum: "pending" | "processing" | "completed" | "failed";
-        /**
-         * @description * `pending` - Pending
-         *     * `in_progress` - In Progress
-         *     * `completed` - Completed
-         *     * `overdue` - Overdue
-         *     * `cancelled` - Cancelled
-         *     * `on_hold` - On Hold
-         * @enum {string}
-         */
-        Status8b3Enum: "pending" | "in_progress" | "completed" | "overdue" | "cancelled" | "on_hold";
-        /**
-         * @description * `pending` - Pending Review
-         *     * `approved` - Approved
-         *     * `rejected` - Rejected
-         *     * `applied` - Applied
-         *     * `expired` - Expired
-         * @enum {string}
-         */
-        Status8f5Enum: "pending" | "approved" | "rejected" | "applied" | "expired";
-        /**
-         * @description * `planned` - Planned
-         *     * `in_progress` - In Progress
-         *     * `implemented` - Implemented
-         *     * `testing` - Under Testing
-         *     * `active` - Active
-         *     * `remediation` - Needs Remediation
-         *     * `disabled` - Disabled
-         *     * `retired` - Retired
-         * @enum {string}
-         */
-        Status949Enum: "planned" | "in_progress" | "implemented" | "testing" | "active" | "remediation" | "disabled" | "retired";
-        /**
-         * @description * `active` - Active
-         *     * `inactive` - Inactive
-         *     * `under_review` - Under Review
-         *     * `approved` - Approved
-         *     * `suspended` - Suspended
-         *     * `terminated` - Terminated
-         * @enum {string}
-         */
-        StatusAb0Enum: "active" | "inactive" | "under_review" | "approved" | "suspended" | "terminated";
-        /**
-         * @description * `draft` - Draft
-         *     * `under_review` - Under Review
-         *     * `approved` - Approved
-         *     * `archived` - Archived
-         * @enum {string}
-         */
-        StatusD38Enum: "draft" | "under_review" | "approved" | "archived";
-        /**
-         * @description * `draft` - Draft
-         *     * `published` - Published
-         *     * `archived` - Archived
-         * @enum {string}
-         */
-        StatusDaeEnum: "draft" | "published" | "archived";
-        /**
-         * @description * `identified` - Identified
-         *     * `assessed` - Assessed
-         *     * `treatment_planned` - Treatment Planned
-         *     * `treatment_in_progress` - Treatment in Progress
-         *     * `mitigated` - Mitigated
-         *     * `accepted` - Accepted
-         *     * `transferred` - Transferred
-         *     * `closed` - Closed
-         * @enum {string}
-         */
-        StatusDb9Enum: "identified" | "assessed" | "treatment_planned" | "treatment_in_progress" | "mitigated" | "accepted" | "transferred" | "closed";
-        /**
-         * @description * `not_started` - Not Started
-         *     * `pending` - Pending
-         *     * `in_progress` - In Progress
-         *     * `under_review` - Under Review
-         *     * `complete` - Complete
-         *     * `not_applicable` - Not Applicable
-         *     * `deferred` - Deferred
-         * @enum {string}
-         */
-        StatusEnum: "not_started" | "pending" | "in_progress" | "under_review" | "complete" | "not_applicable" | "deferred";
-        /**
-         * @description * `pending` - Pending
-         *     * `in_progress` - In Progress
-         *     * `completed` - Completed
-         *     * `cancelled` - Cancelled
-         *     * `deferred` - Deferred
-         * @enum {string}
-         */
-        StatusF58Enum: "pending" | "in_progress" | "completed" | "cancelled" | "deferred";
-        /**
-         * @description * `draft` - Draft
-         *     * `active` - Active
-         *     * `deprecated` - Deprecated
-         *     * `archived` - Archived
-         * @enum {string}
-         */
-        StatusFa2Enum: "draft" | "active" | "deprecated" | "archived";
+        SetupTOTPRequest: {
+            password: string;
+        };
         /** @description Serializer for subscriptions. */
         Subscription: {
             readonly id: number;
@@ -9788,10 +9950,10 @@ export interface components {
             readonly is_trial_active: boolean;
             /** @description Explicit module grants for this subscription */
             enabled_modules?: unknown;
-            readonly enabled_module_keys: string;
+            readonly enabled_module_keys: string[];
             /** @description Single module selected for a trial subscription */
             trial_module?: string;
-            readonly module_catalog: string;
+            readonly module_catalog: components["schemas"]["ModuleCatalogItem"][];
             /** Format: date-time */
             current_period_start?: string | null;
             /** Format: date-time */
@@ -9923,11 +10085,12 @@ export interface components {
             readonly requested_by_name: string;
             /** Format: date-time */
             readonly requested_at: string;
-            readonly status: components["schemas"]["Status62aEnum"];
+            readonly status: components["schemas"]["AnalyticsExportStatusEnum"];
             /** @description Generated spreadsheet or CSV archive */
             readonly generated_file: number | null;
             readonly generated_file_details: components["schemas"]["Document"];
-            readonly download_url: string;
+            /** Format: uri */
+            readonly download_url: string | null;
             /** Format: date-time */
             readonly generation_started_at: string | null;
             /** Format: date-time */
@@ -9963,7 +10126,7 @@ export interface components {
             /** @description Hex color code for category display */
             color?: string;
             is_active?: boolean;
-            readonly videos_count: string;
+            readonly videos_count: number;
             /** Format: date-time */
             readonly created_at: string;
             /** Format: date-time */
@@ -9994,6 +10157,7 @@ export interface components {
             video_url: string;
             /** @description Provider-specific video ID */
             video_id?: string;
+            /** Format: uri */
             readonly embed_url: string;
             /** @description Video duration in minutes */
             duration_minutes?: number | null;
@@ -10002,7 +10166,12 @@ export interface components {
             /** Format: date-time */
             readonly published_at: string | null;
             readonly created_by: number;
-            readonly created_by_details: string;
+            readonly created_by_details: {
+                id?: string;
+                name?: string;
+                /** Format: email */
+                email?: string;
+            } | null;
             readonly view_count: number;
             /** Format: date-time */
             readonly created_at: string;
@@ -10043,7 +10212,7 @@ export interface components {
             is_published?: boolean;
             /** Format: date-time */
             published_at?: string | null;
-            readonly created_by_name: string;
+            readonly created_by_name: string | null;
             view_count?: number;
             /** Format: date-time */
             readonly created_at: string;
@@ -10058,6 +10227,15 @@ export interface components {
          * @enum {string}
          */
         TreatmentStrategyEnum: "mitigate" | "accept" | "transfer" | "avoid";
+        TwoFactorStatus: {
+            readonly email_enabled: boolean;
+            readonly totp_enabled: boolean;
+            readonly push_enabled: boolean;
+            /** Format: email */
+            readonly email: string;
+            readonly push_devices: unknown[];
+            readonly primary_method: string;
+        };
         /**
          * @description * `low` - Low - Standard Review
          *     * `medium` - Medium - 24 Hour Review
@@ -10079,6 +10257,20 @@ export interface components {
             readonly first_name: string;
             readonly last_name: string;
             readonly full_name: string;
+        };
+        UserPreferences: {
+            primary_method?: components["schemas"]["PrimaryMethodEnum"];
+            /** @description Ordered list of fallback methods */
+            fallback_methods?: unknown;
+            require_2fa_for_sensitive_actions?: boolean;
+            remember_device_days?: number;
+        };
+        UserPreferencesRequest: {
+            primary_method?: components["schemas"]["PrimaryMethodEnum"];
+            /** @description Ordered list of fallback methods */
+            fallback_methods?: unknown;
+            require_2fa_for_sensitive_actions?: boolean;
+            remember_device_days?: number;
         };
         UserProfile: {
             readonly id: number;
@@ -10195,9 +10387,9 @@ export interface components {
             state_province?: string;
             postal_code?: string;
             country?: string;
-            status?: components["schemas"]["StatusAb0Enum"];
+            status?: components["schemas"]["VendorStatusEnum"];
             vendor_type?: components["schemas"]["VendorTypeEnum"];
-            risk_level?: components["schemas"]["DefaultPriorityEnum"];
+            risk_level?: components["schemas"]["LowMediumHighCriticalEnum"];
             /**
              * Format: decimal
              * @description Calculated risk score (0-100)
@@ -10269,9 +10461,9 @@ export interface components {
             state_province?: string;
             postal_code?: string;
             country?: string;
-            status?: components["schemas"]["StatusAb0Enum"];
+            status?: components["schemas"]["VendorStatusEnum"];
             vendor_type?: components["schemas"]["VendorTypeEnum"];
-            risk_level?: components["schemas"]["DefaultPriorityEnum"];
+            risk_level?: components["schemas"]["LowMediumHighCriticalEnum"];
             /**
              * Format: decimal
              * @description Calculated risk score (0-100)
@@ -10348,11 +10540,11 @@ export interface components {
             postal_code?: string;
             country?: string;
             readonly full_address: string;
-            status?: components["schemas"]["StatusAb0Enum"];
+            status?: components["schemas"]["VendorStatusEnum"];
             readonly status_display: string;
             vendor_type?: components["schemas"]["VendorTypeEnum"];
             readonly vendor_type_display: string;
-            risk_level?: components["schemas"]["DefaultPriorityEnum"];
+            risk_level?: components["schemas"]["LowMediumHighCriticalEnum"];
             readonly risk_level_display: string;
             /**
              * Format: decimal
@@ -10435,11 +10627,11 @@ export interface components {
             /** @description Primary vendor category for classification */
             category?: number | null;
             readonly category_name: string;
-            status?: components["schemas"]["StatusAb0Enum"];
+            status?: components["schemas"]["VendorStatusEnum"];
             readonly status_display: string;
             vendor_type?: components["schemas"]["VendorTypeEnum"];
             readonly vendor_type_display: string;
-            risk_level?: components["schemas"]["DefaultPriorityEnum"];
+            risk_level?: components["schemas"]["LowMediumHighCriticalEnum"];
             readonly risk_level_display: string;
             /**
              * Format: decimal
@@ -10478,9 +10670,9 @@ export interface components {
             name: string;
             /** @description Primary vendor category for classification */
             category?: number | null;
-            status?: components["schemas"]["StatusAb0Enum"];
+            status?: components["schemas"]["VendorStatusEnum"];
             vendor_type?: components["schemas"]["VendorTypeEnum"];
-            risk_level?: components["schemas"]["DefaultPriorityEnum"];
+            risk_level?: components["schemas"]["LowMediumHighCriticalEnum"];
             /**
              * Format: decimal
              * @description Calculated risk score (0-100)
@@ -10604,6 +10796,16 @@ export interface components {
             /** Format: date */
             end_date?: string | null;
         };
+        /**
+         * @description * `active` - Active
+         *     * `inactive` - Inactive
+         *     * `under_review` - Under Review
+         *     * `approved` - Approved
+         *     * `suspended` - Suspended
+         *     * `terminated` - Terminated
+         * @enum {string}
+         */
+        VendorStatusEnum: "active" | "inactive" | "under_review" | "approved" | "suspended" | "terminated";
         /** @description Serializer for vendor summary statistics. */
         VendorSummary: {
             total_vendors: number;
@@ -10641,9 +10843,9 @@ export interface components {
         VendorTaskBulkActionRequest: {
             task_ids: number[];
             action: components["schemas"]["VendorTaskBulkActionActionEnum"];
-            status?: components["schemas"]["Status8b3Enum"];
+            status?: components["schemas"]["VendorTaskStatusEnum"];
             assigned_to?: number;
-            priority?: components["schemas"]["Priority0aeEnum"];
+            priority?: components["schemas"]["VendorTaskPriorityEnum"];
             notes?: string;
         };
         /** @description Serializer for creating and updating vendor tasks. */
@@ -10684,8 +10886,8 @@ export interface components {
              * @description Optional start date for the task
              */
             start_date?: string | null;
-            priority?: components["schemas"]["Priority0aeEnum"];
-            status?: components["schemas"]["Status8b3Enum"];
+            priority?: components["schemas"]["VendorTaskPriorityEnum"];
+            status?: components["schemas"]["VendorTaskStatusEnum"];
             /** @description User responsible for completing this task */
             assigned_to?: number | null;
             /** @description Days before due date to send reminders (e.g., [30, 14, 7, 1]) */
@@ -10743,8 +10945,8 @@ export interface components {
              * @description Optional start date for the task
              */
             start_date?: string | null;
-            priority?: components["schemas"]["Priority0aeEnum"];
-            status?: components["schemas"]["Status8b3Enum"];
+            priority?: components["schemas"]["VendorTaskPriorityEnum"];
+            status?: components["schemas"]["VendorTaskStatusEnum"];
             /** @description User responsible for completing this task */
             assigned_to?: number | null;
             /** @description Days before due date to send reminders (e.g., [30, 14, 7, 1]) */
@@ -10812,9 +11014,9 @@ export interface components {
              * @description Actual completion timestamp
              */
             completed_date?: string | null;
-            priority?: components["schemas"]["Priority0aeEnum"];
+            priority?: components["schemas"]["VendorTaskPriorityEnum"];
             readonly priority_display: string;
-            status?: components["schemas"]["Status8b3Enum"];
+            status?: components["schemas"]["VendorTaskStatusEnum"];
             readonly status_display: string;
             /** @description User responsible for completing this task */
             assigned_to?: number | null;
@@ -10912,8 +11114,8 @@ export interface components {
              * @description Actual completion timestamp
              */
             completed_date?: string | null;
-            priority?: components["schemas"]["Priority0aeEnum"];
-            status?: components["schemas"]["Status8b3Enum"];
+            priority?: components["schemas"]["VendorTaskPriorityEnum"];
+            status?: components["schemas"]["VendorTaskStatusEnum"];
             /** @description User responsible for completing this task */
             assigned_to?: number | null;
             /** @description User who created this task */
@@ -10979,9 +11181,9 @@ export interface components {
              * @description Date when the task is due for completion
              */
             due_date: string;
-            priority?: components["schemas"]["Priority0aeEnum"];
+            priority?: components["schemas"]["VendorTaskPriorityEnum"];
             readonly priority_display: string;
-            status?: components["schemas"]["Status8b3Enum"];
+            status?: components["schemas"]["VendorTaskStatusEnum"];
             readonly status_display: string;
             /** @description User responsible for completing this task */
             assigned_to?: number | null;
@@ -10995,6 +11197,15 @@ export interface components {
             /** Format: date-time */
             readonly updated_at: string;
         };
+        /**
+         * @description * `low` - Low Priority
+         *     * `medium` - Medium Priority
+         *     * `high` - High Priority
+         *     * `urgent` - Urgent
+         *     * `critical` - Critical
+         * @enum {string}
+         */
+        VendorTaskPriorityEnum: "low" | "medium" | "high" | "urgent" | "critical";
         /** @description Serializer for task reminder operations. */
         VendorTaskReminderRequest: {
             /** @description Specific task IDs to send reminders for (optional) */
@@ -11007,9 +11218,19 @@ export interface components {
             /** @description Additional email addresses to include */
             additional_recipients?: string[];
         };
+        /**
+         * @description * `pending` - Pending
+         *     * `in_progress` - In Progress
+         *     * `completed` - Completed
+         *     * `overdue` - Overdue
+         *     * `cancelled` - Cancelled
+         *     * `on_hold` - On Hold
+         * @enum {string}
+         */
+        VendorTaskStatusEnum: "pending" | "in_progress" | "completed" | "overdue" | "cancelled" | "on_hold";
         /** @description Serializer for updating task status. */
         VendorTaskStatusUpdateRequest: {
-            status: components["schemas"]["Status8b3Enum"];
+            status: components["schemas"]["VendorTaskStatusEnum"];
             completion_notes?: string;
         };
         /** @description Serializer for vendor task summary statistics. */
@@ -11220,7 +11441,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
+            /** @description Logout successful */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -11238,12 +11459,13 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["UserProfile"];
+                };
             };
         };
     };
@@ -11254,10 +11476,24 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedUserProfileRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedUserProfileRequest"];
+                "multipart/form-data": components["schemas"]["PatchedUserProfileRequest"];
+            };
+        };
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserProfile"];
+                };
+            };
+            /** @description Validation errors */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11272,10 +11508,23 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChangePasswordRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["ChangePasswordRequest"];
+                "multipart/form-data": components["schemas"]["ChangePasswordRequest"];
+            };
+        };
         responses: {
-            /** @description No response body */
+            /** @description Password changed successfully */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation errors */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11318,12 +11567,13 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["TwoFactorStatus"];
+                };
             };
         };
     };
@@ -11334,10 +11584,23 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnableTwoFactorRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["EnableTwoFactorRequest"];
+                "multipart/form-data": components["schemas"]["EnableTwoFactorRequest"];
+            };
+        };
         responses: {
-            /** @description No response body */
+            /** @description Two-factor authentication method enabled */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation errors */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11352,10 +11615,23 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DisableTwoFactorRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["DisableTwoFactorRequest"];
+                "multipart/form-data": components["schemas"]["DisableTwoFactorRequest"];
+            };
+        };
         responses: {
-            /** @description No response body */
+            /** @description Two-factor authentication method disabled */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation errors */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11401,10 +11677,30 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetupTOTPRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["SetupTOTPRequest"];
+                "multipart/form-data": components["schemas"]["SetupTOTPRequest"];
+            };
+        };
         responses: {
-            /** @description No response body */
+            /** @description TOTP setup data returned */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation errors */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to set up TOTP device */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11419,10 +11715,23 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmTOTPRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["ConfirmTOTPRequest"];
+                "multipart/form-data": components["schemas"]["ConfirmTOTPRequest"];
+            };
+        };
         responses: {
-            /** @description No response body */
+            /** @description TOTP two-factor authentication enabled */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid verification code or validation errors */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11437,10 +11746,23 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterPushDeviceRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["RegisterPushDeviceRequest"];
+                "multipart/form-data": components["schemas"]["RegisterPushDeviceRequest"];
+            };
+        };
         responses: {
-            /** @description No response body */
-            200: {
+            /** @description Push notification device registered */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation errors */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11455,10 +11777,23 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ApprovePushChallengeRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["ApprovePushChallengeRequest"];
+                "multipart/form-data": components["schemas"]["ApprovePushChallengeRequest"];
+            };
+        };
         responses: {
-            /** @description No response body */
+            /** @description Push challenge decision accepted */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation errors */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11475,12 +11810,13 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["UserPreferences"];
+                };
             };
         };
     };
@@ -11491,10 +11827,23 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["UserPreferencesRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["UserPreferencesRequest"];
+                "multipart/form-data": components["schemas"]["UserPreferencesRequest"];
+            };
+        };
         responses: {
-            /** @description No response body */
+            /** @description Preferences updated successfully */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation errors */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -11969,7 +12318,7 @@ export interface operations {
             };
         };
     };
-    calendar_preferences_retrieve: {
+    calendar_preferences_list: {
         parameters: {
             query?: never;
             header?: never;
@@ -11978,12 +12327,13 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["CalendarNotificationPreference"][];
+                };
             };
         };
     };
@@ -11994,14 +12344,21 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["CalendarNotificationPreferenceRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["CalendarNotificationPreferenceRequest"];
+                "multipart/form-data": components["schemas"]["CalendarNotificationPreferenceRequest"];
+            };
+        };
         responses: {
-            /** @description No response body */
             201: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["CalendarNotificationPreference"];
+                };
             };
         };
     };
@@ -14855,7 +15212,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this assessment report. */
+                id: number;
             };
             cookie?: never;
         };
@@ -14876,7 +15234,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this assessment report. */
+                id: number;
             };
             cookie?: never;
         };
@@ -14903,7 +15262,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this assessment report. */
+                id: number;
             };
             cookie?: never;
         };
@@ -14923,7 +15283,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this assessment report. */
+                id: number;
             };
             cookie?: never;
         };
@@ -14950,7 +15311,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this assessment report. */
+                id: number;
             };
             cookie?: never;
         };
@@ -14971,7 +15333,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this assessment report. */
+                id: number;
             };
             cookie?: never;
         };
@@ -15011,7 +15374,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this assessment report. */
+                id: number;
             };
             cookie?: never;
         };
@@ -15029,7 +15393,20 @@ export interface operations {
     };
     exports_tenant_data_exports_list: {
         parameters: {
-            query?: never;
+            query?: {
+                /**
+                 * @description * `xlsx` - Excel workbook
+                 *     * `csv_zip` - CSV archive
+                 */
+                export_format?: "csv_zip" | "xlsx";
+                /**
+                 * @description * `pending` - Pending Generation
+                 *     * `processing` - Processing
+                 *     * `completed` - Completed
+                 *     * `failed` - Failed
+                 */
+                status?: "completed" | "failed" | "pending" | "processing";
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -15095,7 +15472,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this tenant data export. */
+                id: number;
             };
             cookie?: never;
         };
@@ -15116,7 +15494,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this tenant data export. */
+                id: number;
             };
             cookie?: never;
         };
@@ -15136,7 +15515,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this tenant data export. */
+                id: number;
             };
             cookie?: never;
         };
@@ -15157,7 +15537,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this tenant data export. */
+                id: number;
             };
             cookie?: never;
         };
@@ -15190,7 +15571,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: string;
+                /** @description A unique integer value identifying this tenant data export. */
+                id: number;
             };
             cookie?: never;
         };
@@ -16394,8 +16776,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate action overview */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -16412,8 +16804,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate progress analysis */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -16423,15 +16825,34 @@ export interface operations {
     };
     risk_analytics_category_analysis_retrieve: {
         parameters: {
-            query?: never;
+            query?: {
+                category_id?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Invalid category_id parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to generate category analysis */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -16448,8 +16869,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate control integration analysis */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -16466,12 +16897,16 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
+            /** @description Risk analytics data */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
             };
         };
     };
@@ -16484,8 +16919,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate executive summary */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -16502,8 +16947,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate heat map */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -16520,8 +16975,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate risk overview */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -16531,15 +16996,34 @@ export interface operations {
     };
     risk_analytics_trends_retrieve: {
         parameters: {
-            query?: never;
+            query?: {
+                days?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Invalid days parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to generate trend analysis */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18720,8 +19204,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate executive dashboard */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18738,8 +19232,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate compliance dashboard */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18756,8 +19260,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate vendor dashboard */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18774,8 +19288,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate policy dashboard */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18792,8 +19316,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate training dashboard */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18810,8 +19344,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate integrated risk analysis */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18828,8 +19372,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate executive report */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18846,8 +19400,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to generate operational dashboard */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18857,15 +19421,28 @@ export interface operations {
     };
     analytics_operator_usage_retrieve: {
         parameters: {
-            query?: never;
+            query?: {
+                days?: number;
+                export?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Operator access required */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18880,10 +19457,39 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+                "application/x-www-form-urlencoded": {
+                    [key: string]: unknown;
+                };
+                "multipart/form-data": {
+                    [key: string]: unknown;
+                };
+            };
+        };
         responses: {
-            /** @description No response body */
-            200: {
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Invalid report export request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to create export job */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18893,15 +19499,27 @@ export interface operations {
     };
     analytics_reports_retrieve: {
         parameters: {
-            query?: never;
+            query?: {
+                page?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to fetch reports */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18920,8 +19538,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to check report status */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18940,8 +19568,36 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
+            /** @description Generated report file */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Report is not ready */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Report file not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Report has expired */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to download report */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18960,8 +19616,15 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
-            204: {
+            /** @description Report deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to delete report */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18978,8 +19641,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
-            200: {
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Failed to refresh cache */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -18996,8 +19669,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Analytics service unavailable */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -21087,8 +21770,22 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
+            /** @description Billing portal session created */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No billing information found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to create billing portal session */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -21105,8 +21802,22 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description No response body */
+            /** @description Subscription cancellation scheduled */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No active subscription found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to cancel subscription */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Summary
- add explicit drf-spectacular schemas for custom auth, analytics, billing and risk analytics endpoints
- type computed serializer fields so booleans, counts, nullable URLs and structured objects no longer generate as strings
- add deterministic enum name overrides for repeated status, priority and classification choice sets
- regenerate app/schema.yml and frontend OpenAPI TypeScript types

Closes #196.

Note: this also reduces part of #191 by tightening many computed/custom fields, but #191 remains open for the import-register/import-library custom response payloads.

## Verification
- python manage.py spectacular --file app/schema.yml under production settings: no drf-spectacular warnings/errors
- python manage.py check --deploy under production settings: no issues
- ruff check on touched backend files
- npm run type-check
- npm run verify:api-types

DB-backed pytest slice was attempted, but local Postgres was unavailable and Docker Desktop is not running on this machine, so the run stopped at connection setup rather than assertions.