### PR TITLE
Install fixed libexpat in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 \
+    libexpat1 \
     libmagic1 \
     libcairo2 \
     libpango-1.0-0 \


### PR DESCRIPTION
Closes #301

## Summary
- Explicitly install `libexpat1` in the runtime image so apt pulls Debian's fixed `2.8.2-1~deb13u1` package over the vulnerable base-layer copy.

## Verification
- `docker build -t enterprise-grc-trivy-libexpat:test .`
- `trivy image --severity CRITICAL,HIGH,MEDIUM --ignore-unfixed --scanners vuln --format table enterprise-grc-trivy-libexpat:test`

The rebuilt image reports 0 critical/high/medium vulnerabilities across the Debian layer and Python packages.
