### PR TITLE
fix: reduce image vulnerability surface with stable Debian base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # Multi-stage Dockerfile for production-ready GRC Platform
 
 # Build stage
-FROM python:3.12-slim AS builder
+# Keep the OS release explicit. The unqualified slim tag moved from Bookworm
+# to Trixie, changing the vulnerability and native-library surface underneath
+# otherwise identical application builds.
+FROM python:3.12-slim-bookworm AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -29,7 +32,7 @@ COPY requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Production stage
-FROM python:3.12-slim AS production
+FROM python:3.12-slim-bookworm AS production
 
 # Build arguments
 ARG BUILD_ENV=production


### PR DESCRIPTION
Closes #304. Pin both Docker stages to python:3.12-slim-bookworm instead of the moving python:3.12-slim tag. Local Bookworm image build and Django/WeasyPrint/Psycopg imports pass. CI must provide the authoritative multi-architecture Trivy result before merge. This deliberately does not suppress unfixed findings; the existing xmlsec/lxml mismatch is pre-existing and remains separate.