### PR TITLE
feat: standardise GRC page headers

### DIFF
--- a/frontend/src/app/assessments/page.tsx
+++ b/frontend/src/app/assessments/page.tsx
@@ -1,32 +1,23 @@
 'use client'
 
 import React from 'react'
-import { Card, Typography, Space, Button } from 'antd'
+import { Card, Space, Button } from 'antd'
 import { CheckSquareOutlined, PlusOutlined } from '@ant-design/icons'
-
-const { Title, Text } = Typography
+import { PageHeader } from '@/components/ui'
 
 export default function AssessmentsPage() {
   return (
     <div>
-      <div style={{ marginBottom: 24 }}>
-        <Title level={2}>
-          <CheckSquareOutlined style={{ marginRight: 8 }} />
-          Compliance Assessments
-        </Title>
-        <Text type="secondary">
-          Conduct and track compliance assessments across frameworks
-        </Text>
-      </div>
+      <PageHeader eyebrow="ASSURANCE PROGRAMME" title="Compliance assessments" description="Conduct and track compliance assessments across frameworks." icon={<CheckSquareOutlined />} actions={<Button type="primary" icon={<PlusOutlined />}>Start assessment</Button>} />
 
       <Card>
         <div style={{ textAlign: 'center', padding: '50px 0' }}>
           <CheckSquareOutlined style={{ fontSize: '64px', color: '#1890ff', marginBottom: 16 }} />
-          <Title level={3}>Compliance Assessment Center</Title>
-          <Text type="secondary" style={{ display: 'block', marginBottom: 24 }}>
+          <h2>Compliance Assessment Center</h2>
+          <p style={{ display: 'block', marginBottom: 24 }}>
             Manage compliance assessments for various frameworks including
             SOC 2, ISO 27001, NIST CSF, and custom organizational standards.
-          </Text>
+          </p>
           <Space>
             <Button type="primary" icon={<PlusOutlined />}>
               Start Assessment

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,5 +1,15 @@
 body { margin: 0; }
 
+.page-header { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin: 4px 0 28px; padding-bottom: 22px; border-bottom: 1px solid var(--line, #dce7e5); }
+.page-header-copy { min-width: 0; }
+.page-header-eyebrow { display: block; margin-bottom: 10px; color: var(--teal-deep, #08756d); font-size: 10px; font-weight: 700; letter-spacing: .14em; line-height: 1.2; text-transform: uppercase; }
+.page-header-title { display: flex; align-items: center; gap: 10px; margin: 0 !important; color: var(--ink, #102b2e) !important; font-size: 30px !important; line-height: 1.12 !important; letter-spacing: 0; }
+.page-header-icon { display: inline-flex; color: var(--teal, #0b8f84); font-size: 25px; }
+.page-header-description { display: block; max-width: 680px; margin-top: 9px; color: var(--ink-soft, #466166); font-size: 14px; line-height: 1.5; }
+.page-header-actions { display: flex; align-items: center; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }
+html.dark-mode .page-header { --line: #35504e; --ink: #e8f2ef; --ink-soft: #b4c8c4; --teal: #61c2b5; --teal-deep: #7bd2c6; }
+@media (max-width: 760px) { .page-header { display: block; margin-bottom: 22px; }.page-header-actions { justify-content: flex-start; margin-top: 18px; }.page-header-title { font-size: 26px !important; } }
+
 :root {
   --ink: #102b2e;
   --ink-soft: #466166;

--- a/frontend/src/app/risk/page.tsx
+++ b/frontend/src/app/risk/page.tsx
@@ -4,11 +4,11 @@ import React, { useCallback, useRef, useState, useEffect } from 'react'
 import { Card, Typography, Space, Button, Row, Col, Progress, Table, Tag, message, Modal, Form, Input, Select } from 'antd'
 import { SafetyOutlined, PlusOutlined, ExclamationCircleOutlined, WarningOutlined, CheckCircleOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { useRouter } from 'next/navigation'
-import { Breadcrumb, KPICard, RiskKPICard, StatusTag, PriorityTag, Loading, ExportButton, FilterPanel } from '@/components/ui'
+import { Breadcrumb, KPICard, RiskKPICard, StatusTag, PriorityTag, Loading, ExportButton, FilterPanel, PageHeader } from '@/components/ui'
 import type { FilterValues } from '@/components/ui/FilterPanel'
 import { riskService, type Risk, type RiskCategory, type RiskFilters } from '@/lib/services/riskService'
 
-const { Title, Text } = Typography
+const { Text } = Typography
 
 interface RiskAnalytics {
   totalRisks: number
@@ -315,15 +315,7 @@ export default function RiskPage() {
         ]}
       />
 
-      <div style={{ marginBottom: 24 }}>
-        <Title level={2}>
-          <SafetyOutlined style={{ marginRight: 8 }} />
-          Risk Management
-        </Title>
-        <Text type="secondary">
-          Identify, assess, and manage organizational risks across the enterprise
-        </Text>
-      </div>
+      <PageHeader eyebrow="RISK & RESILIENCE" title="Risk management" description="Identify, assess, and manage organisational risks across the enterprise." icon={<SafetyOutlined />} />
 
       {/* KPI Cards */}
       <Row gutter={[24, 24]} style={{ marginBottom: 32 }}>

--- a/frontend/src/app/vendors/page.tsx
+++ b/frontend/src/app/vendors/page.tsx
@@ -4,11 +4,11 @@ import React, { useCallback, useState, useEffect } from 'react'
 import { Card, Typography, Space, Button, Row, Col, Table, Tag, Progress, Avatar, message, Modal, Form, Input, Select } from 'antd'
 import { TeamOutlined, PlusOutlined, WarningOutlined, CheckCircleOutlined, ClockCircleOutlined } from '@ant-design/icons'
 import { useRouter } from 'next/navigation'
-import { Breadcrumb, VendorKPICard, KPICard, StatusTag, PriorityTag, Loading, ExportButton, FilterPanel } from '@/components/ui'
+import { Breadcrumb, VendorKPICard, KPICard, StatusTag, PriorityTag, Loading, ExportButton, FilterPanel, PageHeader } from '@/components/ui'
 import type { FilterValues } from '@/components/ui/FilterPanel'
 import { vendorService, type Vendor, type VendorCategory, type VendorFilters } from '@/lib/services/vendorService'
 
-const { Title, Text } = Typography
+const { Text } = Typography
 
 interface VendorAnalytics {
   totalVendors: number
@@ -318,15 +318,7 @@ export default function VendorsPage() {
         ]}
       />
 
-      <div style={{ marginBottom: 24 }}>
-        <Title level={2}>
-          <TeamOutlined style={{ marginRight: 8 }} />
-          Vendor Management
-        </Title>
-        <Text type="secondary">
-          Manage vendor relationships, assessments, and risk profiles across the organization
-        </Text>
-      </div>
+      <PageHeader eyebrow="THIRD-PARTY ASSURANCE" title="Vendor management" description="Manage vendor relationships, assessments, and risk profiles across the organisation." icon={<TeamOutlined />} />
 
       {/* KPI Cards */}
       <Row gutter={[24, 24]} style={{ marginBottom: 32 }}>

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Typography } from "antd";
+
+const { Title, Text } = Typography;
+
+interface PageHeaderProps {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  icon?: ReactNode;
+  actions?: ReactNode;
+}
+
+export function PageHeader({ eyebrow, title, description, icon, actions }: PageHeaderProps) {
+  return (
+    <header className="page-header">
+      <div className="page-header-copy">
+        {eyebrow && <span className="page-header-eyebrow">{eyebrow}</span>}
+        <Title level={1} className="page-header-title">
+          {icon && <span className="page-header-icon" aria-hidden="true">{icon}</span>}
+          {title}
+        </Title>
+        {description && <Text className="page-header-description">{description}</Text>}
+      </div>
+      {actions && <div className="page-header-actions">{actions}</div>}
+    </header>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -10,3 +10,4 @@ export * from './SearchBar';
 export * from './Loading';
 export * from './ExportButton';
 export * from './FilterPanel';
+export * from './PageHeader';


### PR DESCRIPTION
## Summary

Continues the bespoke frontend design-system work in #88.

- Adds a reusable `PageHeader` primitive with eyebrow, title, description, icon, and action slots.
- Applies the template to risk management, vendor management, and compliance assessments.
- Adds responsive and dark-mode styling aligned with the merged ink/teal design tokens.
- Replaces inconsistent page-specific headings and keeps domain language in British English.

No API contracts changed.

## Validation

- `npm run lint`
- `npm run type-check`
- `npm run test:unit` — 14 tests passed
- `npm run build`
- `git diff --check`

Relates to #88
