### PR TITLE
fix: enable strict frontend type checking

### DIFF
--- a/frontend/src/app/risk/page.tsx
+++ b/frontend/src/app/risk/page.tsx
@@ -5,6 +5,7 @@ import { Card, Typography, Space, Button, Row, Col, Progress, Table, Tag, messag
 import { SafetyOutlined, PlusOutlined, ExclamationCircleOutlined, WarningOutlined, CheckCircleOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { useRouter } from 'next/navigation'
 import { Breadcrumb, KPICard, RiskKPICard, StatusTag, PriorityTag, Loading, ExportButton, FilterPanel } from '@/components/ui'
+import type { FilterValues } from '@/components/ui/FilterPanel'
 import { riskService, type Risk, type RiskCategory, type RiskFilters } from '@/lib/services/riskService'
 
 const { Title, Text } = Typography
@@ -28,8 +29,6 @@ interface RiskChoices {
   treatment_strategies?: ChoiceOption[]
 }
 
-type FilterValue = string | string[] | null | undefined
-type FilterValues = Record<string, FilterValue>
 type PaginationConfig = { current?: number; pageSize?: number }
 
 export default function RiskPage() {

--- a/frontend/src/app/vendors/page.tsx
+++ b/frontend/src/app/vendors/page.tsx
@@ -5,6 +5,7 @@ import { Card, Typography, Space, Button, Row, Col, Table, Tag, Progress, Avatar
 import { TeamOutlined, PlusOutlined, WarningOutlined, CheckCircleOutlined, ClockCircleOutlined } from '@ant-design/icons'
 import { useRouter } from 'next/navigation'
 import { Breadcrumb, VendorKPICard, KPICard, StatusTag, PriorityTag, Loading, ExportButton, FilterPanel } from '@/components/ui'
+import type { FilterValues } from '@/components/ui/FilterPanel'
 import { vendorService, type Vendor, type VendorCategory, type VendorFilters } from '@/lib/services/vendorService'
 
 const { Title, Text } = Typography
@@ -28,8 +29,6 @@ interface VendorChoices {
   vendor_type_choices?: ChoiceOption[]
 }
 
-type FilterValue = string | string[] | null | undefined
-type FilterValues = Record<string, FilterValue>
 type PaginationConfig = { current?: number; pageSize?: number }
 
 export default function VendorsPage() {

--- a/frontend/src/components/ui/FilterPanel.tsx
+++ b/frontend/src/components/ui/FilterPanel.tsx
@@ -9,9 +9,9 @@ import { useTheme } from '@/theme'
 const { Option } = Select
 const { RangePicker } = DatePicker
 
-type DateRangeValue = [Dayjs | null, Dayjs | null]
-type FilterValue = string | string[] | DateRangeValue | null | undefined
-type FilterValues = Record<string, FilterValue>
+export type DateRangeValue = [Dayjs | null, Dayjs | null]
+export type FilterValue = string | string[] | DateRangeValue | null | undefined
+export type FilterValues = Record<string, FilterValue>
 
 interface FilterOption {
   key: string

--- a/frontend/src/components/ui/StatusTag.tsx
+++ b/frontend/src/components/ui/StatusTag.tsx
@@ -199,6 +199,12 @@ interface StatusTagProps {
   onClick?: () => void;
 }
 
+type StatusConfig = {
+  color: string;
+  icon: React.ReactNode;
+  label: string;
+}
+
 export const StatusTag: React.FC<StatusTagProps> = ({
   status,
   context,
@@ -208,7 +214,7 @@ export const StatusTag: React.FC<StatusTagProps> = ({
   style,
   onClick
 }) => {
-  const config = StatusConfigs[context]?.[status];
+  const config = (StatusConfigs[context] as Record<string, StatusConfig> | undefined)?.[status];
 
   if (!config) {
     return (
@@ -282,7 +288,7 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
   size = 'default',
   showZero = false
 }) => {
-  const config = StatusConfigs[context]?.[status];
+  const config = (StatusConfigs[context] as Record<string, StatusConfig> | undefined)?.[status];
 
   if (!config) return null;
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,7 +8,7 @@
     ],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "noEmit": true,
     "incremental": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary
- enable strict TypeScript checking for the frontend
- share FilterPanel filter value types with risk and vendor pages, including date ranges
- type status configuration lookups without implicit any errors

## Verification
- `npm run type-check`
- `npm run lint`
- `npm run test:unit` (14 passed)

Closes #280