### PR TITLE
ci: skip app checks for non-app changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,90 @@ env:
   DEBUG: '0'
 
 jobs:
+  changes:
+    name: Detect Changed Areas
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      docker: ${{ steps.filter.outputs.docker }}
+      ci_config: ${{ steps.filter.outputs.ci_config }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Classify changed files
+      id: filter
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      run: |
+        set -euo pipefail
+
+        base="$BASE_SHA"
+        head="$HEAD_SHA"
+
+        if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
+          base="$(git rev-parse "$head^")"
+        fi
+
+        if ! git diff --name-only "$base" "$head" > changed-files.txt; then
+          echo "::warning::Could not determine changed files; running full CI."
+          {
+            echo "backend=true"
+            echo "frontend=true"
+            echo "docker=true"
+            echo "ci_config=true"
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "::group::Changed files"
+        cat changed-files.txt
+        echo "::endgroup::"
+
+        matches() {
+          grep -Eq "$1" changed-files.txt
+        }
+
+        backend=false
+        frontend=false
+        docker=false
+        ci_config=false
+
+        if matches '^(app/|requirements(-dev)?\.txt$|pyproject\.toml$|pytest\.ini$|mypy\.ini$|ruff\.toml$)'; then
+          backend=true
+        fi
+
+        if matches '^frontend/'; then
+          frontend=true
+        fi
+
+        if matches '^(Dockerfile|\.dockerignore|compose(\..*)?\.yml|deploy/.*docker-compose.*\.yml|deploy/.*task-definition.*\.json)$'; then
+          docker=true
+        fi
+
+        if matches '^\.github/workflows/ci\.yml$|^\.github/scripts/'; then
+          ci_config=true
+        fi
+
+        {
+          echo "backend=$backend"
+          echo "frontend=$frontend"
+          echo "docker=$docker"
+          echo "ci_config=$ci_config"
+        } >> "$GITHUB_OUTPUT"
+
   backend-quality:
     name: Backend Quality
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.ci_config == 'true'
 
     services:
       postgres:
@@ -135,6 +215,8 @@ jobs:
     name: Backend Test Shard ${{ matrix.shard_number }}/${{ matrix.total_shards }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.ci_config == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -260,7 +342,8 @@ jobs:
     name: Verify OpenAPI Types
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [backend-quality]
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.ci_config == 'true'
     defaults:
       run:
         working-directory: ./frontend
@@ -285,8 +368,8 @@ jobs:
   test-backend:
     name: Backend Tests
     runs-on: ubuntu-latest
-    needs: [backend-quality, backend-test-shards, verify-openapi-types]
-    if: always()
+    needs: [changes, backend-quality, backend-test-shards, verify-openapi-types]
+    if: always() && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.ci_config == 'true')
     steps:
     - name: Check backend quality, OpenAPI types, and test shards
       run: |
@@ -316,6 +399,8 @@ jobs:
   test-frontend:
     name: Frontend Tests
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.ci_config == 'true'
     defaults:
       run:
         working-directory: ./frontend
@@ -357,6 +442,8 @@ jobs:
   test-frontend-e2e:
     name: Frontend E2E
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.ci_config == 'true'
     defaults:
       run:
         working-directory: ./frontend
@@ -427,7 +514,8 @@ jobs:
   build-test:
     name: Test Docker Build
     runs-on: ubuntu-latest
-    needs: [test-backend, test-frontend, test-frontend-e2e]
+    needs: [changes, test-backend, test-frontend, test-frontend-e2e]
+    if: always() && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.docker == 'true' || needs.changes.outputs.ci_config == 'true')
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Closes #287.\n\nAdds a lightweight change-detection job to the main CI workflow, then gates expensive backend, frontend, E2E, OpenAPI, and Docker build jobs by changed area. Security scanning remains active.\n\nImportant behaviour:\n- backend code/dependency/CI-script changes still run backend quality, shards, OpenAPI verification, and Docker build\n- frontend changes still run frontend tests, frontend E2E, OpenAPI verification, and Docker build\n- Docker/runtime build input changes still run Docker build\n- CI workflow/script changes still force the full matrix\n- docs-only and CD-workflow-only PRs emit skipped required contexts instead of running the expensive app matrix\n\nVerification:\n- actionlint .github/workflows/ci.yml\n- ruby YAML parse\n- git diff --check\n- local classifier simulations for CD-workflow-only and app/Docker/CI changes