### PR TITLE
feat: add accessible GRC visualisations

### DIFF
--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -17,8 +17,11 @@ import {
   ComplianceKPICard,
   RiskKPICard,
   VendorKPICard,
-  PolicyKPICard
-  ,PageHeader
+  PolicyKPICard,
+  ControlCoverage,
+  FrameworkReadiness,
+  TrendPanel,
+  PageHeader,
 } from '@/components/ui'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { api } from '@/lib/api'
@@ -82,6 +85,7 @@ interface ComplianceDashboardData {
     automated_controls: number
     avg_maturity_score: number
   }
+  assessment_trends?: Array<{ month: string; created: number; completed: number; avg_score: number | null }>
 }
 
 interface VendorRiskData {
@@ -370,6 +374,18 @@ export default function AnalyticsPage() {
       </Row>
 
       {/* Framework Performance */}
+      <div className="grc-viz-grid">
+        <FrameworkReadiness frameworks={(complianceData?.framework_statistics || []).map((framework) => ({
+          name: framework.name,
+          completionRate: framework.completion_rate,
+          averageScore: framework.avg_score,
+          overdue: framework.overdue_assessments,
+        }))} />
+        <div style={{ display: 'grid', gap: 16 }}>
+          <ControlCoverage total={complianceData?.overall_metrics.total_controls || 0} automated={complianceData?.overall_metrics.automated_controls || 0} />
+          <TrendPanel heading="Assessment momentum" label="Assessment completion trend" values={(complianceData?.assessment_trends || []).map((trend) => trend.completed)} />
+        </div>
+      </div>
       <Card title="Framework Performance" style={{ marginBottom: 24 }}>
         {complianceData?.framework_statistics.length === 0 ? (
           <EmptyState description="No framework data available" />

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -7,6 +7,20 @@ body { margin: 0; }
 .page-header-icon { display: inline-flex; color: var(--teal, #0b8f84); font-size: 25px; }
 .page-header-description { display: block; max-width: 680px; margin-top: 9px; color: var(--ink-soft, #466166); font-size: 14px; line-height: 1.5; }
 .page-header-actions { display: flex; align-items: center; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }
+.grc-viz-grid { display: grid; grid-template-columns: 1.2fr .8fr; gap: 16px; margin-bottom: 24px; }
+.grc-viz-panel { min-width: 0; padding: 22px; background: var(--paper, #fbfcfa); border: 1px solid var(--line, #dce7e5); }
+.grc-viz-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 20px; }
+.grc-viz-heading h3 { margin: 6px 0 0; color: var(--ink, #102b2e); font-size: 18px; line-height: 1.2; letter-spacing: 0; }
+.grc-viz-score { color: var(--teal-deep, #08756d); font-size: 28px; line-height: 1; }
+.grc-viz-caption, .framework-readiness-meta { display: flex; justify-content: space-between; gap: 12px; color: var(--ink-soft, #466166); font-size: 11px; }
+.framework-readiness-list { display: grid; gap: 17px; }
+.framework-readiness-label { display: flex; justify-content: space-between; gap: 16px; color: var(--ink, #102b2e); font-size: 12px; }
+.framework-readiness-label span { color: var(--teal-deep, #08756d); font-weight: 700; }
+.framework-readiness-item .ant-progress { margin: 7px 0 3px; }
+.grc-viz-empty { display: grid; min-height: 96px; place-items: center; color: var(--ink-soft, #466166); font-size: 12px; }
+.grc-sparkline { display: block; width: 100%; height: 92px; overflow: visible; }
+html.dark-mode .grc-viz-panel { --paper: #1e2b2d; --line: #35504e; --ink: #e8f2ef; --ink-soft: #b4c8c4; --teal-deep: #7bd2c6; }
+@media (max-width: 760px) { .grc-viz-grid { grid-template-columns: 1fr; }.grc-viz-panel { padding: 18px; } }
 html.dark-mode .page-header { --line: #35504e; --ink: #e8f2ef; --ink-soft: #b4c8c4; --teal: #61c2b5; --teal-deep: #7bd2c6; }
 @media (max-width: 760px) { .page-header { display: block; margin-bottom: 22px; }.page-header-actions { justify-content: flex-start; margin-top: 18px; }.page-header-title { font-size: 26px !important; } }
 

--- a/frontend/src/components/ui/GRCVisualisations.tsx
+++ b/frontend/src/components/ui/GRCVisualisations.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Progress, Typography } from "antd";
+
+const { Text } = Typography;
+
+export interface FrameworkReadinessItem {
+  name: string;
+  completionRate: number;
+  averageScore?: number;
+  overdue?: number;
+}
+
+export function ControlCoverage({ total, automated }: { total: number; automated: number }) {
+  const percentage = total > 0 ? Math.round((automated / total) * 100) : 0;
+  return (
+    <section className="grc-viz-panel" aria-labelledby="control-coverage-title">
+      <div className="grc-viz-heading">
+        <div>
+          <span className="section-kicker">CONTROL ENVIRONMENT</span>
+          <h3 id="control-coverage-title">Control coverage</h3>
+        </div>
+        <strong className="grc-viz-score">{percentage}%</strong>
+      </div>
+      <Progress percent={percentage} showInfo={false} strokeColor="#0b8f84" trailColor="#e5efed" />
+      <div className="grc-viz-caption"><span>{automated} automated controls</span><span>{total} total controls</span></div>
+    </section>
+  );
+}
+
+export function FrameworkReadiness({ frameworks }: { frameworks: FrameworkReadinessItem[] }) {
+  return (
+    <section className="grc-viz-panel" aria-labelledby="framework-readiness-title">
+      <div className="grc-viz-heading">
+        <div>
+          <span className="section-kicker">ASSURANCE LANDSCAPE</span>
+          <h3 id="framework-readiness-title">Framework readiness</h3>
+        </div>
+        <Text type="secondary">{frameworks.length} frameworks</Text>
+      </div>
+      {frameworks.length === 0 ? <div className="grc-viz-empty">No framework assessments yet.</div> : <div className="framework-readiness-list">{frameworks.map((framework) => <div className="framework-readiness-item" key={framework.name}><div className="framework-readiness-label"><strong>{framework.name}</strong><span>{Math.round(framework.completionRate)}%</span></div><Progress percent={Math.round(framework.completionRate)} showInfo={false} strokeColor={framework.completionRate >= 80 ? "#0b8f84" : "#d29c4c"} trailColor="#e9efed" /><div className="framework-readiness-meta"><span>Score {framework.averageScore == null ? "—" : `${Math.round(framework.averageScore)}%`}</span><span>{framework.overdue ?? 0} overdue</span></div></div>)}</div>}
+    </section>
+  );
+}
+
+export function TrendSparkline({ values, label }: { values: number[]; label: string }) {
+  if (values.length < 2) return <div className="grc-viz-empty">Not enough trend data.</div>;
+  const max = Math.max(...values, 1);
+  const min = Math.min(...values, 0);
+  const range = Math.max(max - min, 1);
+  const points = values.map((value, index) => `${(index / (values.length - 1)) * 100},${36 - ((value - min) / range) * 30}`).join(" ");
+  return <svg className="grc-sparkline" viewBox="0 0 100 40" preserveAspectRatio="none" role="img" aria-label={label}><polyline points={points} fill="none" stroke="#0b8f84" strokeWidth="2.4" vectorEffect="non-scaling-stroke" /></svg>;
+}
+
+export function TrendPanel({ values, label, heading }: { values: number[]; label: string; heading: string }) {
+  return <section className="grc-viz-panel" aria-labelledby={`${heading.toLowerCase().replaceAll(" ", "-")}-title`}><div className="grc-viz-heading"><div><span className="section-kicker">MOVEMENT</span><h3 id={`${heading.toLowerCase().replaceAll(" ", "-")}-title`}>{heading}</h3></div></div><TrendSparkline values={values} label={label} /></section>;
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -11,3 +11,4 @@ export * from './Loading';
 export * from './ExportButton';
 export * from './FilterPanel';
 export * from './PageHeader';
+export * from './GRCVisualisations';


### PR DESCRIPTION
## Summary

Continues #88 with domain-specific visualisations on the live analytics dashboard.

- Adds reusable `ControlCoverage`, `FrameworkReadiness`, and `TrendPanel` components.
- Shows automated control coverage, framework completion/readiness, overdue assessment counts, and assessment momentum.
- Includes accessible headings, SVG labels, empty states, responsive layout, and dark-mode styling.
- Retains the live tenant-scoped analytics API integration from #346.

## Validation

- `npm run lint`
- `npm run type-check`
- `npm run test:unit` — 14 tests passed
- `npm run build`
- `git diff --check`

Relates to #88
