### PR TITLE
Fix remaining CodeQL and Dockerfile scanning alerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # Install build dependencies
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libpq-dev \
@@ -23,9 +24,9 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Install Python dependencies
-COPY requirements.txt .
-RUN pip install --upgrade pip && \
-    pip install -r requirements.txt
+WORKDIR /build
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Production stage
 FROM python:3.12-slim AS production
@@ -58,6 +59,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     BUILD_COMMIT=${BUILD_COMMIT}
 
 # Install runtime dependencies
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 \
     libmagic1 \

--- a/app/analytics/views.py
+++ b/app/analytics/views.py
@@ -33,6 +33,10 @@ from billing.decorators import require_advanced_reporting
 logger = logging.getLogger(__name__)
 
 
+def _log_api_error(message: str, *args: object) -> None:
+    logger.error(message, *args, exc_info=settings.DEBUG)
+
+
 def _is_operator(user, tenant):
     public_schema_name = getattr(settings, "PUBLIC_SCHEMA_NAME", "public")
     return bool(
@@ -111,7 +115,7 @@ def executive_dashboard(request):
         data = CrossModuleAnalyticsService.get_executive_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
     except Exception:
-        logger.exception("Error generating executive dashboard")
+        _log_api_error("Error generating executive dashboard")
         return Response(
             {"error": "Failed to generate executive dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -140,7 +144,7 @@ def compliance_dashboard(request):
         data = CrossModuleAnalyticsService.get_compliance_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
     except Exception:
-        logger.exception("Error generating compliance dashboard")
+        _log_api_error("Error generating compliance dashboard")
         return Response(
             {"error": "Failed to generate compliance dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -169,7 +173,7 @@ def vendor_risk_dashboard(request):
         data = CrossModuleAnalyticsService.get_vendor_risk_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
     except Exception:
-        logger.exception("Error generating vendor dashboard")
+        _log_api_error("Error generating vendor dashboard")
         return Response(
             {"error": "Failed to generate vendor dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -198,7 +202,7 @@ def policy_management_dashboard(request):
         data = CrossModuleAnalyticsService.get_policy_management_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
     except Exception:
-        logger.exception("Error generating policy dashboard")
+        _log_api_error("Error generating policy dashboard")
         return Response(
             {"error": "Failed to generate policy dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -227,7 +231,7 @@ def training_effectiveness_dashboard(request):
         data = CrossModuleAnalyticsService.get_training_effectiveness_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
     except Exception:
-        logger.exception("Error generating training dashboard")
+        _log_api_error("Error generating training dashboard")
         return Response(
             {"error": "Failed to generate training dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -258,7 +262,7 @@ def integrated_risk_posture(request):
         data = CrossModuleAnalyticsService.get_integrated_risk_posture()
         return Response(data, status=status.HTTP_200_OK)
     except Exception:
-        logger.exception("Error generating integrated risk posture")
+        _log_api_error("Error generating integrated risk posture")
         return Response(
             {"error": "Failed to generate integrated risk analysis"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -289,7 +293,7 @@ def executive_report_data(request):
         data = AnalyticsReportGenerator.generate_executive_report_data()
         return Response(data, status=status.HTTP_200_OK)
     except Exception:
-        logger.exception("Error generating executive report")
+        _log_api_error("Error generating executive report")
         return Response(
             {"error": "Failed to generate executive report"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -318,7 +322,7 @@ def operational_dashboard(request):
         data = AnalyticsReportGenerator.generate_operational_dashboard_data()
         return Response(data, status=status.HTTP_200_OK)
     except Exception:
-        logger.exception("Error generating operational dashboard")
+        _log_api_error("Error generating operational dashboard")
         return Response(
             {"error": "Failed to generate operational dashboard"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -364,7 +368,7 @@ def analytics_health_check(request):
         return Response(health_data, status=status.HTTP_200_OK)
 
     except Exception:
-        logger.exception("Analytics health check failed")
+        _log_api_error("Analytics health check failed")
         return Response(
             {
                 "status": "unhealthy",
@@ -453,7 +457,7 @@ def export_report(request):
         )
 
     except Exception:
-        logger.exception("Error creating export job")
+        _log_api_error("Error creating export job")
         return Response(
             {"error": "Failed to create export job"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -511,7 +515,7 @@ def report_status(request, report_id):
         return Response(response_data)
 
     except Exception:
-        logger.exception("Error checking report status %s", report_id)
+        _log_api_error("Error checking report status %s", report_id)
         return Response(
             {"error": "Failed to check report status"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -595,7 +599,7 @@ def download_report(request, report_id):
         return response
 
     except Exception:
-        logger.exception("Error downloading report %s", report_id)
+        _log_api_error("Error downloading report %s", report_id)
         return Response(
             {"error": "Failed to download report"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -667,7 +671,7 @@ def my_reports(request):
         )
 
     except Exception:
-        logger.exception("Error fetching user reports")
+        _log_api_error("Error fetching user reports")
         return Response(
             {"error": "Failed to fetch reports"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -698,7 +702,11 @@ def delete_report(request, report_id):
             try:
                 default_storage.delete(report.file_path)
             except Exception:
-                logger.warning("Failed to delete file for report %s", report_id, exc_info=True)
+                logger.warning(
+                    "Failed to delete file for report %s",
+                    report_id,
+                    exc_info=settings.DEBUG,
+                )
 
         # Delete the report record
         report.delete()
@@ -708,7 +716,7 @@ def delete_report(request, report_id):
         return Response({"message": "Report deleted successfully"})
 
     except Exception:
-        logger.exception("Error deleting report %s", report_id)
+        _log_api_error("Error deleting report %s", report_id)
         return Response(
             {"error": "Failed to delete report"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -750,7 +758,7 @@ def refresh_cache(request):
         )
 
     except Exception:
-        logger.exception("Error queuing cache refresh")
+        _log_api_error("Error queuing cache refresh")
         return Response(
             {"error": "Failed to refresh cache"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )

--- a/app/risk/serializers.py
+++ b/app/risk/serializers.py
@@ -1,3 +1,6 @@
+import logging
+
+from django.conf import settings
 from rest_framework import serializers
 from drf_spectacular.utils import extend_schema_field
 from django.contrib.auth import get_user_model
@@ -14,6 +17,7 @@ from .models import (
 )
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 class RiskCategorySerializer(serializers.ModelSerializer):
@@ -432,9 +436,14 @@ class BulkRiskCreateSerializer(serializers.Serializer):
                     )
                     created_risks.append(risk)
 
-                except Exception as e:
+                except Exception:
+                    logger.error("Bulk risk creation failed for one item", exc_info=settings.DEBUG)
                     errors.append(
-                        {"index": i, "title": risk_data.get("title", ""), "error": str(e)}
+                        {
+                            "index": i,
+                            "title": risk_data.get("title", ""),
+                            "error": "Unable to create risk.",
+                        }
                     )
 
         return created_risks, errors
@@ -907,9 +916,17 @@ class RiskActionBulkCreateSerializer(serializers.Serializer):
                             action, action.assigned_to, self.context["request"].user
                         )
 
-                except Exception as e:
+                except Exception:
+                    logger.error(
+                        "Bulk risk action creation failed for one item",
+                        exc_info=settings.DEBUG,
+                    )
                     errors.append(
-                        {"index": i, "title": action_data.get("title", ""), "error": str(e)}
+                        {
+                            "index": i,
+                            "title": action_data.get("title", ""),
+                            "error": "Unable to create risk action.",
+                        }
                     )
 
         return created_actions, errors

--- a/app/risk/tests/test_bulk_error_sanitisation.py
+++ b/app/risk/tests/test_bulk_error_sanitisation.py
@@ -1,0 +1,96 @@
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from ..models import Risk, RiskAction, RiskCategory
+from ..serializers import BulkRiskCreateSerializer, RiskActionBulkCreateSerializer
+
+User = get_user_model()
+
+
+class BulkErrorSanitisationTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="bulk-security-user",
+            email="bulk-security@example.com",
+            password="testpass123",
+        )
+        self.category = RiskCategory.objects.create(name="Bulk Security")
+        self.risk = Risk.objects.create(
+            title="Existing risk",
+            description="Existing risk description",
+            category=self.category,
+            risk_owner=self.user,
+            impact=3,
+            likelihood=3,
+            status="assessed",
+        )
+        self.request = type("Request", (), {"user": self.user})()
+
+    def test_bulk_risk_errors_do_not_expose_internal_exception_text(self):
+        serializer = BulkRiskCreateSerializer(
+            data={
+                "category": self.category.pk,
+                "risk_owner": self.user.pk,
+                "risks": [
+                    {
+                        "title": "Sensitive failure",
+                        "description": "This row will fail",
+                    }
+                ],
+            },
+            context={"request": self.request},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        with patch.object(Risk.objects, "create", side_effect=RuntimeError("password=secret")):
+            created_risks, errors = serializer.create_bulk_risks()
+
+        self.assertEqual(created_risks, [])
+        self.assertEqual(
+            errors,
+            [
+                {
+                    "index": 0,
+                    "title": "Sensitive failure",
+                    "error": "Unable to create risk.",
+                }
+            ],
+        )
+
+    def test_bulk_risk_action_errors_do_not_expose_internal_exception_text(self):
+        serializer = RiskActionBulkCreateSerializer(
+            data={
+                "risk": self.risk.pk,
+                "actions": [
+                    {
+                        "title": "Sensitive action failure",
+                        "description": "This action will fail",
+                        "due_date": (date.today() + timedelta(days=7)).isoformat(),
+                    }
+                ],
+            },
+            context={"request": self.request},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        with patch.object(
+            RiskAction.objects,
+            "create",
+            side_effect=RuntimeError("api_key=secret"),
+        ):
+            created_actions, errors = serializer.create_bulk_actions()
+
+        self.assertEqual(created_actions, [])
+        self.assertEqual(
+            errors,
+            [
+                {
+                    "index": 0,
+                    "title": "Sensitive action failure",
+                    "error": "Unable to create risk action.",
+                }
+            ],
+        )

--- a/app/risk/views.py
+++ b/app/risk/views.py
@@ -2,6 +2,7 @@ import logging
 from rest_framework import viewsets, status, filters, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from django.conf import settings
 from django_filters.rest_framework import DjangoFilterBackend
 from django.db.models import Count, Q, Case, When, Value, IntegerField, F
 from django.utils import timezone
@@ -63,6 +64,10 @@ from .audit import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _log_api_error(message: str, *args: object) -> None:
+    logger.error(message, *args, exc_info=settings.DEBUG)
 
 
 @extend_schema_view(
@@ -1402,7 +1407,7 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
             dashboard_data = RiskReportGenerator.generate_risk_dashboard_data()
             return Response(dashboard_data)
         except Exception:
-            logger.exception("Failed to generate risk dashboard data")
+            _log_api_error("Failed to generate risk dashboard data")
             return Response(
                 {"error": "Failed to generate dashboard data"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1431,7 +1436,7 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
             overview_data = RiskAnalyticsService.get_risk_overview_stats()
             return Response(overview_data)
         except Exception:
-            logger.exception("Failed to generate risk overview")
+            _log_api_error("Failed to generate risk overview")
             return Response(
                 {"error": "Failed to generate risk overview"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1460,7 +1465,7 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
             action_data = RiskAnalyticsService.get_risk_action_overview_stats()
             return Response(action_data)
         except Exception:
-            logger.exception("Failed to generate risk action overview")
+            _log_api_error("Failed to generate risk action overview")
             return Response(
                 {"error": "Failed to generate action overview"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1489,7 +1494,7 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
             heat_map_data = RiskAnalyticsService.get_risk_heat_map_data()
             return Response(heat_map_data)
         except Exception:
-            logger.exception("Failed to generate risk heat map")
+            _log_api_error("Failed to generate risk heat map")
             return Response(
                 {"error": "Failed to generate heat map"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1531,7 +1536,7 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except Exception:
-            logger.exception("Failed to generate risk trend analysis")
+            _log_api_error("Failed to generate risk trend analysis")
             return Response(
                 {"error": "Failed to generate trend analysis"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1560,7 +1565,7 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
             progress_data = RiskAnalyticsService.get_risk_action_progress_analysis()
             return Response(progress_data)
         except Exception:
-            logger.exception("Failed to generate risk action progress analysis")
+            _log_api_error("Failed to generate risk action progress analysis")
             return Response(
                 {"error": "Failed to generate progress analysis"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1590,7 +1595,7 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
             executive_data = RiskAnalyticsService.get_executive_risk_summary()
             return Response(executive_data)
         except Exception:
-            logger.exception("Failed to generate executive risk summary")
+            _log_api_error("Failed to generate executive risk summary")
             return Response(
                 {"error": "Failed to generate executive summary"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1620,7 +1625,7 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
             integration_data = RiskAnalyticsService.get_risk_control_integration_analysis()
             return Response(integration_data)
         except Exception:
-            logger.exception("Failed to generate risk-control integration analysis")
+            _log_api_error("Failed to generate risk-control integration analysis")
             return Response(
                 {"error": "Failed to generate control integration analysis"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1663,7 +1668,7 @@ class RiskAnalyticsViewSet(viewsets.ViewSet):
             category_data = RiskReportGenerator.get_risk_category_deep_dive(category_id)
             return Response(category_data)
         except Exception:
-            logger.exception("Failed to generate risk category analysis")
+            _log_api_error("Failed to generate risk category analysis")
             return Response(
                 {"error": "Failed to generate category analysis"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/app/sso/oauth_backends.py
+++ b/app/sso/oauth_backends.py
@@ -21,6 +21,14 @@ User = get_user_model()
 logger = logging.getLogger(__name__)
 
 
+def _log_oauth_error(message: str, *args: object) -> None:
+    logger.error(message, *args, exc_info=settings.DEBUG)
+
+
+def _log_oauth_warning(message: str, *args: object) -> None:
+    logger.warning(message, *args, exc_info=settings.DEBUG)
+
+
 class OAuthBackend(BaseBackend):
     """
     OAuth 2.0 / OpenID Connect authentication backend.
@@ -104,15 +112,15 @@ class OAuthBackend(BaseBackend):
                 return user
 
         except SSOProvider.DoesNotExist:
-            logger.error(f"SSO provider {oauth_provider_id} not found")
-        except Exception as e:
-            logger.error(f"OAuth authentication error: {str(e)}")
+            logger.error("SSO provider not found for OAuth authentication")
+        except Exception:
+            _log_oauth_error("OAuth authentication failed")
             SSOAuditLog.log_event(
                 "error",
-                f"OAuth authentication error: {str(e)}",
+                "OAuth authentication failed",
                 request=request,
                 success=False,
-                error_message=str(e),
+                error_message="OAuth authentication failed.",
             )
 
         return None
@@ -153,11 +161,11 @@ class OAuthBackend(BaseBackend):
             if response.status_code == 200:
                 return response.json()
             else:
-                logger.error(f"Token exchange failed: {response.status_code} {response.text}")
+                logger.error("OAuth token exchange failed with status %s", response.status_code)
                 return None
 
-        except Exception as e:
-            logger.error(f"Token exchange error: {str(e)}")
+        except Exception:
+            _log_oauth_error("OAuth token exchange failed")
             return None
 
     def _get_user_info(self, oauth_config, access_token, id_token=None):
@@ -175,8 +183,8 @@ class OAuthBackend(BaseBackend):
                         options={"verify_signature": False},  # DO NOT DO THIS IN PRODUCTION
                     )
                     return decoded_token
-                except Exception as e:
-                    logger.warning(f"Failed to decode ID token: {str(e)}")
+                except Exception:
+                    _log_oauth_warning("Failed to decode OAuth ID token")
 
             # Fall back to UserInfo endpoint
             if oauth_config.userinfo_url:
@@ -195,8 +203,8 @@ class OAuthBackend(BaseBackend):
                     logger.error(f"UserInfo request failed: {response.status_code}")
                     return None
 
-        except Exception as e:
-            logger.error(f"Failed to get user info: {str(e)}")
+        except Exception:
+            _log_oauth_error("Failed to get OAuth user info")
             return None
 
     def _calculate_token_expiry(self, token_data):
@@ -234,7 +242,7 @@ class OAuthBackend(BaseBackend):
             if sso_provider.enable_jit_provisioning:
                 return provision_user_from_sso(sso_provider, user_info, email, request)
             else:
-                logger.warning(f"JIT provisioning disabled for {email}")
+                logger.warning("JIT provisioning disabled for OAuth user")
                 return None
 
     def _get_user_attribute(self, sso_provider, user_info, field_name):
@@ -260,8 +268,8 @@ class OAuthBackend(BaseBackend):
             if updated:
                 user.save()
 
-        except Exception as e:
-            logger.error(f"Failed to update user from OAuth info: {str(e)}")
+        except Exception:
+            _log_oauth_error("Failed to update user from OAuth info")
 
     def get_user(self, user_id):
         """
@@ -313,8 +321,8 @@ class OAuthClient:
             response = requests.get(discovery_url, timeout=30)
             if response.status_code == 200:
                 return response.json()
-        except Exception as e:
-            logger.error(f"OIDC discovery failed: {str(e)}")
+        except Exception:
+            _log_oauth_error("OIDC discovery failed")
 
         return None
 

--- a/app/sso/test_oauth_backend.py
+++ b/app/sso/test_oauth_backend.py
@@ -1,3 +1,4 @@
+import logging
 from types import SimpleNamespace
 from uuid import uuid4
 from unittest.mock import Mock, patch
@@ -52,3 +53,31 @@ def test_oauth_backend_does_not_store_provider_refresh_token():
     assert created_session_id.startswith("oauth-")
     assert created_session_id != "provider-refresh-token"
     assert request.session["sso_session_id"] == str(sso_session.id)
+
+
+def test_token_exchange_does_not_log_provider_response_body(caplog):
+    oauth_config = SimpleNamespace(
+        client_id="client-id",
+        client_secret="client-secret",
+        sso_provider=SimpleNamespace(id=uuid4()),
+        token_url="https://idp.example.test/token",
+        verify_ssl=True,
+    )
+    request = SimpleNamespace(
+        build_absolute_uri=lambda path: f"https://app.example.test{path}",
+    )
+    response = Mock(status_code=400, text="access_token=secret-refresh-token")
+
+    caplog.set_level(logging.ERROR, logger="sso.oauth_backends")
+
+    with patch("sso.oauth_backends.requests.post", return_value=response):
+        token_data = OAuthBackend()._exchange_code_for_token(
+            oauth_config,
+            "auth-code",
+            request,
+        )
+
+    assert token_data is None
+    assert "OAuth token exchange failed with status 400" in caplog.text
+    assert "secret-refresh-token" not in caplog.text
+    assert "client-secret" not in caplog.text


### PR DESCRIPTION
Closes #297

## Summary
- Sanitise OAuth failure logging so provider responses, exception text, and user identifiers are not written to production logs or SSO audit error messages.
- Replace production `logger.exception` usage in analytics/risk API handlers with debug-only traceback logging.
- Stop bulk risk/action APIs returning raw exception strings in per-row error payloads.
- Resolve Dockerfile hadolint findings by removing the explicit pip upgrade, copying requirements into an explicit workdir, and documenting the apt pinning exceptions inline.

## Verification
- `ruff check app/sso/oauth_backends.py app/sso/test_oauth_backend.py app/analytics/views.py app/risk/views.py app/risk/serializers.py app/risk/tests/test_bulk_error_sanitisation.py`
- `ruff format --check app/sso/oauth_backends.py app/sso/test_oauth_backend.py app/analytics/views.py app/risk/views.py app/risk/serializers.py app/risk/tests/test_bulk_error_sanitisation.py`
- `VIRTUAL_ENV=/private/tmp/enterprise-grc-296-venv .github/scripts/run-mypy.sh`
- `pytest sso/test_oauth_backend.py risk/tests/test_bulk_error_sanitisation.py`
- `docker build -t enterprise-grc-security-cleanup:test .`
