### PR TITLE
ci: update docker metadata action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Extract metadata (tags, labels)
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6.2.0
       with:
         images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
         tags: |


### PR DESCRIPTION
Closes #283.\n\nUpdates docker/metadata-action from v5 to v6.2.0 so the CD workflow no longer relies on the deprecated Node.js 20 action runtime.\n\nVerification:\n- git diff --check\n- confirmed upstream latest release is v6.2.0