### PR TITLE
refactor: route export queries through catalogue service

### DIFF
--- a/app/catalogs/services.py
+++ b/app/catalogs/services.py
@@ -11,6 +11,39 @@ from .models import AssessmentEvidence, Control, ControlAssessment, Framework
 ASSESSMENT_OPEN_STATUSES = ["not_started", "in_progress"]
 
 
+class CatalogueReportQueryService:
+    """Read-only catalogue queries used by report and export workflows."""
+
+    @staticmethod
+    def active_framework_options():
+        return Framework.objects.filter(status="active").values(
+            "id", "name", "short_name", "description"
+        )
+
+    @staticmethod
+    def assessment_options(*, framework_id=None, search="", limit=100):
+        assessments = ControlAssessment.objects.select_related("control").prefetch_related(
+            "control__clauses__framework"
+        )
+        if framework_id:
+            assessments = assessments.filter(control__clauses__framework_id=framework_id)
+        if search:
+            assessments = assessments.filter(
+                Q(control__control_id__icontains=search) | Q(control__name__icontains=search)
+            )
+        return assessments.distinct()[:limit]
+
+    @staticmethod
+    def existing_assessment_ids(assessment_ids):
+        return set(
+            ControlAssessment.objects.filter(id__in=assessment_ids).values_list("id", flat=True)
+        )
+
+    @staticmethod
+    def assessments_for_ids(assessment_ids):
+        return ControlAssessment.objects.filter(id__in=assessment_ids)
+
+
 def _maturity_score():
     return Case(
         When(assessments__maturity_level="ad_hoc", then=Value(1.0)),

--- a/app/exports/serializers.py
+++ b/app/exports/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from drf_spectacular.utils import extend_schema_field
-from catalogs.models import Framework, ControlAssessment
+from catalogs.services import CatalogueReportQueryService
 from core.serializers import DocumentSerializer
 from .models import AssessmentReport, TenantDataExport
 from .services import get_export_coverage_manifest
@@ -91,9 +91,7 @@ class AssessmentReportCreateSerializer(serializers.ModelSerializer):
             request = self.context.get("request")
             if request and hasattr(request, "user"):
                 # In a multi-tenant system, assessments are automatically scoped
-                existing_ids = set(
-                    ControlAssessment.objects.filter(id__in=value).values_list("id", flat=True)
-                )
+                existing_ids = CatalogueReportQueryService.existing_assessment_ids(value)
                 invalid_ids = set(value) - existing_ids
                 if invalid_ids:
                     raise serializers.ValidationError(
@@ -123,7 +121,7 @@ class AssessmentReportCreateSerializer(serializers.ModelSerializer):
 
         # Add specific assessments if provided
         if assessment_ids:
-            assessments = ControlAssessment.objects.filter(id__in=assessment_ids)
+            assessments = CatalogueReportQueryService.assessments_for_ids(assessment_ids)
             report.assessments.set(assessments)
 
         return report

--- a/app/exports/views.py
+++ b/app/exports/views.py
@@ -7,7 +7,6 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from django_filters.rest_framework import DjangoFilterBackend
-from django.db.models import Q
 from drf_spectacular.utils import (
     extend_schema,
     extend_schema_view,
@@ -17,7 +16,7 @@ from drf_spectacular.utils import (
 )
 from drf_spectacular.types import OpenApiTypes
 
-from catalogs.models import Framework, ControlAssessment
+from catalogs.services import CatalogueReportQueryService
 from .models import AssessmentReport
 from .models import TenantDataExport
 from .audit import (
@@ -394,9 +393,7 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
     @action(detail=False, methods=["get"])
     def framework_options(self, request):
         """Get available frameworks for report generation."""
-        frameworks = Framework.objects.filter(status="active").values(
-            "id", "name", "short_name", "description"
-        )
+        frameworks = CatalogueReportQueryService.active_framework_options()
 
         return Response({"frameworks": list(frameworks)})
 
@@ -406,20 +403,9 @@ class AssessmentReportViewSet(viewsets.ModelViewSet):
         framework_id = request.query_params.get("framework_id")
         search = request.query_params.get("search", "")
 
-        assessments = ControlAssessment.objects.select_related("control").prefetch_related(
-            "control__clauses__framework"
+        assessments = CatalogueReportQueryService.assessment_options(
+            framework_id=framework_id, search=search
         )
-
-        if framework_id:
-            assessments = assessments.filter(control__clauses__framework_id=framework_id)
-
-        if search:
-            assessments = assessments.filter(
-                Q(control__control_id__icontains=search) | Q(control__name__icontains=search)
-            )
-
-        # Limit results to prevent large responses
-        assessments = assessments.distinct()[:100]
 
         assessment_data = [
             {


### PR DESCRIPTION
## Summary

First bounded slice of #194: catalogue assessment/report query knowledge now lives behind a catalogue-owned service.

- Adds `CatalogueReportQueryService` for active framework options, assessment options, existing-ID validation, and selected assessment lookup.
- Routes export views and serializers through the service instead of importing `Framework` and `ControlAssessment` directly.
- Preserves filtering, search, distinct results, and the 100-item response limit.

This is intentionally limited to the exports/catalogue boundary; calendar, vulnerability intake, and operator analytics remain follow-up slices.

## Validation

- `ruff check app/catalogs/services.py app/exports/views.py app/exports/serializers.py`
- Python syntax compilation
- `git diff --check`

The focused Docker pytest command could not start locally because the compose stack requires the absent `frontend/.env.local`; CI should provide the normal environment.

Relates to #194
