### PR TITLE
security: avoid logging demo credential env name

### DIFF
--- a/app/generate_dummy_data.py
+++ b/app/generate_dummy_data.py
@@ -124,9 +124,7 @@ class GRCDataGenerator:
 
         print(f"✅ Created {len(self.users)} users")
         if not os.environ.get(DEMO_PASSWORD_ENV):
-            print(
-                f"ℹ️  Users have unusable passwords. Set {DEMO_PASSWORD_ENV} to enable demo login."
-            )
+            print("ℹ️  Demo user login is disabled by default.")
 
     def create_risk_data(self):
         """Generate 10 comprehensive risk records"""

--- a/app/generate_dummy_data_container.py
+++ b/app/generate_dummy_data_container.py
@@ -118,9 +118,7 @@ class GRCDataGenerator:
 
         print(f"✅ Created {len(self.users)} users")
         if not os.environ.get(DEMO_PASSWORD_ENV):
-            print(
-                f"ℹ️  Users have unusable passwords. Set {DEMO_PASSWORD_ENV} to enable demo login."
-            )
+            print("ℹ️  Demo user login is disabled by default.")
 
     def create_risk_data(self):
         """Generate 10 comprehensive risk records"""

--- a/app/generate_tenant_dummy_data.py
+++ b/app/generate_tenant_dummy_data.py
@@ -166,9 +166,7 @@ class TenantDummyDataGenerator:
 
         print(f"✅ Created {len(created_users)} users")
         if not os.environ.get(DEMO_PASSWORD_ENV):
-            print(
-                f"ℹ️  Users have unusable passwords. Set {DEMO_PASSWORD_ENV} to enable demo login."
-            )
+            print("ℹ️  Demo user login is disabled by default.")
         return created_users
 
     def create_risk_data(self, users):


### PR DESCRIPTION
## Summary
- stop printing the demo credential environment variable name from dummy-data scripts
- keep demo login disabled by default when no opt-in credential is configured
- targets CodeQL clear-text logging alerts #590, #591, and #592

## Validation
- python -m py_compile app/generate_dummy_data.py app/generate_dummy_data_container.py app/generate_tenant_dummy_data.py
- rg check for remaining printed credential env-var-name path
- git diff --check

Closes #264