### PR TITLE
chore: split runtime and development requirements

### DIFF
--- a/.github/scripts/run-mypy.sh
+++ b/.github/scripts/run-mypy.sh
@@ -21,7 +21,7 @@ if [[ -z "$MYPY_BIN" ]]; then
     MYPY_BIN="$(command -v mypy)"
   else
     echo "mypy not found; skipping type check locally (CI will verify)"
-    echo "To set up: pip install -r requirements.txt"
+    echo "To set up: pip install -r requirements-dev.txt"
     exit 0
   fi
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
         cache: pip
         cache-dependency-path: |
           requirements.txt
+          requirements-dev.txt
           pyproject.toml
 
     - name: Install system dependencies
@@ -106,8 +107,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install pytest pytest-django pytest-cov ruff mypy
+        pip install -r requirements-dev.txt
 
     - name: Wait for services
       timeout-minutes: 3
@@ -209,6 +209,7 @@ jobs:
         cache: pip
         cache-dependency-path: |
           requirements.txt
+          requirements-dev.txt
           pyproject.toml
 
     - name: Install system dependencies
@@ -231,8 +232,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install pytest pytest-django pytest-cov ruff mypy
+        pip install -r requirements-dev.txt
 
     - name: Wait for services
       timeout-minutes: 3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,20 @@
+-r requirements.txt
+
+# Testing dependencies
+pytest==9.0.3
+pytest-django==4.11.1
+pytest-cov==6.0.0
+pytest-mock==3.15.1
+factory-boy==3.3.3
+faker==40.31.0
+
+# Code quality
+ruff==0.15.20
+mypy>=1.19,<1.20
+django-stubs[compatible-mypy]>=5.0,<6.0
+djangorestframework-stubs>=3.15,<4.0
+pre-commit>=4.6.0
+
+# Security tooling
+bandit==1.9.4
+safety==3.2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,27 +23,7 @@ django-tenants==3.10.2
 gunicorn==23.0.0
 packaging>=23.0
 flower==2.0.1
-qrcode==7.4.2
 stripe==12.4.0
-
-# Testing dependencies
-pytest==9.0.3
-pytest-django==4.11.1
-pytest-cov==6.0.0
-pytest-mock==3.15.1
-factory-boy==3.3.3
-faker==40.31.0
-
-# Code quality
-ruff==0.15.20
-mypy>=1.19,<1.20
-django-stubs[compatible-mypy]>=5.0,<6.0
-djangorestframework-stubs>=3.15,<4.0
-pre-commit>=4.6.0
-
-# Security
-bandit==1.9.4
-safety==3.2.10
 
 # SSO and Enterprise Authentication
 python3-saml==1.16.0


### PR DESCRIPTION
Closes #274

## Summary
- Keep requirements.txt as the production/runtime dependency set only.
- Add requirements-dev.txt as an overlay for tests, linting, type checking, pre-commit and security tooling.
- Update backend CI to install requirements-dev.txt while Docker production builds continue to install requirements.txt.
- Remove the duplicate plain qrcode pin because qrcode[pil]==7.4.2 already pins the same package.

## Verification
- git diff --check
- python -m pip install --dry-run -r requirements-dev.txt
- docker build --target production -t enterprise-grc-req-split-check .
- docker run runtime package check confirms pytest, ruff, mypy, bandit, safety, pre-commit, pip, wheel and virtualenv are absent
- docker run runtime import check confirms Django, Celery, DRF and WeasyPrint still import

Note: the existing WeasyPrint fontconfig cache warning still appears during import and is already tracked under #129.