### PR TITLE
refactor: delegate operator usage metrics to domains

### DIFF
--- a/app/analytics/operator.py
+++ b/app/analytics/operator.py
@@ -12,9 +12,9 @@ from django.utils import timezone
 
 from billing.entitlements import MODULE_CATALOG
 from core.models import AuditEvent, Document, Subscription, Tenant
-from exports.models import TenantDataExport
-from policies.models import PolicyAcknowledgment, PolicyDistribution
-from training.models import CampaignDelivery, VideoView
+from exports.services import ExportUsageProvider
+from policies.services import PolicyUsageProvider
+from training.services import TrainingUsageProvider
 
 User = get_user_model()
 logger = logging.getLogger(__name__)
@@ -198,27 +198,11 @@ class OperatorProductAnalyticsService:
                 "document_uploads": Document.objects.filter(
                     uploaded_at__gte=self.window.start_at
                 ).count(),
-                "data_exports": TenantDataExport.objects.filter(
-                    requested_at__gte=self.window.start_at
-                ).count(),
                 "audit_events": AuditEvent.objects.filter(at__gte=self.window.start_at).count(),
-                "policy_acknowledgements": PolicyAcknowledgment.objects.filter(
-                    acknowledged_at__gte=self.window.start_at
-                ).count(),
-                "policy_distributions": PolicyDistribution.objects.filter(
-                    distributed_at__gte=self.window.start_at
-                ).count(),
-                "training_deliveries": CampaignDelivery.objects.filter(
-                    sent_at__gte=self.window.start_at
-                ).count(),
-                "training_views": VideoView.objects.filter(
-                    started_at__gte=self.window.start_at
-                ).count(),
-                "training_completions": VideoView.objects.filter(
-                    started_at__gte=self.window.start_at,
-                    completed=True,
-                ).count(),
             }
+            usage_counts.update(ExportUsageProvider.usage_counts(start_at=self.window.start_at))
+            usage_counts.update(PolicyUsageProvider.usage_counts(start_at=self.window.start_at))
+            usage_counts.update(TrainingUsageProvider.usage_counts(start_at=self.window.start_at))
             return {
                 "user_count": User.objects.filter(is_active=True).count(),
                 "usage_counts": usage_counts,

--- a/app/analytics/test_service_boundaries.py
+++ b/app/analytics/test_service_boundaries.py
@@ -30,6 +30,20 @@ def test_analytics_services_do_not_import_cross_domain_models_directly():
     assert direct_model_imports == set()
 
 
+def test_operator_analytics_uses_domain_usage_providers():
+    source = Path(__file__).with_name("operator.py").read_text()
+    tree = ast.parse(source)
+
+    direct_model_imports = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module in {"exports.models", "policies.models", "training.models"}
+    }
+
+    assert direct_model_imports == set()
+
+
 @pytest.mark.django_db
 def test_cross_module_dashboard_services_smoke():
     assert "risk_summary" in CrossModuleAnalyticsService.get_executive_dashboard_data()

--- a/app/exports/services.py
+++ b/app/exports/services.py
@@ -46,6 +46,17 @@ EXCLUDED_FIELD_NAMES = {
     "stripe_price_id",
 }
 
+
+class ExportUsageProvider:
+    """Provide export usage counts to privileged cross-domain analytics."""
+
+    @staticmethod
+    def usage_counts(*, start_at):
+        return {
+            "data_exports": TenantDataExport.objects.filter(requested_at__gte=start_at).count(),
+        }
+
+
 EXPORT_COVERAGE = [
     {
         "module": "identity",

--- a/app/policies/services.py
+++ b/app/policies/services.py
@@ -40,6 +40,21 @@ class PolicyCalendarProvider:
         ]
 
 
+class PolicyUsageProvider:
+    """Provide policy usage counts to privileged cross-domain analytics."""
+
+    @staticmethod
+    def usage_counts(*, start_at):
+        return {
+            "policy_acknowledgements": PolicyAcknowledgment.objects.filter(
+                acknowledged_at__gte=start_at
+            ).count(),
+            "policy_distributions": PolicyDistribution.objects.filter(
+                distributed_at__gte=start_at
+            ).count(),
+        }
+
+
 class PolicyAnalyticsService:
     """Read-side analytics owned by the policy domain."""
 

--- a/app/training/services.py
+++ b/app/training/services.py
@@ -6,9 +6,30 @@ from django.contrib.auth import get_user_model
 from django.db.models import Avg, Case, Count, F, FloatField, Q, Sum, Value, When
 from django.utils import timezone
 
-from .models import SecurityAwarenessCampaign, TrainingCategory, TrainingVideo, VideoView
+from .models import (
+    CampaignDelivery,
+    SecurityAwarenessCampaign,
+    TrainingCategory,
+    TrainingVideo,
+    VideoView,
+)
 
 User = get_user_model()
+
+
+class TrainingUsageProvider:
+    """Provide training usage counts to privileged cross-domain analytics."""
+
+    @staticmethod
+    def usage_counts(*, start_at):
+        return {
+            "training_deliveries": CampaignDelivery.objects.filter(sent_at__gte=start_at).count(),
+            "training_views": VideoView.objects.filter(started_at__gte=start_at).count(),
+            "training_completions": VideoView.objects.filter(
+                started_at__gte=start_at,
+                completed=True,
+            ).count(),
+        }
 
 
 class TrainingAnalyticsService:


### PR DESCRIPTION
Part of #194.

Adds owner-domain usage providers for exports, policies, and training. The privileged operator dashboard composes these providers, preserving its cross-tenant aggregate contract while removing direct imports of those domains' models. Adds an AST boundary regression test.

Checks: Ruff lint, Ruff format, compileall, diff check, and boundary test pass locally.