### PR TITLE
security: remove package tooling from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,10 @@ RUN groupadd -r appuser && useradd -r -g appuser appuser
 # Copy virtual environment from builder
 COPY --from=builder /opt/venv /opt/venv
 
+# Runtime containers do not need package-management tooling.
+RUN /opt/venv/bin/python -m pip uninstall -y pip wheel virtualenv && \
+    /usr/local/bin/python -m pip uninstall -y pip wheel
+
 # Create workspace and set permissions
 WORKDIR /workspace
 RUN mkdir -p /workspace/app /workspace/static /workspace/media && \


### PR DESCRIPTION
## Summary
- remove pip, wheel, and virtualenv from the production runtime image after dependencies are installed
- keep setuptools in the application venv to avoid breaking libraries that still import pkg_resources
- targets Trivy runtime package alerts for pip/virtualenv in #272

## Validation
- git diff --check
- attempted local docker build, but Docker daemon is not running on this machine: docker.sock not found

Refs #272