### PR TITLE
ci: upgrade Codecov action to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
 
     - name: Upload coverage reports
       if: always() && hashFiles('app/coverage.xml') != ''
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: ./app/coverage.xml
         flags: backend-shard-${{ matrix.shard_number }}
@@ -348,7 +348,7 @@ jobs:
 
     - name: Upload coverage reports
       if: always() && false  # Disabled until tests are configured
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         directory: ./frontend/coverage
         flags: frontend


### PR DESCRIPTION
## Summary
- upgrade Codecov coverage uploads from codecov/codecov-action@v5 to @v6
- update the disabled frontend coverage upload too so it cannot reintroduce the Node 20 annotation later

## Validation
- workflow YAML parsed successfully
- rg confirms no direct actions/github-script references remain
- git diff --check

Closes #261