### PR TITLE
ci: speed up backend shards

### DIFF
--- a/.github/scripts/run-pytest-shard.sh
+++ b/.github/scripts/run-pytest-shard.sh
@@ -46,7 +46,10 @@ print(f"Collected {len(nodeids)} tests; selected {len(selected)} for shard {shar
 PY
 echo "::endgroup::"
 
-mapfile -t selected_nodeids <"$selected_file"
+selected_nodeids=()
+while IFS= read -r nodeid; do
+  selected_nodeids+=("$nodeid")
+done <"$selected_file"
 
 if (( ${#selected_nodeids[@]} == 0 )); then
   echo "::error::No tests selected for shard $((shard_index + 1))/$total_shards."
@@ -64,5 +67,4 @@ python -m pytest \
   --cov-report=term-missing \
   --cov-fail-under=0 \
   --durations=25 \
-  --verbose \
-  --migrations
+  --verbose


### PR DESCRIPTION
Closes #218.\n\n## Summary\n- stop forcing Django migrations inside every backend test shard; the shard runner now honours the project pytest config's --nomigrations setting\n- keep migration coverage in the existing Backend Quality migration smoke via bootstrap-backend-ci-db.sh\n- replace mapfile with a Bash 3-compatible read loop so the shard wrapper can be run locally on macOS as well as Ubuntu CI\n\n## Verification\n- git diff --check\n- bash -n .github/scripts/run-pytest-shard.sh\n- local wrapper smoke: run-pytest-shard.sh 0 1 core/test_observability.py -> 5 passed in 4.11s