### PR TITLE
refactor: add catalogue calendar provider

### DIFF
--- a/app/calendarhub/services.py
+++ b/app/calendarhub/services.py
@@ -7,7 +7,7 @@ from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from assets.models import Asset
-from catalogs.models import ControlAssessment
+from catalogs.services import CatalogueCalendarProvider
 from policies.models import Policy
 from risk.models import Risk, RiskAction
 from vendors.models import Vendor, VendorTask
@@ -104,36 +104,12 @@ def list_custom_events(start_date=None, end_date=None, owner=None):
 
 
 def list_assessment_events(start_date=None, end_date=None, owner=None):
-    queryset = (
-        ControlAssessment.objects.filter(due_date__isnull=False)
-        .exclude(status__in=["complete", "not_applicable"])
-        .select_related("assigned_to", "control")
+    return CatalogueCalendarProvider.list_events(
+        CalendarSourceEvent,
+        start_date=start_date,
+        end_date=end_date,
+        owner=owner,
     )
-    queryset = _date_filter(queryset, "due_date", start_date, end_date)
-    if owner:
-        queryset = queryset.filter(assigned_to=owner)
-    return [
-        CalendarSourceEvent(
-            source_type="control_assessment",
-            source_id=str(assessment.id),
-            title=f"Control assessment due: {assessment.control.control_id}",
-            due_date=assessment.due_date,
-            owner=assessment.assigned_to,
-            source_url=f"/api/catalogs/assessments/{assessment.id}/",
-            status=assessment.status,
-            module="frameworks",
-            metadata={
-                "assessment_id": assessment.assessment_id,
-                "control_id": assessment.control.control_id,
-                "remediation_due_date": (
-                    assessment.remediation_due_date.isoformat()
-                    if assessment.remediation_due_date
-                    else None
-                ),
-            },
-        )
-        for assessment in queryset
-    ]
 
 
 def list_risk_events(start_date=None, end_date=None, owner=None):

--- a/app/catalogs/services.py
+++ b/app/catalogs/services.py
@@ -44,6 +44,47 @@ class CatalogueReportQueryService:
         return ControlAssessment.objects.filter(id__in=assessment_ids)
 
 
+class CatalogueCalendarProvider:
+    """Provide catalogue-owned due dates to the calendar aggregation layer."""
+
+    @staticmethod
+    def list_events(event_factory, *, start_date=None, end_date=None, owner=None):
+        queryset = (
+            ControlAssessment.objects.filter(due_date__isnull=False)
+            .exclude(status__in=["complete", "not_applicable"])
+            .select_related("assigned_to", "control")
+        )
+        if start_date:
+            queryset = queryset.filter(due_date__gte=start_date)
+        if end_date:
+            queryset = queryset.filter(due_date__lte=end_date)
+        if owner:
+            queryset = queryset.filter(assigned_to=owner)
+
+        return [
+            event_factory(
+                source_type="control_assessment",
+                source_id=str(assessment.id),
+                title=f"Control assessment due: {assessment.control.control_id}",
+                due_date=assessment.due_date,
+                owner=assessment.assigned_to,
+                source_url=f"/api/catalogs/assessments/{assessment.id}/",
+                status=assessment.status,
+                module="frameworks",
+                metadata={
+                    "assessment_id": assessment.assessment_id,
+                    "control_id": assessment.control.control_id,
+                    "remediation_due_date": (
+                        assessment.remediation_due_date.isoformat()
+                        if assessment.remediation_due_date
+                        else None
+                    ),
+                },
+            )
+            for assessment in queryset
+        ]
+
+
 def _maturity_score():
     return Case(
         When(assessments__maturity_level="ad_hoc", then=Value(1.0)),


### PR DESCRIPTION
## Summary

Second bounded slice of #194: catalogue-owned assessment due dates are now exposed through a provider consumed by calendar aggregation.

- Adds `CatalogueCalendarProvider` inside the catalogue domain.
- Moves assessment filtering, ownership filtering, date bounds, and event metadata construction out of `calendarhub.services`.
- Keeps `calendarhub` responsible for composing and sorting source events.
- Leaves risk, vendor, policy, and asset providers for subsequent slices.

## Validation

- `ruff check app/catalogs/services.py app/calendarhub/services.py`
- Python syntax compilation
- `git diff --check`

Relates to #194
