### PR TITLE
fix: remove unused gdk-pixbuf from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libffi-dev \
     libcairo2-dev \
     libpango1.0-dev \
-    libgdk-pixbuf-xlib-2.0-dev \
     libmagic1 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -51,6 +50,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     DJANGO_SETTINGS_MODULE=app.settings.production \
+    HOME="/home/appuser" \
+    XDG_CACHE_HOME="/home/appuser/.cache" \
     PATH="/opt/venv/bin:$PATH" \
     BUILD_ENV=${BUILD_ENV} \
     APP_VERSION=${BUILD_VERSION} \
@@ -63,7 +64,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcairo2 \
     libpango-1.0-0 \
     libpangoft2-1.0-0 \
-    libgdk-pixbuf-xlib-2.0-0 \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
@@ -89,8 +89,9 @@ COPY --chown=appuser:appuser scripts ./scripts
 # Make scripts executable
 RUN chmod +x ./scripts/startup.sh
 
-# Create log directory
-RUN mkdir -p /home/LogFiles && chown appuser:appuser /home/LogFiles
+# Create writable runtime directories for logs and font caches
+RUN mkdir -p /home/LogFiles /home/appuser/.cache/fontconfig && \
+    chown -R appuser:appuser /home/LogFiles /home/appuser
 
 # Switch to non-root user
 USER appuser


### PR DESCRIPTION
## Summary
- Remove gdk-pixbuf build/runtime packages that pull libtiff into the production image.
- Add a writable non-root HOME/XDG cache path for fontconfig so WeasyPrint can render without cache errors.

## Verification
- docker build -t enterprise-grc-trivy-clean-check .
- docker run --rm enterprise-grc-trivy-clean-check sh -lc 'dpkg-query -W libtiff6 2>/dev/null || true' produced no package output.
- docker run --rm enterprise-grc-trivy-clean-check python -c 'from weasyprint import HTML; pdf = HTML(string="<h1>PDF smoke</h1><p>Test</p>").write_pdf(); print(len(pdf)); assert pdf.startswith(b"%PDF")'
- trivy image --severity HIGH,CRITICAL --ignore-unfixed --quiet enterprise-grc-trivy-clean-check reported 0 Debian and 0 Python high/critical fixed vulnerabilities.

Closes #272