### PR TITLE
ci: upgrade download-artifact action to Node 24

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -237,7 +237,7 @@ jobs:
 
     steps:
     - name: Download all artifacts
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v8
 
     - name: Generate security summary
       run: |
@@ -288,4 +288,4 @@ jobs:
           echo ""
           cat security-summary.md
         } > pr-comment.md
-        gh pr comment "$PR_NUMBER" --body-file pr-comment.md
+        gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file pr-comment.md


### PR DESCRIPTION
## Summary
- upgrade Security Summary artifact download from actions/download-artifact@v6 to @v8
- removes the Node 20 compatibility annotation seen on the main Security Scanning run

## Validation
- checked latest actions/download-artifact release via GitHub API: v8.0.1
- security workflow YAML parsed successfully
- rg confirms the updated action reference
- git diff --check

Closes #266