### PR TITLE
test: keep coverage configuration compatible

### DIFF
--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -10,7 +10,6 @@ addopts =
     --reuse-db
     --nomigrations
 filterwarnings =
-    ignore::django.utils.deprecation.RemovedInDjango50Warning
     ignore::DeprecationWarning
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ addopts = """
     --cov-fail-under=70
 """
 filterwarnings = [
-    "ignore::django.utils.deprecation.RemovedInDjango50Warning",
     "ignore::DeprecationWarning",
     "ignore::PendingDeprecationWarning",
 ]
@@ -101,7 +100,7 @@ markers = [
 ]
 
 [tool.coverage.run]
-source = "."
+source = ["."]
 omit = [
     "*/migrations/*",
     "*/venv/*",


### PR DESCRIPTION
## Summary
- remove the obsolete Django 5.0 warning class from both pytest configurations
- use the coverage.py-compatible list form for the source setting

This is the configuration groundwork for #83. It does not close #83: per-app floors and the currently excluded test suites remain follow-up work.

## Verification
- `core/test_management_commands.py` and `catalogs/test_catalogue_audit.py`: 5 passed
- `git diff --check`

Related #83