### PR TITLE
refactor: route vulnerability intake through risk service

### DIFF
--- a/app/risk/services.py
+++ b/app/risk/services.py
@@ -13,6 +13,57 @@ OPEN_RISK_STATUSES = ["closed", "transferred"]
 OPEN_ACTION_STATUSES = ["pending", "in_progress", "deferred"]
 
 
+class RiskIntakeService:
+    """Create risk records from structured intake data owned by another domain."""
+
+    @staticmethod
+    def create_vulnerability_risk(
+        *,
+        title,
+        description,
+        severity,
+        risk_owner=None,
+        created_by=None,
+        next_review_date=None,
+    ):
+        impact, likelihood = _severity_to_risk_rating(severity)
+        return Risk.objects.create(
+            title=title,
+            description=description,
+            impact=impact,
+            likelihood=likelihood,
+            treatment_strategy="mitigate",
+            status="identified",
+            risk_owner=risk_owner,
+            created_by=created_by,
+            next_review_date=next_review_date,
+        )
+
+    @staticmethod
+    def create_vulnerability_action(
+        *,
+        risk,
+        title,
+        remediation,
+        severity,
+        assigned_to=None,
+        created_by=None,
+        due_date=None,
+    ):
+        return RiskAction.objects.create(
+            risk=risk,
+            title=title,
+            description=(
+                remediation or "Remediate or document an accepted risk decision for this finding."
+            ),
+            action_type="technical",
+            assigned_to=assigned_to,
+            priority=_severity_to_priority(severity),
+            due_date=due_date,
+            created_by=created_by,
+        )
+
+
 class RiskCalendarProvider:
     """Provide risk-owned review and action due dates to calendar aggregation."""
 
@@ -130,3 +181,23 @@ class RiskDomainAnalyticsService:
         return list(
             Risk.objects.values("category__name").annotate(count=Count("id")).order_by("-count")
         )
+
+
+def _severity_to_risk_rating(severity):
+    return {
+        "critical": (5, 4),
+        "high": (4, 4),
+        "medium": (3, 3),
+        "low": (2, 2),
+        "info": (1, 1),
+    }.get(severity, (2, 2))
+
+
+def _severity_to_priority(severity):
+    return {
+        "critical": "critical",
+        "high": "high",
+        "medium": "medium",
+        "low": "low",
+        "info": "low",
+    }.get(severity, "medium")

--- a/app/vuln/services.py
+++ b/app/vuln/services.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 
-from risk.models import Risk, RiskAction
+from risk.services import RiskIntakeService
 
 from .models import ScanJob, ScanTarget, VulnerabilityFinding
 
@@ -242,14 +242,10 @@ def store_findings(job, findings):
 
 
 def create_risk_from_finding(finding, user=None):
-    impact, likelihood = _severity_to_risk_rating(finding.severity)
-    risk = Risk.objects.create(
+    risk = RiskIntakeService.create_vulnerability_risk(
         title=f"Vulnerability: {finding.title}",
         description=_finding_description(finding),
-        impact=impact,
-        likelihood=likelihood,
-        treatment_strategy="mitigate",
-        status="identified",
+        severity=finding.severity,
         risk_owner=user,
         created_by=user,
         next_review_date=timezone.now().date() + timezone.timedelta(days=30),
@@ -261,14 +257,12 @@ def create_risk_from_finding(finding, user=None):
 
 def create_risk_action_from_finding(finding, user=None):
     risk = finding.risk or create_risk_from_finding(finding, user=user)
-    action = RiskAction.objects.create(
+    action = RiskIntakeService.create_vulnerability_action(
         risk=risk,
         title=f"Remediate vulnerability: {finding.title}",
-        description=finding.remediation
-        or "Remediate or document an accepted risk decision for this finding.",
-        action_type="technical",
+        remediation=finding.remediation,
+        severity=finding.severity,
         assigned_to=user,
-        priority=_severity_to_priority(finding.severity),
         due_date=timezone.now().date()
         + timezone.timedelta(days=_severity_to_due_days(finding.severity)),
         created_by=user,
@@ -321,26 +315,6 @@ def _settings_list(name):
     if isinstance(value, str):
         return [item.strip().lstrip(".") for item in value.split(",") if item.strip()]
     return [str(item).strip().lstrip(".") for item in value if str(item).strip()]
-
-
-def _severity_to_risk_rating(severity):
-    return {
-        "critical": (5, 4),
-        "high": (4, 4),
-        "medium": (3, 3),
-        "low": (2, 2),
-        "info": (1, 1),
-    }.get(severity, (2, 2))
-
-
-def _severity_to_priority(severity):
-    return {
-        "critical": "critical",
-        "high": "high",
-        "medium": "medium",
-        "low": "low",
-        "info": "low",
-    }.get(severity, "medium")
 
 
 def _severity_to_due_days(severity):


### PR DESCRIPTION
Part of #194.

Moves vulnerability-to-risk and vulnerability-remediation creation into the risk domain via RiskIntakeService. The vulnerability domain retains only finding linkage and compatibility wrappers, removing its direct imports of risk models.

Checks: Ruff lint, Ruff format, compileall, and diff check pass locally. Focused pytest could not start because the local environment is missing django_tenants; CI will run the full backend suite.