### PR TITLE
fix: remove curl from runtime healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcairo2 \
     libpango-1.0-0 \
     libpangoft2-1.0-0 \
-    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
@@ -101,7 +100,7 @@ WORKDIR /workspace/app
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8000}/health/ || exit 1
+    CMD ["python", "-c", "import os, urllib.request; urllib.request.urlopen('http://localhost:%s/health/' % os.environ.get('PORT', '8000'), timeout=10).read()"]
 
 # Expose port
 EXPOSE 8000

--- a/deploy/aws-ecs-task-definition.json
+++ b/deploy/aws-ecs-task-definition.json
@@ -44,7 +44,7 @@
         {"name": "STRIPE_WEBHOOK_SECRET", "valueFrom": "arn:aws:ssm:<region>:<account-id>:parameter/axim-grc/stripe-webhook-secret"}
       ],
       "healthCheck": {
-        "command": ["CMD-SHELL", "curl -f http://localhost:8000/health/ || exit 1"],
+        "command": ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health/', timeout=10).read()\""],
         "interval": 30,
         "timeout": 10,
         "retries": 3,

--- a/deploy/docker-compose.production.yml
+++ b/deploy/docker-compose.production.yml
@@ -43,7 +43,7 @@ services:
     volumes:
       - media:/workspace/app/media
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${PORT:-8000}/health/"]
+      test: ["CMD", "python", "-c", "import os, urllib.request; urllib.request.urlopen('http://localhost:%s/health/' % os.environ.get('PORT', '8000'), timeout=10).read()"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/deploy/docker-compose.webapp.yml
+++ b/deploy/docker-compose.webapp.yml
@@ -30,7 +30,7 @@ services:
       - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health/"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/', timeout=10).read()"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Closes #284.\n\n## Summary\n- Remove runtime `curl` from the production Docker image.\n- Replace Dockerfile healthcheck with Python stdlib `urllib.request`.\n- Update Docker Compose and ECS container healthchecks so deployed containers no longer depend on curl being installed.\n\n## Verification\n- `jq empty deploy/aws-ecs-task-definition.json`\n- `git diff --check`\n- `docker build -t enterprise-grc-no-curl-check .`\n- `docker run --rm enterprise-grc-no-curl-check sh -lc 'dpkg-query -W curl libcurl4t64 libnghttp2-14 libssh2-1t64 libtiff6 2>/dev/null || true'` returned no packages\n- `docker run --rm enterprise-grc-no-curl-check python -c 'from pathlib import Path; from weasyprint import HTML; pdf = HTML(string="<h1>PDF smoke</h1><p>Test</p>").write_pdf(); print(len(pdf)); assert pdf.startswith(b"%PDF"); assert Path("/home/appuser/.cache/fontconfig").is_dir()'`\n- `docker inspect enterprise-grc-no-curl-check --format '{{json .Config.Healthcheck}}'` confirms the Python healthcheck\n- `trivy image --severity HIGH,CRITICAL --ignore-unfixed --quiet enterprise-grc-no-curl-check` reports 0 Debian and 0 Python vulnerabilities\n- `trivy image --severity HIGH,CRITICAL --quiet enterprise-grc-no-curl-check` reports only unfixed Debian base-image findings after the curl/libcurl slice