### PR TITLE
security: return safe API errors

### DIFF
--- a/app/analytics/views.py
+++ b/app/analytics/views.py
@@ -110,8 +110,8 @@ def executive_dashboard(request):
     try:
         data = CrossModuleAnalyticsService.get_executive_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
-    except Exception as e:
-        logger.error(f"Error generating executive dashboard: {str(e)}")
+    except Exception:
+        logger.exception("Error generating executive dashboard")
         return Response(
             {"error": "Failed to generate executive dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -139,8 +139,8 @@ def compliance_dashboard(request):
     try:
         data = CrossModuleAnalyticsService.get_compliance_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
-    except Exception as e:
-        logger.error(f"Error generating compliance dashboard: {str(e)}")
+    except Exception:
+        logger.exception("Error generating compliance dashboard")
         return Response(
             {"error": "Failed to generate compliance dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -168,8 +168,8 @@ def vendor_risk_dashboard(request):
     try:
         data = CrossModuleAnalyticsService.get_vendor_risk_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
-    except Exception as e:
-        logger.error(f"Error generating vendor dashboard: {str(e)}")
+    except Exception:
+        logger.exception("Error generating vendor dashboard")
         return Response(
             {"error": "Failed to generate vendor dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -197,8 +197,8 @@ def policy_management_dashboard(request):
     try:
         data = CrossModuleAnalyticsService.get_policy_management_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
-    except Exception as e:
-        logger.error(f"Error generating policy dashboard: {str(e)}")
+    except Exception:
+        logger.exception("Error generating policy dashboard")
         return Response(
             {"error": "Failed to generate policy dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -226,8 +226,8 @@ def training_effectiveness_dashboard(request):
     try:
         data = CrossModuleAnalyticsService.get_training_effectiveness_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
-    except Exception as e:
-        logger.error(f"Error generating training dashboard: {str(e)}")
+    except Exception:
+        logger.exception("Error generating training dashboard")
         return Response(
             {"error": "Failed to generate training dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -257,8 +257,8 @@ def integrated_risk_posture(request):
     try:
         data = CrossModuleAnalyticsService.get_integrated_risk_posture()
         return Response(data, status=status.HTTP_200_OK)
-    except Exception as e:
-        logger.error(f"Error generating integrated risk posture: {str(e)}")
+    except Exception:
+        logger.exception("Error generating integrated risk posture")
         return Response(
             {"error": "Failed to generate integrated risk analysis"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -288,8 +288,8 @@ def executive_report_data(request):
     try:
         data = AnalyticsReportGenerator.generate_executive_report_data()
         return Response(data, status=status.HTTP_200_OK)
-    except Exception as e:
-        logger.error(f"Error generating executive report: {str(e)}")
+    except Exception:
+        logger.exception("Error generating executive report")
         return Response(
             {"error": "Failed to generate executive report"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -317,8 +317,8 @@ def operational_dashboard(request):
     try:
         data = AnalyticsReportGenerator.generate_operational_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
-    except Exception as e:
-        logger.error(f"Error generating operational dashboard: {str(e)}")
+    except Exception:
+        logger.exception("Error generating operational dashboard")
         return Response(
             {"error": "Failed to generate operational dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -363,10 +363,14 @@ def analytics_health_check(request):
 
         return Response(health_data, status=status.HTTP_200_OK)
 
-    except Exception as e:
-        logger.error(f"Analytics health check failed: {str(e)}")
+    except Exception:
+        logger.exception("Analytics health check failed")
         return Response(
-            {"status": "unhealthy", "error": str(e), "timestamp": timezone.now().isoformat()},
+            {
+                "status": "unhealthy",
+                "error": "Analytics service unavailable.",
+                "timestamp": timezone.now().isoformat(),
+            },
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -448,8 +452,8 @@ def export_report(request):
             status=status.HTTP_202_ACCEPTED,
         )
 
-    except Exception as e:
-        logger.error(f"Error creating export job: {str(e)}")
+    except Exception:
+        logger.exception("Error creating export job")
         return Response(
             {"error": "Failed to create export job"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -506,8 +510,8 @@ def report_status(request, report_id):
 
         return Response(response_data)
 
-    except Exception as e:
-        logger.error(f"Error checking report status {report_id}: {str(e)}")
+    except Exception:
+        logger.exception("Error checking report status %s", report_id)
         return Response(
             {"error": "Failed to check report status"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -590,8 +594,8 @@ def download_report(request, report_id):
 
         return response
 
-    except Exception as e:
-        logger.error(f"Error downloading report {report_id}: {str(e)}")
+    except Exception:
+        logger.exception("Error downloading report %s", report_id)
         return Response(
             {"error": "Failed to download report"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -662,8 +666,8 @@ def my_reports(request):
             }
         )
 
-    except Exception as e:
-        logger.error(f"Error fetching user reports: {str(e)}")
+    except Exception:
+        logger.exception("Error fetching user reports")
         return Response(
             {"error": "Failed to fetch reports"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -693,8 +697,8 @@ def delete_report(request, report_id):
         if report.file_path and default_storage.exists(report.file_path):
             try:
                 default_storage.delete(report.file_path)
-            except Exception as e:
-                logger.warning(f"Failed to delete file for report {report_id}: {str(e)}")
+            except Exception:
+                logger.warning("Failed to delete file for report %s", report_id, exc_info=True)
 
         # Delete the report record
         report.delete()
@@ -703,8 +707,8 @@ def delete_report(request, report_id):
 
         return Response({"message": "Report deleted successfully"})
 
-    except Exception as e:
-        logger.error(f"Error deleting report {report_id}: {str(e)}")
+    except Exception:
+        logger.exception("Error deleting report %s", report_id)
         return Response(
             {"error": "Failed to delete report"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -745,8 +749,8 @@ def refresh_cache(request):
             status=status.HTTP_202_ACCEPTED,
         )
 
-    except Exception as e:
-        logger.error(f"Error queuing cache refresh: {str(e)}")
+    except Exception:
+        logger.exception("Error queuing cache refresh")
         return Response(
             {"error": "Failed to refresh cache"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )

--- a/app/authn/views.py
+++ b/app/authn/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from rest_framework import status, permissions
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
@@ -32,6 +34,7 @@ from .serializers import (
 )
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 class RegisterView(APIView):
@@ -556,9 +559,10 @@ class SetupTOTPView(APIView):
                     status=status.HTTP_200_OK,
                 )
 
-            except ValueError as e:
-                return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
-            except Exception as e:
+            except ValueError:
+                return Response({"error": "Invalid password"}, status=status.HTTP_400_BAD_REQUEST)
+            except Exception:
+                logger.exception("Failed to set up TOTP device")
                 return Response(
                     {"error": "Failed to setup TOTP device. Please try again."},
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/app/catalogs/views.py
+++ b/app/catalogs/views.py
@@ -1,4 +1,5 @@
 import tempfile
+import logging
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -74,6 +75,8 @@ from .serializers import (
     TemplateImportRequestSerializer,
     TemplateImportSummarySerializer,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class CatalogueAuditMixin:
@@ -1411,9 +1414,14 @@ class ControlAssessmentViewSet(CatalogueAuditMixin, viewsets.ModelViewSet):
                     }
                 )
 
-            except Exception as e:
+            except Exception:
+                logger.exception("Failed to process uploaded assessment evidence")
                 errors.append(
-                    {"file_name": uploaded_file.name, "error": str(e), "status": "failed"}
+                    {
+                        "file_name": uploaded_file.name,
+                        "error": "File could not be processed.",
+                        "status": "failed",
+                    }
                 )
 
         return Response(

--- a/app/core/health.py
+++ b/app/core/health.py
@@ -3,6 +3,7 @@ Health check views for monitoring and deployment verification.
 """
 
 import hmac
+import logging
 
 from django.http import HttpResponse, JsonResponse
 from django.views import View
@@ -14,6 +15,8 @@ import time
 from datetime import datetime
 
 from .observability import render_prometheus_metrics
+
+logger = logging.getLogger(__name__)
 
 
 class HealthCheckView(View):
@@ -39,11 +42,12 @@ class HealthCheckView(View):
                     "status": "healthy",
                     "message": "Database connection successful",
                 }
-        except Exception as e:
+        except Exception:
+            logger.exception("Health check database probe failed")
             health_data["status"] = "unhealthy"
             health_data["checks"]["database"] = {
                 "status": "unhealthy",
-                "message": f"Database connection failed: {str(e)}",
+                "message": "Database connection failed.",
             }
 
         # Cache check
@@ -61,10 +65,11 @@ class HealthCheckView(View):
             else:
                 raise Exception("Cache value mismatch")
 
-        except Exception as e:
+        except Exception:
+            logger.exception("Health check cache probe failed")
             health_data["checks"]["cache"] = {
                 "status": "degraded",
-                "message": f"Cache check failed: {str(e)}",
+                "message": "Cache check failed.",
             }
 
         # Storage check
@@ -78,10 +83,11 @@ class HealthCheckView(View):
                     "status": "healthy",
                     "message": f"{default_storage.__class__.__name__} configured",
                 }
-        except Exception as e:
+        except Exception:
+            logger.exception("Health check storage probe failed")
             health_data["checks"]["storage"] = {
                 "status": "degraded",
-                "message": f"Storage check failed: {str(e)}",
+                "message": "Storage check failed.",
             }
 
         # Stripe connectivity check (basic)
@@ -97,10 +103,11 @@ class HealthCheckView(View):
                     "status": "degraded",
                     "message": "Stripe not configured",
                 }
-        except Exception as e:
+        except Exception:
+            logger.exception("Health check Stripe configuration probe failed")
             health_data["checks"]["stripe"] = {
                 "status": "degraded",
-                "message": f"Stripe check failed: {str(e)}",
+                "message": "Stripe check failed.",
             }
 
         # Check if any critical systems are unhealthy
@@ -140,11 +147,12 @@ class ReadinessCheckView(View):
 
             return JsonResponse({"status": "ready", "timestamp": datetime.utcnow().isoformat()})
 
-        except Exception as e:
+        except Exception:
+            logger.exception("Readiness check failed")
             return JsonResponse(
                 {
                     "status": "not_ready",
-                    "message": str(e),
+                    "message": "Application is not ready.",
                     "timestamp": datetime.utcnow().isoformat(),
                 },
                 status=503,

--- a/app/exports/views.py
+++ b/app/exports/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import viewsets, status
@@ -36,6 +38,8 @@ from .serializers import (
 )
 from .services import AssessmentReportGenerator, get_export_coverage_manifest
 from .tasks import generate_assessment_report_task, generate_tenant_data_export_task
+
+logger = logging.getLogger(__name__)
 
 
 @extend_schema_view(
@@ -242,9 +246,10 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_202_ACCEPTED,
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to start assessment report generation")
             return Response(
-                {"error": f"Failed to start report generation: {str(e)}"},
+                {"error": "Failed to start report generation"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -375,11 +380,12 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
                     status=status.HTTP_201_CREATED,
                 )
 
-            except Exception as e:
+            except Exception:
+                logger.exception("Failed to start quick assessment report generation")
                 # Clean up created report on failure
                 report.delete()
                 return Response(
-                    {"error": f"Failed to start report generation: {str(e)}"},
+                    {"error": "Failed to start report generation"},
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
 

--- a/app/policies/views.py
+++ b/app/policies/views.py
@@ -13,6 +13,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from django.db.models import Count, Q, Avg, Case, When, Value, IntegerField
 from django.utils import timezone
 from django.shortcuts import get_object_or_404
+import logging
 from datetime import timedelta
 from typing import Any
 
@@ -44,6 +45,8 @@ from .serializers import (
     PolicyVersionAuditLogSerializer,
 )
 from .filters import PolicyFilter, PolicyVersionFilter, PolicyAcknowledgmentFilter
+
+logger = logging.getLogger(__name__)
 
 
 class PolicyCategoryViewSet(viewsets.ModelViewSet):
@@ -727,15 +730,19 @@ class PolicyVersionViewSet(viewsets.ModelViewSet):
         try:
             finalize_policy_version_pdf(version)
         except DocumentConversionError as exc:
+            logger.exception("Policy version PDF finalisation failed")
             log_policy_version_event(
                 version=version,
                 action="conversion_failed",
                 actor=request.user,
                 request=request,
                 source={"type": "conversion", "reference": "policy_final_pdf"},
-                details={"error": str(exc)},
+                details={"error": exc.__class__.__name__},
             )
-            return Response({"error": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+            return Response(
+                {"error": "Document conversion failed. Please try again later."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
 
         version.lifecycle_state = "final"
         version.finalized_at = timezone.now()

--- a/app/risk/views.py
+++ b/app/risk/views.py
@@ -1,3 +1,4 @@
+import logging
 from rest_framework import viewsets, status, filters, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -60,6 +61,8 @@ from .audit import (
     snapshot_risk_action,
     snapshot_risk_action_evidence,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @extend_schema_view(
@@ -1398,9 +1401,10 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
         try:
             dashboard_data = RiskReportGenerator.generate_risk_dashboard_data()
             return Response(dashboard_data)
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate risk dashboard data")
             return Response(
-                {"error": f"Failed to generate dashboard data: {str(e)}"},
+                {"error": "Failed to generate dashboard data"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -1426,9 +1430,10 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
         try:
             overview_data = RiskAnalyticsService.get_risk_overview_stats()
             return Response(overview_data)
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate risk overview")
             return Response(
-                {"error": f"Failed to generate risk overview: {str(e)}"},
+                {"error": "Failed to generate risk overview"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -1454,9 +1459,10 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
         try:
             action_data = RiskAnalyticsService.get_risk_action_overview_stats()
             return Response(action_data)
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate risk action overview")
             return Response(
-                {"error": f"Failed to generate action overview: {str(e)}"},
+                {"error": "Failed to generate action overview"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -1482,9 +1488,10 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
         try:
             heat_map_data = RiskAnalyticsService.get_risk_heat_map_data()
             return Response(heat_map_data)
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate risk heat map")
             return Response(
-                {"error": f"Failed to generate heat map: {str(e)}"},
+                {"error": "Failed to generate heat map"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -1523,9 +1530,10 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
                 {"error": "Invalid days parameter. Must be a number between 30 and 365."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate risk trend analysis")
             return Response(
-                {"error": f"Failed to generate trend analysis: {str(e)}"},
+                {"error": "Failed to generate trend analysis"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -1551,9 +1559,10 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
         try:
             progress_data = RiskAnalyticsService.get_risk_action_progress_analysis()
             return Response(progress_data)
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate risk action progress analysis")
             return Response(
-                {"error": f"Failed to generate progress analysis: {str(e)}"},
+                {"error": "Failed to generate progress analysis"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -1580,9 +1589,10 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
         try:
             executive_data = RiskAnalyticsService.get_executive_risk_summary()
             return Response(executive_data)
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate executive risk summary")
             return Response(
-                {"error": f"Failed to generate executive summary: {str(e)}"},
+                {"error": "Failed to generate executive summary"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -1609,9 +1619,10 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
         try:
             integration_data = RiskAnalyticsService.get_risk_control_integration_analysis()
             return Response(integration_data)
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate risk-control integration analysis")
             return Response(
-                {"error": f"Failed to generate control integration analysis: {str(e)}"},
+                {"error": "Failed to generate control integration analysis"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -1651,8 +1662,9 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
 
             category_data = RiskReportGenerator.get_risk_category_deep_dive(category_id)
             return Response(category_data)
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate risk category analysis")
             return Response(
-                {"error": f"Failed to generate category analysis: {str(e)}"},
+                {"error": "Failed to generate category analysis"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/app/vuln/serializers.py
+++ b/app/vuln/serializers.py
@@ -29,7 +29,9 @@ class ScanTargetSerializer(serializers.ModelSerializer):
         try:
             return validate_scan_target_address(value)
         except TargetValidationError as exc:
-            raise serializers.ValidationError(str(exc)) from exc
+            raise serializers.ValidationError(
+                "Enter an approved hostname, IP address or URL."
+            ) from exc
 
 
 class ScanScheduleSerializer(serializers.ModelSerializer):

--- a/app/vuln/views.py
+++ b/app/vuln/views.py
@@ -43,8 +43,11 @@ class ScanTargetViewSet(viewsets.ModelViewSet):
         target = self.get_object()
         try:
             job = create_scan_job(target, requested_by=request.user)
-        except ValueError as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except ValueError:
+            return Response(
+                {"detail": "Only approved scan targets can be scanned."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         schema_name = getattr(getattr(request, "tenant", None), "schema_name", None)
         run_scan_job.delay(str(job.id), schema_name)


### PR DESCRIPTION
## Summary

- Replace raw exception text in API responses with stable client-safe messages.
- Log server-side exceptions with stack traces using logger.exception or exc_info.
- Keep controlled validation behaviour for user mistakes, but avoid echoing exception objects.

## Validation

- python -m compileall on all touched files
- ruff check on all touched files
- ruff format --check on all touched files
- git diff --check
- Django system check with local Postgres, Redis and Azurite
- Targeted service-backed pytest slice: 100 passed; 11 failures were existing risk analytics URL/data assertions outside the changed error paths.

Closes #270