### PR TITLE
chore: consolidate safe dependency bumps

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Log in to GHCR
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
       image-digest: ${{ steps.build.outputs.digest }}
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
 
     - name: Set up QEMU
     # Needed for linux/arm64 cross-builds
@@ -109,7 +109,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging'
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
 
     - name: Azure Login (OIDC)
       uses: azure/login@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: pip
@@ -203,7 +203,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -200,7 +200,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -267,7 +267,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Set up Node.js
       uses: actions/setup-node@v7
@@ -322,7 +322,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Set up Node.js
       uses: actions/setup-node@v7
@@ -363,7 +363,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Set up Node.js
       uses: actions/setup-node@v7
@@ -390,7 +390,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
@@ -431,7 +431,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
 
@@ -63,7 +63,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
 
@@ -147,7 +147,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -60,7 +60,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -96,7 +96,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Fetch all history for all branches
 
@@ -114,7 +114,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Run Hadolint Dockerfile linter
       uses: hadolint/hadolint-action@v3.1.0
@@ -144,7 +144,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -186,7 +186,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
@@ -202,7 +202,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Run Checkov
       id: checkov

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^6.0.4",
@@ -3672,9 +3672,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^6.0.4",
         "eslint": "^10.8.0",
-        "eslint-config-next": "16.2.11",
+        "eslint-config-next": "16.2.12",
         "jsdom": "^30.0.0",
         "openapi-typescript": "^7.13.0",
         "typescript": "^5.6.3",
@@ -1523,9 +1523,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.11.tgz",
-      "integrity": "sha512-vMEf/aXOpzFFdtIvFYOnIDPKb0xBbrXONsz83CcKdRrekfxNdL8PNkq5qHqAHSXVlIifnX68LOMaxr3z5PkeLQ==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.12.tgz",
+      "integrity": "sha512-uF2z/qAK2q7B5/6CpnFcBRX6jOq5iCO+Uqh1UkJhXljX1JwLarLYhhoJadO6dPb6moTprOKewMXheBcbIoSbug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5920,13 +5920,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.11.tgz",
-      "integrity": "sha512-FIpbK/dUyxUExchDB7eBg3k+VU8R2iR/Cx9/kqTBUTFv2bOIR9aRrpno4rvAQ9VhiPQAyFKNA2NlZwouGWtclA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.12.tgz",
+      "integrity": "sha512-iaaf4vvKo5h2LBdGt0JuRv7t0Ysqr9FMCiFxbptDg8LqOE//mIKR80DdpOnSVM7qjLH3jT8P0aFiwXxBEGZRXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.11",
+        "@next/eslint-plugin-next": "16.2.12",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
       },
       "devDependencies": {
         "@eslint/compat": "^2.1.0",
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "^1.62.0",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1844,19 +1844,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@rc-component/async-validator": {
@@ -8741,35 +8741,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/pluralize": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/nextjs-registry": "^1.0.1",
         "@sentry/nextjs": "^10.68.0",
-        "@tanstack/react-query": "^5.101.2",
+        "@tanstack/react-query": "^5.101.4",
         "antd": "^5.21.4",
         "axios": "^1.18.1",
         "dayjs": "^1.11.21",
@@ -3479,9 +3479,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
-      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3489,12 +3489,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
-      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.101.2"
+        "@tanstack/query-core": "5.101.4"
       },
       "funding": {
         "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "^26.1.1",
+    "@types/node": "^26.1.2",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^6.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^6.0.4",
     "eslint": "^10.8.0",
-    "eslint-config-next": "16.2.11",
+    "eslint-config-next": "16.2.12",
     "jsdom": "^30.0.0",
     "openapi-typescript": "^7.13.0",
     "typescript": "^5.6.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@eslint/compat": "^2.1.0",
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "^1.62.0",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ant-design/nextjs-registry": "^1.0.1",
     "@sentry/nextjs": "^10.68.0",
-    "@tanstack/react-query": "^5.101.2",
+    "@tanstack/react-query": "^5.101.4",
     "antd": "^5.21.4",
     "axios": "^1.18.1",
     "dayjs": "^1.11.21",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==5.2.15
-djangorestframework==3.15.2
+djangorestframework==3.17.1
 django-filter==26.1
 psycopg[binary]==3.3.4
 django-otp==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==5.2.15
 djangorestframework==3.15.2
 django-filter==26.1
-psycopg[binary]==3.2.1
+psycopg[binary]==3.3.4
 django-otp==1.3.0
 django-two-factor-auth==1.15.5
 pyotp==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ stripe==12.4.0
 pytest==9.0.3
 pytest-django==4.11.1
 pytest-cov==6.0.0
-pytest-mock==3.12.0
+pytest-mock==3.15.1
 factory-boy==3.3.3
 faker==40.31.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-two-factor-auth==1.15.5
 pyotp==2.10.0
 qrcode[pil]==7.4.2
 django-cors-headers==4.3.1
-celery==5.4.0
+celery==5.6.3
 redis==5.0.7
 python-dotenv==1.2.2
 drf-spectacular==0.30.0


### PR DESCRIPTION
Closes #256.\n\nConsolidates the clean, routine Dependabot bumps into one donolu-authored PR to avoid serial long-running CI cycles.\n\nIncluded:\n- actions/checkout 5 -> 7\n- actions/setup-python 6 -> 7\n- docker/login-action 3 -> 4\n- @playwright/test 1.61.1 -> 1.62.0\n- eslint-config-next 16.2.11 -> 16.2.12\n- @types/node 26.1.1 -> 26.1.2\n- @tanstack/react-query 5.101.2 -> 5.101.4\n- pytest-mock 3.12.0 -> 3.15.1\n- psycopg 3.2.1 -> 3.3.4\n- celery 5.4.0 -> 5.6.3\n- djangorestframework 3.15.2 -> 3.17.1\n\nSupersedes Dependabot PRs #239, #240, #241, #245, #248, #249, #250, #251, #252, #253, and #246.\n\nLeft out deliberately because they are failing/riskier major bumps:\n- #254 antd 5 -> 6\n- #247 social-auth-core 4 -> 5\n\nLocal verification:\n- npm run type-check\n- npm run lint\n- python manage.py check\n- git diff --check