### PR TITLE
fix: sanitise operator analytics errors

### DIFF
--- a/app/analytics/operator.py
+++ b/app/analytics/operator.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import logging
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime
@@ -16,6 +17,7 @@ from policies.models import PolicyAcknowledgment, PolicyDistribution
 from training.models import CampaignDelivery, VideoView
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -65,8 +67,14 @@ class OperatorProductAnalyticsService:
 
             try:
                 tenant_usage = self._tenant_usage(tenant)
-            except Exception as exc:  # pragma: no cover - defensive for partially migrated tenants
-                collection_errors.append({"tenant_schema": tenant.schema_name, "error": str(exc)})
+            except Exception:  # pragma: no cover - defensive for partially migrated tenants
+                logger.exception("Unable to collect analytics for tenant %s", tenant.id)
+                collection_errors.append(
+                    {
+                        "tenant_schema": tenant.schema_name,
+                        "error": "Unable to collect tenant usage.",
+                    }
+                )
                 tenant_usage = self._empty_usage()
 
             aggregate_usage.update(tenant_usage["usage_counts"])

--- a/app/analytics/tests.py
+++ b/app/analytics/tests.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest import mock
 
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
@@ -108,6 +109,18 @@ class OperatorProductAnalyticsTest(TestCase):
         self.assertNotIn("Secret audit export", response_text)
         self.assertNotIn("do not expose", response_text)
         self.assertTrue(dashboard["privacy"]["tenant_content_excluded"])
+
+    @mock.patch.object(OperatorProductAnalyticsService, "_tenant_usage")
+    def test_operator_dashboard_sanitises_tenant_collection_errors(self, tenant_usage):
+        tenant_usage.side_effect = RuntimeError("sensitive database details")
+
+        dashboard = OperatorProductAnalyticsService().build_dashboard()
+
+        self.assertEqual(
+            dashboard["collection_errors"][0]["error"],
+            "Unable to collect tenant usage.",
+        )
+        self.assertNotIn("sensitive database details", str(dashboard))
 
     def test_operator_endpoint_requires_staff_user(self):
         self.client.defaults["HTTP_HOST"] = self.tenant_a_domain


### PR DESCRIPTION
## Summary

- stop returning raw tenant collection exception messages from operator analytics
- retain diagnostic tracebacks in server-side logs only
- add regression coverage for sensitive error sanitisation

## Verification

- `ruff check app/analytics/operator.py app/analytics/tests.py`
- `ruff format --check app/analytics/operator.py app/analytics/tests.py`
- `pytest app/analytics/tests.py -q` — 5 passed
- `git diff --check`
