### PR TITLE
ci: upload image Trivy SARIF

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,6 +15,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  security-events: write
 
 # Prevent overlapping deploys per branch/env
 concurrency:
@@ -249,6 +250,12 @@ jobs:
         image-ref: ${{ needs.build-and-push.outputs.image-tag }}
         format: sarif
         output: trivy-image-results.sarif
+
+    - name: Upload image scan SARIF to Code Scanning
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        sarif_file: trivy-image-results.sarif
+        category: trivy-image
 
     - name: Upload image scan SARIF as artifact
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Upload CD image Trivy SARIF to GitHub Code Scanning.
- Grant the workflow security-events write permission so image-layer alerts can be reconciled.
- Keep the existing SARIF artifact upload as a fallback.

## Context

PR #273 removed pip, wheel, and virtualenv from the production runtime image and was verified locally, but the open Trivy alerts remained because the image scan in cd.yml only uploaded SARIF as an artifact. Without uploading image SARIF to Code Scanning, GitHub cannot close stale image-layer alerts.

Refs #272

## Validation

- git diff --check