### PR TITLE
fix: disambiguate tenant provisioning command

### DIFF
--- a/app/core/management/commands/provision_tenant.py
+++ b/app/core/management/commands/provision_tenant.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
-from core.models import Tenant, Domain
+
+from core.models import Domain, Tenant
 
 
 class Command(BaseCommand):
@@ -15,17 +16,13 @@ class Command(BaseCommand):
         slug = options["slug"]
         domain_name = options["domain"]
 
-        # Create tenant
         tenant = Tenant.objects.create(name=name, slug=slug, schema_name=slug)
-
-        # Create domain
-        domain = Domain.objects.create(domain=domain_name, tenant=tenant, is_primary=True)
+        Domain.objects.create(domain=domain_name, tenant=tenant, is_primary=True)
 
         self.stdout.write(
             self.style.SUCCESS(f'Successfully created tenant "{name}" with domain "{domain_name}"')
         )
 
-        # Run migrations for this tenant
         self.stdout.write("Running migrations for new tenant...")
         from django.core.management import call_command
 

--- a/app/core/test_management_commands.py
+++ b/app/core/test_management_commands.py
@@ -1,0 +1,8 @@
+from django.core.management import get_commands
+
+
+def test_tenant_management_commands_are_unambiguous():
+    commands = get_commands()
+
+    assert commands["create_tenant"] == "django_tenants"
+    assert commands["provision_tenant"] == "core"

--- a/docs/backlog/project_backlog.md
+++ b/docs/backlog/project_backlog.md
@@ -64,7 +64,7 @@
         4.  Users from one tenant cannot access data from another.
     *   **What was achieved:**
         1.  ✅ Full django-tenants integration with PostgreSQL schema isolation
-        2.  ✅ Automatic schema creation via `create_tenant` management command
+        2.  ✅ Automatic schema creation via `provision_tenant` management command
         3.  ✅ Tenant resolution via subdomain middleware (django-tenants)
         4.  ✅ Complete data isolation verified - users cannot cross-access tenants
         5.  ✅ Shared vs tenant app separation properly configured


### PR DESCRIPTION
Closes #295

- Rename the project command from `create_tenant` to `provision_tenant` because django-tenants owns the `create_tenant` command name.
- Update the backlog documentation.
- Add a command-resolution regression test.

Verified:
- `pytest app/core/test_management_commands.py -q` — 1 passed.
- `manage.py provision_tenant --help` exposes the expected positional arguments.
- Ruff clean.