### PR TITLE
fix: avoid storing OAuth refresh tokens

### DIFF
--- a/app/sso/oauth_backends.py
+++ b/app/sso/oauth_backends.py
@@ -3,6 +3,7 @@ OAuth 2.0 / OpenID Connect authentication backend.
 """
 
 import logging
+import uuid
 from typing import Any
 import requests
 import jwt
@@ -81,7 +82,7 @@ class OAuthBackend(BaseBackend):
                 sso_session = SSOSession.objects.create(
                     user=user,
                     sso_provider=sso_provider,
-                    sso_session_id=token_data.get("refresh_token", ""),
+                    sso_session_id=f"oauth-{uuid.uuid4()}",
                     ip_address=SSOAuditLog.get_client_ip(request),
                     user_agent=request.META.get("HTTP_USER_AGENT", ""),
                     expires_at=self._calculate_token_expiry(token_data),

--- a/app/sso/test_oauth_backend.py
+++ b/app/sso/test_oauth_backend.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from uuid import uuid4
+from unittest.mock import Mock, patch
+
+from sso.oauth_backends import OAuthBackend
+
+
+def test_oauth_backend_does_not_store_provider_refresh_token():
+    tenant = SimpleNamespace(id=1)
+    oauth_config = SimpleNamespace()
+    sso_provider = SimpleNamespace(
+        id=uuid4(),
+        name="OIDC",
+        oauth_config=oauth_config,
+    )
+    user = SimpleNamespace(email="oauth-user@example.com")
+    sso_session = SimpleNamespace(id=uuid4())
+    request = SimpleNamespace(
+        META={
+            "HTTP_USER_AGENT": "pytest",
+            "REMOTE_ADDR": "127.0.0.1",
+        },
+        session={},
+    )
+    token_data = {
+        "access_token": "access-token",
+        "refresh_token": "provider-refresh-token",
+        "token_type": "Bearer",
+    }
+
+    with (
+        patch("sso.oauth_backends.get_tenant_from_request", return_value=tenant),
+        patch("sso.oauth_backends.SSOProvider.objects.get", return_value=sso_provider),
+        patch(
+            "sso.oauth_backends.SSOSession.objects.create", return_value=sso_session
+        ) as create_session,
+        patch.object(OAuthBackend, "_exchange_code_for_token", return_value=token_data),
+        patch.object(OAuthBackend, "_get_user_info", return_value={"email": user.email}),
+        patch.object(OAuthBackend, "_get_or_create_user", return_value=user),
+        patch("sso.oauth_backends.SSOAuditLog.get_client_ip", return_value="127.0.0.1"),
+        patch("sso.oauth_backends.SSOAuditLog.log_event"),
+    ):
+        authenticated_user = OAuthBackend().authenticate(
+            request,
+            oauth_code="auth-code",
+            oauth_provider_id=sso_provider.id,
+        )
+
+    assert authenticated_user == user
+    assert create_session.call_count == 1
+    created_session_id = create_session.call_args.kwargs["sso_session_id"]
+    assert created_session_id.startswith("oauth-")
+    assert created_session_id != "provider-refresh-token"
+    assert request.session["sso_session_id"] == str(sso_session.id)


### PR DESCRIPTION
Closes #293.\n\n## Summary\n- Replace provider refresh-token persistence in SSOSession.sso_session_id with an opaque local oauth-<uuid> identifier.\n- Add a focused OAuthBackend regression test proving the provider refresh token is never stored as the local SSO session id.\n\n## Verification\n- VIRTUAL_ENV=/private/tmp/enterprise-grc-schema-venv312 .github/scripts/run-mypy.sh -> Success: no issues found in 33 source files\n- ruff check app/sso/oauth_backends.py app/sso/test_oauth_backend.py\n- ruff format --check app/sso/oauth_backends.py app/sso/test_oauth_backend.py\n- pytest sso/test_oauth_backend.py sso/test_transform_expressions.py -q -> 4 passed