### PR TITLE
feat: prototype ReportLab assessment summaries

### DIFF
--- a/app/exports/pdf_renderers.py
+++ b/app/exports/pdf_renderers.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import io
+from datetime import date, datetime
+from typing import Any
+
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_CENTER
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import cm
+from reportlab.platypus import (
+    BaseDocTemplate,
+    Frame,
+    PageTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+
+class AssessmentSummaryPDFRenderer:
+    """Render assessment summaries without an HTML/CSS runtime."""
+
+    def render(self, context: dict[str, Any]) -> bytes:
+        buffer = io.BytesIO()
+        document = BaseDocTemplate(
+            buffer,
+            pagesize=A4,
+            leftMargin=2 * cm,
+            rightMargin=2 * cm,
+            topMargin=2 * cm,
+            bottomMargin=2 * cm,
+            title=str(context["report"].title),
+        )
+        frame = Frame(document.leftMargin, document.bottomMargin, document.width, document.height)
+        document.addPageTemplates(
+            [PageTemplate(id="assessment-summary", frames=[frame], onPage=self._draw_footer)]
+        )
+
+        styles = getSampleStyleSheet()
+        title_style = ParagraphStyle(
+            "ReportTitle", parent=styles["Title"], fontSize=20, leading=24, textColor="#0066CC"
+        )
+        subtitle_style = ParagraphStyle(
+            "ReportSubtitle", parent=styles["Normal"], fontSize=10, leading=14, textColor="#666666"
+        )
+        heading_style = ParagraphStyle(
+            "SectionHeading",
+            parent=styles["Heading2"],
+            fontSize=14,
+            leading=18,
+            textColor="#0066CC",
+        )
+        body_style = ParagraphStyle(
+            "ReportBody", parent=styles["BodyText"], fontSize=9, leading=12, textColor="#333333"
+        )
+        cell_style = ParagraphStyle(
+            "TableCell", parent=body_style, fontSize=7.5, leading=9, wordWrap="CJK"
+        )
+        cell_header_style = ParagraphStyle(
+            "TableHeader", parent=cell_style, fontName="Helvetica-Bold", textColor=colors.white
+        )
+        metric_style = ParagraphStyle(
+            "Metric",
+            parent=body_style,
+            alignment=TA_CENTER,
+            fontSize=16,
+            leading=19,
+            textColor="#0066CC",
+        )
+        metric_label_style = ParagraphStyle(
+            "MetricLabel", parent=body_style, alignment=TA_CENTER, fontSize=7.5, leading=9
+        )
+
+        report = context["report"]
+        framework = context.get("framework")
+        requested_by = report.requested_by.get_full_name() or report.requested_by.username
+        story = [Paragraph(str(report.title), title_style)]
+        framework_line = (
+            f"Framework: {framework.name} ({framework.short_name})"
+            if framework
+            else "Assessment Summary Report"
+        )
+        story.extend(
+            [
+                Paragraph(framework_line, subtitle_style),
+                Paragraph(
+                    f"Generated: {self._format_datetime(context.get('generated_at'))}",
+                    subtitle_style,
+                ),
+                Paragraph(f"Requested by: {requested_by}", subtitle_style),
+                Spacer(1, 0.7 * cm),
+            ]
+        )
+
+        if framework:
+            story.append(Paragraph("Executive Summary", heading_style))
+            evidence_stats = context.get("evidence_stats") or {}
+            metrics = [
+                (f"{context.get('completion_percentage', 0)}%", "Overall Completion"),
+                (context.get("total_assessments", 0), "Total Assessments"),
+                (context.get("completed_assessments", 0), "Completed"),
+                (context.get("overdue_assessments", 0), "Overdue"),
+                (evidence_stats.get("total_evidence", 0), "Evidence Items"),
+                (evidence_stats.get("primary_evidence", 0), "Primary Evidence"),
+            ]
+            metric_rows = []
+            for index in range(0, len(metrics), 3):
+                metric_rows.append(
+                    [
+                        [Paragraph(str(value), metric_style), Paragraph(label, metric_label_style)]
+                        for value, label in metrics[index : index + 3]
+                    ]
+                )
+            metric_table = Table(metric_rows, colWidths=[document.width / 3] * 3)
+            metric_table.setStyle(
+                TableStyle(
+                    [
+                        ("BOX", (0, 0), (-1, -1), 0.5, colors.HexColor("#DDDDDD")),
+                        ("INNERGRID", (0, 0), (-1, -1), 0.25, colors.HexColor("#EEEEEE")),
+                        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                        ("TOPPADDING", (0, 0), (-1, -1), 5),
+                        ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+                    ]
+                )
+            )
+            story.extend([metric_table, Spacer(1, 0.6 * cm)])
+
+        story.append(Paragraph("Assessment Status Breakdown", heading_style))
+        story.append(
+            self._assessment_table(context.get("assessments", []), cell_style, cell_header_style)
+        )
+
+        if report.include_overdue_items and context.get("overdue_assessments", 0) > 0:
+            story.extend(
+                [
+                    Spacer(1, 0.6 * cm),
+                    Paragraph("Overdue Items Requiring Attention", heading_style),
+                    Paragraph("The following assessments require immediate attention:", body_style),
+                    self._overdue_table(
+                        context.get("assessments", []), cell_style, cell_header_style
+                    ),
+                ]
+            )
+
+        document.build(story)
+        return buffer.getvalue()
+
+    @staticmethod
+    def _assessment_table(assessments, cell_style, header_style):
+        headers = ["Control ID", "Control Title", "Status", "Assigned To", "Due Date", "Evidence"]
+        rows = [[Paragraph(value, header_style) for value in headers]]
+        for assessment in assessments:
+            assigned_to = assessment.assigned_to
+            assigned_name = (
+                (assigned_to.get_full_name() or assigned_to.username)
+                if assigned_to
+                else "Unassigned"
+            )
+            rows.append(
+                [
+                    Paragraph(str(assessment.control.control_id), cell_style),
+                    Paragraph(str(assessment.control.name), cell_style),
+                    Paragraph(str(assessment.get_status_display()), cell_style),
+                    Paragraph(assigned_name, cell_style),
+                    Paragraph(
+                        assessment.due_date.isoformat() if assessment.due_date else "Not set",
+                        cell_style,
+                    ),
+                    Paragraph(str(assessment.evidence_links.count()), cell_style),
+                ]
+            )
+        table = Table(
+            rows,
+            repeatRows=1,
+            colWidths=[1.7 * cm, 5.2 * cm, 2.2 * cm, 3.1 * cm, 2.3 * cm, 1.4 * cm],
+        )
+        table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#0066CC")),
+                    ("GRID", (0, 0), (-1, -1), 0.25, colors.HexColor("#DDDDDD")),
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    (
+                        "ROWBACKGROUNDS",
+                        (0, 1),
+                        (-1, -1),
+                        [colors.white, colors.HexColor("#F5F5F5")],
+                    ),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 4),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+                ]
+            )
+        )
+        return table
+
+    @staticmethod
+    def _overdue_table(assessments, cell_style, header_style):
+        headers = ["Control ID", "Control Title", "Assigned To", "Due Date"]
+        rows = [[Paragraph(value, header_style) for value in headers]]
+        for assessment in assessments:
+            if (
+                assessment.status == "complete"
+                or not assessment.due_date
+                or assessment.due_date >= date.today()
+            ):
+                continue
+            assigned_to = assessment.assigned_to
+            assigned_name = (
+                (assigned_to.get_full_name() or assigned_to.username)
+                if assigned_to
+                else "Unassigned"
+            )
+            rows.append(
+                [
+                    Paragraph(str(assessment.control.control_id), cell_style),
+                    Paragraph(str(assessment.control.name), cell_style),
+                    Paragraph(assigned_name, cell_style),
+                    Paragraph(assessment.due_date.isoformat(), cell_style),
+                ]
+            )
+        table = Table(rows, repeatRows=1, colWidths=[2.5 * cm, 8.5 * cm, 4 * cm, 2.5 * cm])
+        table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#0066CC")),
+                    ("GRID", (0, 0), (-1, -1), 0.25, colors.HexColor("#DDDDDD")),
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ]
+            )
+        )
+        return table
+
+    @staticmethod
+    def _format_datetime(value: datetime | None) -> str:
+        return value.strftime("%B %d, %Y %I:%M %p") if value else "Unknown"
+
+    @staticmethod
+    def _draw_footer(canvas, document):
+        canvas.saveState()
+        canvas.setFont("Helvetica", 8)
+        canvas.setFillColor(colors.HexColor("#666666"))
+        canvas.drawCentredString(A4[0] / 2, 1.1 * cm, f"Page {document.page}")
+        canvas.restoreState()

--- a/app/exports/services.py
+++ b/app/exports/services.py
@@ -13,14 +13,12 @@ from django.core.files.base import ContentFile
 from django.apps import apps
 from django.db import models
 from openpyxl import Workbook
-from weasyprint import HTML, CSS
-from weasyprint.text.fonts import FontConfiguration
-
 from core.models import Document
 from catalogs.models import ControlAssessment, Framework, AssessmentEvidence
 from risk.analytics import RiskAnalyticsService, RiskReportGenerator
 from risk.models import Risk, RiskAction
 from .models import AssessmentReport, TenantDataExport
+from .pdf_renderers import AssessmentSummaryPDFRenderer
 from .audit import (
     assessment_report_display,
     audit_export_change,
@@ -423,7 +421,7 @@ class AssessmentReportGenerator:
 
     def __init__(self, report: AssessmentReport):
         self.report = report
-        self.font_config = FontConfiguration()
+        self.pdf_renderer = AssessmentSummaryPDFRenderer()
 
     def generate_report(self):
         """Generate the PDF report based on report type."""
@@ -431,10 +429,14 @@ class AssessmentReportGenerator:
             self.report.status = "processing"
             self.report.generation_started_at = timezone.now()
             self.report.save()
+            summary_context = None
 
             # Generate report based on type
             if self.report.report_type == "assessment_summary":
-                html_content = self._generate_assessment_summary()
+                summary_context = self._get_assessment_summary_context()
+                html_content = render_to_string(
+                    "exports/reports/assessment_summary.html", summary_context
+                )
             elif self.report.report_type == "detailed_assessment":
                 html_content = self._generate_detailed_assessment()
             elif self.report.report_type == "evidence_portfolio":
@@ -447,7 +449,11 @@ class AssessmentReportGenerator:
                 raise ValueError(f"Unknown report type: {self.report.report_type}")
 
             # Generate PDF
-            pdf_content = self._render_pdf(html_content)
+            pdf_content = (
+                self.pdf_renderer.render(summary_context)
+                if summary_context is not None
+                else self._render_pdf(html_content)
+            )
 
             # Save PDF as Document
             filename = self._generate_filename()
@@ -495,6 +501,11 @@ class AssessmentReportGenerator:
 
     def _generate_assessment_summary(self):
         """Generate assessment summary report HTML."""
+        return render_to_string(
+            "exports/reports/assessment_summary.html", self._get_assessment_summary_context()
+        )
+
+    def _get_assessment_summary_context(self):
         context = {
             "report": self.report,
             "framework": self.report.framework,
@@ -552,7 +563,7 @@ class AssessmentReportGenerator:
             assessments = self.report.assessments.all()
             context["assessments"] = assessments
 
-        return render_to_string("exports/reports/assessment_summary.html", context)
+        return context
 
     def _generate_detailed_assessment(self):
         """Generate detailed assessment report HTML."""
@@ -668,6 +679,10 @@ class AssessmentReportGenerator:
 
     def _render_pdf(self, html_content):
         """Convert HTML to PDF using WeasyPrint."""
+        from weasyprint import CSS, HTML
+        from weasyprint.text.fonts import FontConfiguration
+
+        font_config = FontConfiguration()
         # Define CSS for styling
         css_content = """
         @page {
@@ -779,14 +794,14 @@ class AssessmentReportGenerator:
         }
         """
 
-        css = CSS(string=css_content, font_config=self.font_config)
+        css = CSS(string=css_content, font_config=font_config)
         html = HTML(string=html_content)
 
         pdf_buffer = io.BytesIO()
         html.write_pdf(
             pdf_buffer,
             stylesheets=[css],
-            font_config=self.font_config,
+            font_config=font_config,
             presentational_hints=False,
         )
         pdf_buffer.seek(0)

--- a/app/exports/test_pdf_renderers.py
+++ b/app/exports/test_pdf_renderers.py
@@ -1,0 +1,46 @@
+from datetime import date, datetime
+from types import SimpleNamespace
+
+from exports.pdf_renderers import AssessmentSummaryPDFRenderer
+
+
+class EvidenceLinks:
+    def __init__(self, count):
+        self._count = count
+
+    def count(self):
+        return self._count
+
+
+def test_assessment_summary_renderer_returns_pdf():
+    user = SimpleNamespace(username="owner", get_full_name=lambda: "Report Owner")
+    control = SimpleNamespace(control_id="AC-1", name="Access control")
+    assessment = SimpleNamespace(
+        control=control,
+        status="in_progress",
+        get_status_display=lambda: "In progress",
+        assigned_to=user,
+        due_date=date.today(),
+        evidence_links=EvidenceLinks(2),
+    )
+    report = SimpleNamespace(
+        title="Assessment summary",
+        requested_by=user,
+        include_overdue_items=True,
+    )
+    context = {
+        "report": report,
+        "framework": SimpleNamespace(name="ISO 27001", short_name="ISO27001"),
+        "generated_at": datetime(2026, 8, 5, 10, 30),
+        "completion_percentage": 50.0,
+        "total_assessments": 2,
+        "completed_assessments": 1,
+        "overdue_assessments": 0,
+        "evidence_stats": {"total_evidence": 2, "primary_evidence": 1},
+        "assessments": [assessment],
+    }
+
+    pdf = AssessmentSummaryPDFRenderer().render(context)
+
+    assert pdf.startswith(b"%PDF-")
+    assert len(pdf) > 1000

--- a/app/exports/tests.py
+++ b/app/exports/tests.py
@@ -380,14 +380,10 @@ class AssessmentReportGeneratorTest(TestCase):
             assessment=self.assessment, evidence=self.evidence, is_primary_evidence=True
         )
 
-    @patch("exports.services.HTML")
-    @patch("exports.services.CSS")
-    def test_generate_assessment_summary(self, mock_css, mock_html):
+    @patch("exports.services.AssessmentSummaryPDFRenderer.render")
+    def test_generate_assessment_summary(self, mock_render):
         """Test generating assessment summary report."""
-        # Mock WeasyPrint components
-        mock_html_instance = MagicMock()
-        mock_html.return_value = mock_html_instance
-        mock_html_instance.write_pdf.return_value = None
+        mock_render.return_value = b"%PDF-1.4\nassessment summary\n%%EOF"
 
         report = AssessmentReport.objects.create(
             report_type="assessment_summary",
@@ -411,9 +407,10 @@ class AssessmentReportGeneratorTest(TestCase):
             self.assertEqual(event.details["actor"]["email"], self.user.email)
             self.assertEqual(event.details["new"]["status"], "completed")
             self.assertEqual(event.details["new"]["generated_file_id"], mock_document.id)
-            mock_html_instance.write_pdf.assert_called_once()
-            _, write_pdf_kwargs = mock_html_instance.write_pdf.call_args
-            self.assertFalse(write_pdf_kwargs["presentational_hints"])
+            mock_render.assert_called_once()
+            render_context = mock_render.call_args.args[0]
+            self.assertEqual(render_context["report"], report)
+            self.assertEqual(render_context["framework"], self.framework)
 
     def test_generate_detailed_assessment(self):
         """Test generating detailed assessment report HTML."""

--- a/docs/adr/0040-pdf-renderer-evaluation.md
+++ b/docs/adr/0040-pdf-renderer-evaluation.md
@@ -1,0 +1,32 @@
+# ADR-0040: PDF Renderer Evaluation
+
+- Status: Proposed
+- Date: 2026-08-05
+- Decision scope: assessment report generation
+
+## Context
+
+The platform currently uses WeasyPrint to render all assessment-report HTML templates. This preserves CSS well, but it adds native Cairo/Pango dependencies to the production image and is subject to the presentational-hints advisory tracked in issue #129. The application already declares ReportLab and its assessment reports are structured documents containing headings, metrics and tables.
+
+## Decision
+
+Prototype ReportLab for the assessment-summary report first. The prototype renders the report title and metadata, executive metrics, assessment table, overdue table and page numbers without an HTML/CSS runtime.
+
+Keep WeasyPrint for the other report types during the evaluation. Removing it before parity has been demonstrated would create a regression risk for detailed assessment, evidence portfolio, compliance-gap and risk-analytics reports.
+
+## Rationale
+
+ReportLab is a better operational fit for structured compliance reports:
+
+- no browser process or additional rendering service;
+- no Cairo/Pango runtime dependency;
+- deterministic pagination for tables;
+- already present in the Python dependency set.
+
+Playwright/Chromium remains a possible alternative if visual parity with the existing HTML templates becomes more important than image size and runtime complexity. It should be evaluated separately rather than introduced alongside this prototype.
+
+## Consequences
+
+- The assessment-summary path now has an independent renderer that can be tested without WeasyPrint.
+- The remaining report types still require WeasyPrint and the existing presentational_hints=False mitigation.
+- A follow-up migration slice must compare generated PDFs for content, pagination and styling before the dependency can be removed.


### PR DESCRIPTION
## Summary
a ReportLab renderer for assessment-summary PDFs\n- preserve the existing HTML/WeasyPrint path for the other report types during evaluation\n- lazy-load WeasyPrint so the new path does not initialise Cairo/Pango\n- add an ADR documenting the renderer trade-offs and follow-up parity work\n\n## Verification\n- ReportLab renderer generated a valid PDF locally\n- pure renderer test passes\n- Ruff, compileall and diff checks pass\n- full Django tests require the tenant-aware CI environment\n\nPartially addresses #129. WeasyPrint remains in place until all report types have verified content, pagination and styling parity.