### PR TITLE
refactor: add asset calendar provider

### DIFF
--- a/app/assets/services.py
+++ b/app/assets/services.py
@@ -1,0 +1,36 @@
+"""Asset-owned read services used by cross-domain workflows."""
+
+
+from .models import Asset
+
+
+class AssetCalendarProvider:
+    """Provide asset review dates to calendar aggregation."""
+
+    @staticmethod
+    def list_events(event_factory, *, start_date=None, end_date=None, owner=None):
+        queryset = (
+            Asset.objects.filter(next_review_date__isnull=False)
+            .exclude(lifecycle_status__in=["retired", "disposed"])
+            .select_related("owner")
+        )
+        if start_date:
+            queryset = queryset.filter(next_review_date__gte=start_date)
+        if end_date:
+            queryset = queryset.filter(next_review_date__lte=end_date)
+        if owner:
+            queryset = queryset.filter(owner=owner)
+        return [
+            event_factory(
+                source_type="asset_review",
+                source_id=str(asset.id),
+                title=f"Asset review due: {asset.name}",
+                due_date=asset.next_review_date,
+                owner=asset.owner,
+                source_url=f"/api/assets/assets/{asset.id}/",
+                status=asset.lifecycle_status,
+                module="assets",
+                metadata={"asset_id": asset.asset_id, "criticality": asset.criticality},
+            )
+            for asset in queryset
+        ]

--- a/app/assets/services.py
+++ b/app/assets/services.py
@@ -1,6 +1,5 @@
 """Asset-owned read services used by cross-domain workflows."""
 
-
 from .models import Asset
 
 

--- a/app/calendarhub/services.py
+++ b/app/calendarhub/services.py
@@ -6,7 +6,7 @@ from django.core.mail import send_mail
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 
-from assets.models import Asset
+from assets.services import AssetCalendarProvider
 from catalogs.services import CatalogueCalendarProvider
 from policies.services import PolicyCalendarProvider
 from risk.services import RiskCalendarProvider
@@ -140,28 +140,12 @@ def list_policy_events(start_date=None, end_date=None, owner=None):
 
 
 def list_asset_events(start_date=None, end_date=None, owner=None):
-    queryset = (
-        Asset.objects.filter(next_review_date__isnull=False)
-        .exclude(lifecycle_status__in=["retired", "disposed"])
-        .select_related("owner")
+    return AssetCalendarProvider.list_events(
+        CalendarSourceEvent,
+        start_date=start_date,
+        end_date=end_date,
+        owner=owner,
     )
-    queryset = _date_filter(queryset, "next_review_date", start_date, end_date)
-    if owner:
-        queryset = queryset.filter(owner=owner)
-    return [
-        CalendarSourceEvent(
-            source_type="asset_review",
-            source_id=str(asset.id),
-            title=f"Asset review due: {asset.name}",
-            due_date=asset.next_review_date,
-            owner=asset.owner,
-            source_url=f"/api/assets/assets/{asset.id}/",
-            status=asset.lifecycle_status,
-            module="assets",
-            metadata={"asset_id": asset.asset_id, "criticality": asset.criticality},
-        )
-        for asset in queryset
-    ]
 
 
 def send_due_reminders(reference_date=None):


### PR DESCRIPTION
## Summary

Sixth calendar slice for #194: asset-owned review dates now come through `AssetCalendarProvider`.

- Adds an asset-domain service module for review-date queries and event metadata.
- Keeps `calendarhub` as the composer and removes its direct asset model import.
- Preserves existing filtering and event payload behaviour.

This completes the calendar provider extraction; vulnerability intake and operator analytics remain separate #194 follow-ups.

## Validation

- `ruff check app/assets/services.py app/calendarhub/services.py`
- Python syntax compilation
- `git diff --check`

Relates to #194
