### PR TITLE
chore: remove unused social-auth dependencies

### DIFF
--- a/app/sso/test_sso_simple.py
+++ b/app/sso/test_sso_simple.py
@@ -235,7 +235,6 @@ def run_all_tests():
     print("8. Testing SSO dependencies:")
     dependencies = [
         ("onelogin.saml2.auth", "python3-saml"),
-        ("social_django", "social-auth-app-django"),
         ("jwt", "PyJWT"),
         ("cryptography", "cryptography"),
     ]

--- a/app/test_sso_final.py
+++ b/app/test_sso_final.py
@@ -208,7 +208,6 @@ def run_validation():
 
         sso_deps = [
             "python3-saml",
-            "social-auth-app-django",
             "djangorestframework-simplejwt",
             "xmlsec",
         ]

--- a/docs/adr/0024-enterprise-sso-integration-architecture.md
+++ b/docs/adr/0024-enterprise-sso-integration-architecture.md
@@ -43,7 +43,7 @@ We will implement a comprehensive enterprise SSO integration supporting both SAM
 
 ### Technology Stack
 - **SAML**: `python3-saml` (OneLogin SAML library) for robust SAML 2.0 support
-- **OAuth/OIDC**: `social-auth-app-django` with custom backend implementation
+- **OAuth/OIDC**: Custom OAuth/OIDC backend implementation
 - **JWT**: `PyJWT` for token validation and processing
 - **XML Security**: `xmlsec` for SAML signature validation and encryption
 - **Session Management**: Django sessions with custom SSO session tracking

--- a/docs/backlog/project_backlog.md
+++ b/docs/backlog/project_backlog.md
@@ -332,7 +332,7 @@
         10. ✅ **Integration & Dependencies** - Professional implementation:
             - Integration with existing Django authentication system
             - Compatible with django-tenants multi-tenant architecture
-            - Professional dependency management (python3-saml, social-auth-app-django, PyJWT, xmlsec)
+            - Professional dependency management (python3-saml, PyJWT, xmlsec)
             - URL routing and view handlers for all authentication flows
 
 ### EPIC 1: Certifications & Compliance Workflows

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,8 +47,6 @@ safety==3.2.10
 
 # SSO and Enterprise Authentication
 python3-saml==1.16.0
-social-auth-app-django==5.6.0
-social-auth-core[saml]==4.5.3
 djangorestframework-simplejwt==5.5.1
 cryptography==48.0.1
 xmlsec==1.3.14


### PR DESCRIPTION
Closes #259.\n\nRemoves unused python-social-auth packages from the backend dependency set. The project uses custom SSO code: SAML is handled via python3-saml/OneLogin and OAuth/OIDC is handled in app/sso/oauth_backends.py. social-auth-app-django and social-auth-core are not wired into INSTALLED_APPS, AUTHENTICATION_BACKENDS, URLs, or runtime imports.\n\nThis supersedes closed Dependabot PR #247, which was invalid because social-auth-core 5.0.2 conflicts with social-auth-app-django 5.6.0's social-auth-core ~=4.4 requirement.\n\nChanges:\n- Remove social-auth-app-django and social-auth-core[saml] from requirements.txt.\n- Keep python3-saml for SAML support.\n- Update stale SSO smoke-test dependency checks and docs.\n\nVerification:\n- python manage.py check\n- python -m compileall -q app/sso app/test_sso_final.py\n- python -m pip install --dry-run -r requirements.txt\n- git diff --check