### PR TITLE
ci: remove Node 20 action annotations

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ jobs:
       uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to GHCR
       uses: docker/login-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build Docker image
       uses: docker/build-push-action@v7

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -279,15 +279,13 @@ jobs:
     - name: Comment on PR (if applicable)
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       continue-on-error: true
-      uses: actions/github-script@v9
-      with:
-        script: |
-          const fs = require('fs');
-          const summary = fs.readFileSync('security-summary.md', 'utf8');
-
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `## 🔒 Security Scan Results\n\n${summary}`
-          });
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        {
+          echo "## Security Scan Results"
+          echo ""
+          cat security-summary.md
+        } > pr-comment.md
+        gh pr comment "$PR_NUMBER" --body-file pr-comment.md


### PR DESCRIPTION
Closes #258.\nCloses #261.\n\nRemoves the Node 20 deprecation annotations seen in CI after the Node 24 runner migration.\n\nChanges:\n- Update docker/setup-buildx-action from v3 to v4 in CI and CD workflows.\n- Replace actions/github-script@v9 in the security summary job with a GitHub CLI comment step, preserving same-repository PR commenting without a Node-backed action.\n\nVerification:\n- Confirmed current upstream tags: docker/setup-buildx-action has v4; actions/github-script currently has no newer major than v9.\n- rg confirms no docker/setup-buildx-action@v3 or actions/github-script references remain.\n- Parsed ci.yml, cd.yml and security.yml with PyYAML.\n- git diff --check.