### PR TITLE
fix: harden generated business identifiers

### DIFF
--- a/app/compliance/models.py
+++ b/app/compliance/models.py
@@ -2,6 +2,8 @@ from django.contrib.auth import get_user_model
 from django.db import models
 from django.utils import timezone
 
+from core.identifiers import next_prefixed_identifier, save_with_generated_identifier
+
 User = get_user_model()
 
 
@@ -86,15 +88,17 @@ class GovernanceArtefact(models.Model):
         return f"{self.artefact_id}: {self.title}"
 
     def save(self, *args, **kwargs):
-        if not self.artefact_id:
-            self.artefact_id = self._generate_identifier("GOV")
-        super().save(*args, **kwargs)
+        save_with_generated_identifier(
+            self,
+            "artefact_id",
+            lambda: self._generate_identifier("GOV"),
+            lambda: super(GovernanceArtefact, self).save(*args, **kwargs),
+        )
 
     @classmethod
     def _generate_identifier(cls, prefix):
         year = timezone.now().year
-        existing_count = cls.objects.filter(artefact_id__startswith=f"{prefix}-{year}").count()
-        return f"{prefix}-{year}-{existing_count + 1:04d}"
+        return next_prefixed_identifier(cls, "artefact_id", f"{prefix}-{year}")
 
 
 class RegulatoryRequirement(models.Model):
@@ -206,13 +210,17 @@ class RegulatoryRequirement(models.Model):
         return f"{self.requirement_id}: {self.title}"
 
     def save(self, *args, **kwargs):
-        if not self.requirement_id:
-            year = timezone.now().year
-            existing_count = RegulatoryRequirement.objects.filter(
-                requirement_id__startswith=f"REQ-{year}"
-            ).count()
-            self.requirement_id = f"REQ-{year}-{existing_count + 1:04d}"
-        super().save(*args, **kwargs)
+        save_with_generated_identifier(
+            self,
+            "requirement_id",
+            self._generate_requirement_id,
+            lambda: super(RegulatoryRequirement, self).save(*args, **kwargs),
+        )
+
+    @classmethod
+    def _generate_requirement_id(cls):
+        year = timezone.now().year
+        return next_prefixed_identifier(cls, "requirement_id", f"REQ-{year}")
 
 
 class NonConformity(models.Model):
@@ -313,17 +321,21 @@ class NonConformity(models.Model):
         return f"{self.nonconformity_id}: {self.title}"
 
     def save(self, *args, **kwargs):
-        if not self.nonconformity_id:
-            year = timezone.now().year
-            existing_count = NonConformity.objects.filter(
-                nonconformity_id__startswith=f"NC-{year}"
-            ).count()
-            self.nonconformity_id = f"NC-{year}-{existing_count + 1:04d}"
         if self.status in {"closed", "accepted"} and not self.closed_on:
             self.closed_on = timezone.now().date()
         elif self.status not in {"closed", "accepted"}:
             self.closed_on = None
-        super().save(*args, **kwargs)
+        save_with_generated_identifier(
+            self,
+            "nonconformity_id",
+            self._generate_nonconformity_id,
+            lambda: super(NonConformity, self).save(*args, **kwargs),
+        )
+
+    @classmethod
+    def _generate_nonconformity_id(cls):
+        year = timezone.now().year
+        return next_prefixed_identifier(cls, "nonconformity_id", f"NC-{year}")
 
     @property
     def is_overdue(self):
@@ -417,10 +429,14 @@ class ManagementReview(models.Model):
         return f"{self.review_id}: {self.title}"
 
     def save(self, *args, **kwargs):
-        if not self.review_id:
-            year = timezone.now().year
-            existing_count = ManagementReview.objects.filter(
-                review_id__startswith=f"MR-{year}"
-            ).count()
-            self.review_id = f"MR-{year}-{existing_count + 1:04d}"
-        super().save(*args, **kwargs)
+        save_with_generated_identifier(
+            self,
+            "review_id",
+            self._generate_review_id,
+            lambda: super(ManagementReview, self).save(*args, **kwargs),
+        )
+
+    @classmethod
+    def _generate_review_id(cls):
+        year = timezone.now().year
+        return next_prefixed_identifier(cls, "review_id", f"MR-{year}")

--- a/app/core/identifiers.py
+++ b/app/core/identifiers.py
@@ -1,0 +1,67 @@
+from collections.abc import Callable
+from typing import Any, cast
+
+from django.db import IntegrityError, models, transaction
+
+
+def next_prefixed_identifier(
+    model: type[Any],
+    field_name: str,
+    prefix: str,
+    *,
+    width: int = 4,
+) -> str:
+    """Return the next identifier by incrementing the highest existing suffix."""
+    lookup = {f"{field_name}__startswith": f"{prefix}-"}
+    last_identifier = (
+        model.objects.filter(**lookup)
+        .order_by(f"-{field_name}")
+        .values_list(field_name, flat=True)
+        .first()
+    )
+
+    next_number = 1
+    if last_identifier:
+        try:
+            next_number = int(str(last_identifier).rsplit("-", 1)[1]) + 1
+        except (IndexError, ValueError):
+            next_number = 1
+
+    return f"{prefix}-{next_number:0{width}d}"
+
+
+def save_with_generated_identifier[T](
+    instance: models.Model,
+    field_name: str,
+    generate_identifier: Callable[[], str],
+    save: Callable[[], T],
+    *,
+    max_attempts: int = 5,
+) -> T:
+    """Save an instance with retry-on-collision for generated unique identifiers."""
+    should_generate = not getattr(instance, field_name)
+    attempts = max_attempts if should_generate else 1
+    last_error: IntegrityError | None = None
+
+    for _ in range(attempts):
+        if should_generate:
+            setattr(instance, field_name, generate_identifier())
+            attempted_identifier = getattr(instance, field_name)
+
+        try:
+            with transaction.atomic():
+                return save()
+        except IntegrityError as exc:
+            if not should_generate:
+                raise
+            collision_lookup = {field_name: attempted_identifier}
+            instance_model = cast(Any, instance.__class__)
+            if not instance_model.objects.filter(**collision_lookup).exists():
+                raise
+            last_error = exc
+            setattr(instance, field_name, "")
+
+    if last_error is not None:
+        raise last_error
+
+    return save()

--- a/app/core/test_identifiers.py
+++ b/app/core/test_identifiers.py
@@ -1,0 +1,110 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError
+from django.test import TestCase
+from django.utils import timezone
+
+from compliance.models import GovernanceArtefact
+from core.identifiers import save_with_generated_identifier
+from policies.models import Policy, PolicyCategory
+from risk.models import Risk
+
+User = get_user_model()
+
+
+class GeneratedIdentifierTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="identifier.owner",
+            email="identifier.owner@example.com",
+            password="testpass123",
+        )
+
+    def test_generated_identifier_retries_after_unique_collision(self):
+        year = timezone.now().year
+        existing_id = f"RISK-{year}-0001"
+        next_id = f"RISK-{year}-0002"
+        Risk.objects.create(
+            risk_id=existing_id,
+            title="Existing risk",
+            description="Existing risk description.",
+            impact=3,
+            likelihood=3,
+            risk_owner=self.user,
+            created_by=self.user,
+        )
+
+        with patch.object(Risk, "_generate_risk_id", side_effect=[existing_id, next_id]):
+            risk = Risk.objects.create(
+                title="Concurrent risk",
+                description="Risk created while another worker claimed the first ID.",
+                impact=4,
+                likelihood=3,
+                risk_owner=self.user,
+                created_by=self.user,
+            )
+
+        self.assertEqual(risk.risk_id, next_id)
+
+    def test_generated_identifier_does_not_retry_unrelated_integrity_error(self):
+        generated_ids: list[str] = []
+        risk = Risk(
+            title="Invalid concurrent risk",
+            description="Risk with an unrelated integrity failure.",
+            impact=4,
+            likelihood=3,
+            risk_owner=self.user,
+            created_by=self.user,
+        )
+
+        def generate_id() -> str:
+            identifier = f"RISK-{timezone.now().year}-0099"
+            generated_ids.append(identifier)
+            return identifier
+
+        def fail_save() -> None:
+            raise IntegrityError("unrelated constraint failure")
+
+        with self.assertRaises(IntegrityError):
+            save_with_generated_identifier(risk, "risk_id", generate_id, fail_save)
+
+        self.assertEqual(generated_ids, [f"RISK-{timezone.now().year}-0099"])
+
+    def test_identifier_generation_uses_highest_suffix_when_sequence_has_gaps(self):
+        year = timezone.now().year
+        GovernanceArtefact.objects.create(
+            artefact_id=f"GOV-{year}-0003",
+            title="Existing scope document",
+            artefact_type="scope_document",
+            owner=self.user,
+            created_by=self.user,
+        )
+
+        artefact = GovernanceArtefact.objects.create(
+            title="Next scope document",
+            artefact_type="scope_document",
+            owner=self.user,
+            created_by=self.user,
+        )
+
+        self.assertEqual(artefact.artefact_id, f"GOV-{year}-0004")
+
+    def test_policy_code_generation_uses_highest_category_suffix(self):
+        category = PolicyCategory.objects.create(name="Security")
+        Policy.objects.create(
+            policy_code="POL-SEC-003",
+            title="Existing information security policy",
+            category=category,
+            owner=self.user,
+            created_by=self.user,
+        )
+
+        policy = Policy.objects.create(
+            title="Acceptable use policy",
+            category=category,
+            owner=self.user,
+            created_by=self.user,
+        )
+
+        self.assertEqual(policy.policy_code, "POL-SEC-004")

--- a/app/policies/models.py
+++ b/app/policies/models.py
@@ -13,6 +13,8 @@ from django.urls import reverse
 import uuid
 import os
 
+from core.identifiers import next_prefixed_identifier, save_with_generated_identifier
+
 User = get_user_model()
 
 
@@ -151,12 +153,6 @@ class Policy(models.Model):
         return reverse("admin:policies_policy_change", args=[self.pk])
 
     def save(self, *args, **kwargs):
-        # Auto-generate policy code if not provided
-        if not self.policy_code:
-            category_prefix = self.category.name[:3].upper()
-            count = Policy.objects.filter(category=self.category).count() + 1
-            self.policy_code = f"POL-{category_prefix}-{count:03d}"
-
         # Set next review date if not provided
         if not self.next_review_date and self.review_frequency_months:
             from dateutil.relativedelta import relativedelta  # type: ignore[import-untyped]
@@ -165,7 +161,16 @@ class Policy(models.Model):
                 months=self.review_frequency_months
             )
 
-        super().save(*args, **kwargs)
+        save_with_generated_identifier(
+            self,
+            "policy_code",
+            self._generate_policy_code,
+            lambda: super(Policy, self).save(*args, **kwargs),
+        )
+
+    def _generate_policy_code(self):
+        category_prefix = self.category.name[:3].upper()
+        return next_prefixed_identifier(Policy, "policy_code", f"POL-{category_prefix}", width=3)
 
 
 class PolicyVersion(models.Model):

--- a/app/risk/models.py
+++ b/app/risk/models.py
@@ -4,6 +4,8 @@ from django.core.validators import MinValueValidator, MaxValueValidator
 from django.utils import timezone
 import uuid
 
+from core.identifiers import next_prefixed_identifier, save_with_generated_identifier
+
 User = get_user_model()
 
 
@@ -209,10 +211,6 @@ class Risk(models.Model):
         return f"{self.risk_id}: {self.title}"
 
     def save(self, *args, **kwargs):
-        # Auto-generate risk_id if not provided
-        if not self.risk_id:
-            self.risk_id = self._generate_risk_id()
-
         # Calculate risk level based on impact and likelihood
         self.risk_level = self._calculate_risk_level()
 
@@ -230,14 +228,17 @@ class Risk(models.Model):
         elif self.status != "closed" and self.closed_date:
             self.closed_date = None
 
-        super().save(*args, **kwargs)
+        save_with_generated_identifier(
+            self,
+            "risk_id",
+            self._generate_risk_id,
+            lambda: super(Risk, self).save(*args, **kwargs),
+        )
 
     def _generate_risk_id(self):
         """Generate a unique risk ID."""
-        # Get current year and a sequence number
         year = timezone.now().year
-        existing_count = Risk.objects.filter(risk_id__startswith=f"RISK-{year}").count()
-        return f"RISK-{year}-{existing_count + 1:04d}"
+        return next_prefixed_identifier(Risk, "risk_id", f"RISK-{year}")
 
     def _calculate_risk_level(self):
         """Calculate risk level based on impact, likelihood, and risk matrix."""
@@ -454,10 +455,6 @@ class RiskAction(models.Model):
         return f"{self.action_id}: {self.title}"
 
     def save(self, *args, **kwargs):
-        # Auto-generate action_id if not provided
-        if not self.action_id:
-            self.action_id = self._generate_action_id()
-
         # Auto-set completed date when status changes to completed
         if self.status == "completed" and not self.completed_date:
             self.completed_date = timezone.now().date()
@@ -465,14 +462,17 @@ class RiskAction(models.Model):
         elif self.status != "completed" and self.completed_date:
             self.completed_date = None
 
-        super().save(*args, **kwargs)
+        save_with_generated_identifier(
+            self,
+            "action_id",
+            self._generate_action_id,
+            lambda: super(RiskAction, self).save(*args, **kwargs),
+        )
 
     def _generate_action_id(self):
         """Generate a unique risk action ID."""
-        # Get current year and a sequence number
         year = timezone.now().year
-        existing_count = RiskAction.objects.filter(action_id__startswith=f"RA-{year}").count()
-        return f"RA-{year}-{existing_count + 1:04d}"
+        return next_prefixed_identifier(RiskAction, "action_id", f"RA-{year}")
 
     @property
     def is_overdue(self):

--- a/app/vendors/models.py
+++ b/app/vendors/models.py
@@ -13,6 +13,8 @@ from decimal import Decimal
 import uuid
 from datetime import timedelta
 
+from core.identifiers import next_prefixed_identifier, save_with_generated_identifier
+
 User = get_user_model()
 
 
@@ -326,24 +328,17 @@ class Vendor(models.Model):
         ]
 
     def save(self, *args, **kwargs):
-        if not self.vendor_id:
-            self.vendor_id = self._generate_vendor_id()
-        super().save(*args, **kwargs)
-
-    def _generate_vendor_id(self):
-        """Generate unique vendor ID in format VEN-YYYY-NNNN"""
-        year = timezone.now().year
-        last_vendor = (
-            Vendor.objects.filter(vendor_id__startswith=f"VEN-{year}-").order_by("vendor_id").last()
+        save_with_generated_identifier(
+            self,
+            "vendor_id",
+            self._generate_vendor_id,
+            lambda: super(Vendor, self).save(*args, **kwargs),
         )
 
-        if last_vendor:
-            last_number = int(last_vendor.vendor_id.split("-")[-1])
-            next_number = last_number + 1
-        else:
-            next_number = 1
-
-        return f"VEN-{year}-{next_number:04d}"
+    def _generate_vendor_id(self):
+        """Generate unique vendor ID in format VEN-YYYY-NNNN."""
+        year = timezone.now().year
+        return next_prefixed_identifier(Vendor, "vendor_id", f"VEN-{year}")
 
     @property
     def full_address(self):
@@ -749,9 +744,6 @@ class VendorTask(models.Model):
         verbose_name_plural = "Vendor Tasks"
 
     def save(self, *args, **kwargs):
-        if not self.task_id:
-            self.task_id = self._generate_task_id()
-
         # Auto-update status based on dates
         if self.due_date and not self.completed_date:
             if timezone.now().date() > self.due_date and self.status == "pending":
@@ -763,7 +755,12 @@ class VendorTask(models.Model):
         elif self.status != "completed":
             self.completed_date = None
 
-        super().save(*args, **kwargs)
+        save_with_generated_identifier(
+            self,
+            "task_id",
+            self._generate_task_id,
+            lambda: super(VendorTask, self).save(*args, **kwargs),
+        )
 
         # Create recurring instance if needed
         if (
@@ -775,19 +772,9 @@ class VendorTask(models.Model):
             self._create_next_recurring_instance()
 
     def _generate_task_id(self):
-        """Generate unique task ID in format TSK-YYYY-NNNN"""
+        """Generate unique task ID in format TSK-YYYY-NNNN."""
         year = timezone.now().year
-        last_task = (
-            VendorTask.objects.filter(task_id__startswith=f"TSK-{year}-").order_by("task_id").last()
-        )
-
-        if last_task:
-            last_number = int(last_task.task_id.split("-")[-1])
-            next_number = last_number + 1
-        else:
-            next_number = 1
-
-        return f"TSK-{year}-{next_number:04d}"
+        return next_prefixed_identifier(VendorTask, "task_id", f"TSK-{year}")
 
     def _create_next_recurring_instance(self):
         """Create next instance of a recurring task"""


### PR DESCRIPTION
## Summary
- Replace count/last-based business identifier generation with a shared retry-on-collision helper.
- Apply it to risk IDs, action IDs, compliance artefact IDs, requirement IDs, nonconformity IDs, management review IDs, policy codes, vendor IDs, and vendor task IDs.
- Add regression tests for collision retry, sparse suffixes, policy category suffixes, and unrelated IntegrityError handling.

## Verification
- ruff check app/core/identifiers.py app/core/test_identifiers.py app/risk/models.py app/compliance/models.py app/policies/models.py app/vendors/models.py
- ruff format --check app/core/identifiers.py app/core/test_identifiers.py app/risk/models.py app/compliance/models.py app/policies/models.py app/vendors/models.py
- mypy app/core/identifiers.py --config-file pyproject.toml
- pytest app/core/test_identifiers.py app/compliance/tests.py app/risk/test_workflow_audit.py app/policies/test_policy_simple.py app/vendors/test_vendor_simple.py app/vendors/test_task_simple.py -q

Closes #279