### PR TITLE
feat: add tenant email identity settings

### DIFF
--- a/app/core/migrations/0004_tenant_email_settings.py
+++ b/app/core/migrations/0004_tenant_email_settings.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("core", "0003_alter_auditevent_options_and_more")]
+
+    operations = [
+        migrations.AddField(
+            model_name="tenant",
+            name="email_sender_name",
+            field=models.CharField(blank=True, max_length=200),
+        ),
+        migrations.AddField(
+            model_name="tenant",
+            name="email_sender_address",
+            field=models.EmailField(blank=True, max_length=254),
+        ),
+        migrations.AddField(
+            model_name="tenant",
+            name="email_reply_to",
+            field=models.EmailField(blank=True, max_length=254),
+        ),
+        migrations.AddField(
+            model_name="tenant",
+            name="email_sender_verified_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -16,6 +16,10 @@ class Tenant(TenantMixin):
         default="free",
         choices=[("free", "Free"), ("basic", "Basic"), ("enterprise", "Enterprise")],
     )
+    email_sender_name = models.CharField(max_length=200, blank=True)
+    email_sender_address = models.EmailField(blank=True)
+    email_reply_to = models.EmailField(blank=True)
+    email_sender_verified_at = models.DateTimeField(null=True, blank=True)
 
     def __str__(self):
         return f"{self.name} ({self.schema_name})"

--- a/app/core/serializers.py
+++ b/app/core/serializers.py
@@ -3,7 +3,7 @@ Serializers for core models including document upload functionality.
 """
 
 from rest_framework import serializers
-from .models import AuditEvent, Document, DocumentAccess, User
+from .models import AuditEvent, Document, DocumentAccess, Tenant, User
 
 
 class DocumentSerializer(serializers.ModelSerializer):
@@ -124,3 +124,23 @@ class AuditEventSerializer(serializers.ModelSerializer):
         model = AuditEvent
         fields = ["id", "event", "user", "user_email", "details", "at"]
         read_only_fields = ["id", "event", "user", "user_email", "details", "at"]
+
+
+class TenantEmailSettingsSerializer(serializers.ModelSerializer):
+    sender_email_verified = serializers.BooleanField(
+        source="email_sender_verified_at", read_only=True
+    )
+    sender_email_verified_at = serializers.DateTimeField(
+        source="email_sender_verified_at", read_only=True
+    )
+
+    class Meta:
+        model = Tenant
+        fields = [
+            "email_sender_name",
+            "email_sender_address",
+            "email_reply_to",
+            "sender_email_verified",
+            "sender_email_verified_at",
+        ]
+        read_only_fields = ["sender_email_verified", "sender_email_verified_at"]

--- a/app/core/serializers.py
+++ b/app/core/serializers.py
@@ -127,9 +127,7 @@ class AuditEventSerializer(serializers.ModelSerializer):
 
 
 class TenantEmailSettingsSerializer(serializers.ModelSerializer):
-    sender_email_verified = serializers.BooleanField(
-        source="email_sender_verified_at", read_only=True
-    )
+    sender_email_verified = serializers.SerializerMethodField()
     sender_email_verified_at = serializers.DateTimeField(
         source="email_sender_verified_at", read_only=True
     )
@@ -144,3 +142,6 @@ class TenantEmailSettingsSerializer(serializers.ModelSerializer):
             "sender_email_verified_at",
         ]
         read_only_fields = ["sender_email_verified", "sender_email_verified_at"]
+
+    def get_sender_email_verified(self, obj) -> bool:
+        return bool(obj.email_sender_verified_at)

--- a/app/core/test_tenant_email_settings.py
+++ b/app/core/test_tenant_email_settings.py
@@ -1,0 +1,45 @@
+import pytest
+from django_tenants.utils import schema_context, tenant_context
+
+from core.models import AuditEvent
+
+
+@pytest.mark.django_db
+def test_tenant_admin_can_read_and_update_email_settings(tenant_client, test_tenant, admin_user):
+    tenant_client.force_authenticate(user=admin_user)
+
+    response = tenant_client.get("/api/tenant-email-settings/")
+    assert response.status_code == 200
+    assert response.json()["sender_email_verified"] is False
+
+    response = tenant_client.patch(
+        "/api/tenant-email-settings/",
+        {
+            "email_sender_name": "Test Company",
+            "email_sender_address": "notifications@example.com",
+            "email_reply_to": "support@example.com",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["email_sender_address"] == "notifications@example.com"
+    with schema_context("public"):
+        test_tenant.refresh_from_db()
+        assert test_tenant.email_sender_name == "Test Company"
+    with tenant_context(test_tenant):
+        event = AuditEvent.objects.get(event="TENANT_EMAIL_SETTINGS_UPDATED")
+        assert event.details["new"]["email_sender_address"] == "notifications@example.com"
+
+
+@pytest.mark.django_db
+def test_tenant_member_cannot_update_email_settings(tenant_client, test_user):
+    tenant_client.force_authenticate(user=test_user)
+
+    response = tenant_client.patch(
+        "/api/tenant-email-settings/",
+        {"email_sender_name": "Not authorised"},
+        format="json",
+    )
+
+    assert response.status_code == 403

--- a/app/core/urls.py
+++ b/app/core/urls.py
@@ -4,7 +4,7 @@ URL configuration for core app including document management.
 
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import AuditEventViewSet, DocumentViewSet
+from .views import AuditEventViewSet, DocumentViewSet, TenantEmailSettingsView
 from .health import (
     HealthCheckView,
     LivenessCheckView,
@@ -23,6 +23,11 @@ router.register("audit-events", AuditEventViewSet, basename="audit-events")
 urlpatterns = [
     # API endpoints
     path("api/", include(router.urls)),
+    path(
+        "api/tenant-email-settings/",
+        TenantEmailSettingsView.as_view(),
+        name="tenant-email-settings",
+    ),
     # Health check endpoints
     path("health/", HealthCheckView.as_view(), name="health_check"),
     path("health/ready/", ReadinessCheckView.as_view(), name="readiness_check"),

--- a/app/core/views.py
+++ b/app/core/views.py
@@ -15,12 +15,14 @@ from .document_audit import (
     document_display,
     snapshot_document,
 )
+from .audit import log_audit_event
 from .models import AuditEvent, Document, DocumentAccess, Tenant
 from .serializers import (
     AuditEventSerializer,
     DocumentSerializer,
     DocumentListSerializer,
     DocumentAccessSerializer,
+    TenantEmailSettingsSerializer,
 )
 from billing.decorators import check_document_limits
 from billing.services import PlanEnforcementService
@@ -32,6 +34,47 @@ from drf_spectacular.utils import (
     OpenApiExample,
 )
 from drf_spectacular.types import OpenApiTypes
+from rest_framework.views import APIView
+
+
+class TenantEmailSettingsView(APIView):
+    """Read and update the current tenant's outbound email identity settings."""
+
+    permission_classes = [permissions.IsAdminUser]
+
+    @extend_schema(
+        responses=TenantEmailSettingsSerializer,
+        tags=["Tenant settings"],
+    )
+    def get(self, request):
+        return Response(TenantEmailSettingsSerializer(request.tenant).data)
+
+    @extend_schema(
+        request=TenantEmailSettingsSerializer,
+        responses=TenantEmailSettingsSerializer,
+        tags=["Tenant settings"],
+    )
+    def patch(self, request):
+        tenant = request.tenant
+        serializer = TenantEmailSettingsSerializer(
+            tenant,
+            data=request.data,
+            partial=True,
+        )
+        serializer.is_valid(raise_exception=True)
+        changed_fields = list(serializer.validated_data)
+        previous = {field: getattr(tenant, field) for field in changed_fields}
+        serializer.save()
+        log_audit_event(
+            event="TENANT_EMAIL_SETTINGS_UPDATED",
+            actor=request.user,
+            target=tenant,
+            object_display=tenant.slug,
+            previous=previous,
+            new={field: getattr(tenant, field) for field in changed_fields},
+            request=request,
+        )
+        return Response(TenantEmailSettingsSerializer(tenant).data)
 
 
 @extend_schema_view(

--- a/app/core/views.py
+++ b/app/core/views.py
@@ -3,12 +3,14 @@ Views for document management and storage testing.
 """
 
 from django.conf import settings
+from django.db import transaction
 from rest_framework import filters, viewsets, status, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.parsers import MultiPartParser, FormParser
 from django.http import HttpResponse, Http404
 from django.utils import timezone
+from django_tenants.utils import schema_context
 from .document_audit import (
     audit_document_change,
     document_changed_values,
@@ -47,7 +49,9 @@ class TenantEmailSettingsView(APIView):
         tags=["Tenant settings"],
     )
     def get(self, request):
-        return Response(TenantEmailSettingsSerializer(request.tenant).data)
+        with schema_context("public"):
+            tenant = Tenant.objects.get(pk=request.tenant.pk)
+        return Response(TenantEmailSettingsSerializer(tenant).data)
 
     @extend_schema(
         request=TenantEmailSettingsSerializer,
@@ -55,23 +59,25 @@ class TenantEmailSettingsView(APIView):
         tags=["Tenant settings"],
     )
     def patch(self, request):
-        tenant = request.tenant
-        serializer = TenantEmailSettingsSerializer(
-            tenant,
-            data=request.data,
-            partial=True,
-        )
-        serializer.is_valid(raise_exception=True)
-        changed_fields = list(serializer.validated_data)
-        previous = {field: getattr(tenant, field) for field in changed_fields}
-        serializer.save()
+        with transaction.atomic(), schema_context("public"):
+            tenant = Tenant.objects.select_for_update().get(pk=request.tenant.pk)
+            serializer = TenantEmailSettingsSerializer(
+                tenant,
+                data=request.data,
+                partial=True,
+            )
+            serializer.is_valid(raise_exception=True)
+            changed_fields = list(serializer.validated_data)
+            previous = {field: getattr(tenant, field) for field in changed_fields}
+            serializer.save()
+            new = {field: getattr(tenant, field) for field in changed_fields}
         log_audit_event(
             event="TENANT_EMAIL_SETTINGS_UPDATED",
             actor=request.user,
             target=tenant,
             object_display=tenant.slug,
             previous=previous,
-            new={field: getattr(tenant, field) for field in changed_fields},
+            new=new,
             request=request,
         )
         return Response(TenantEmailSettingsSerializer(tenant).data)

--- a/app/schema.yml
+++ b/app/schema.yml
@@ -436,33 +436,6 @@ paths:
         '400':
           description: Validation errors
   /api/assets/assets/:
-    post:
-      operationId: assets_assets_create
-      description: CRUD API for information assets.
-      tags:
-      - assets
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AssetDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AssetDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/AssetDetailRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetDetail'
-          description: ''
     get:
       operationId: assets_assets_list
       description: CRUD API for information assets.
@@ -580,6 +553,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedAssetListList'
+          description: ''
+    post:
+      operationId: assets_assets_create
+      description: CRUD API for information assets.
+      tags:
+      - assets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssetDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetDetail'
           description: ''
   /api/assets/assets/due_for_review/:
     get:
@@ -739,79 +739,6 @@ paths:
         '403':
           description: Staff administrator access required
   /api/assets/assets/{id}/:
-    patch:
-      operationId: assets_assets_partial_update
-      description: CRUD API for information assets.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this asset.
-        required: true
-      tags:
-      - assets
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedAssetDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedAssetDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedAssetDetailRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetDetail'
-          description: ''
-    delete:
-      operationId: assets_assets_destroy
-      description: CRUD API for information assets.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this asset.
-        required: true
-      tags:
-      - assets
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: assets_assets_retrieve
-      description: CRUD API for information assets.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this asset.
-        required: true
-      tags:
-      - assets
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetDetail'
-          description: ''
     put:
       operationId: assets_assets_update
       description: CRUD API for information assets.
@@ -846,6 +773,79 @@ paths:
               schema:
                 $ref: '#/components/schemas/AssetDetail'
           description: ''
+    patch:
+      operationId: assets_assets_partial_update
+      description: CRUD API for information assets.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this asset.
+        required: true
+      tags:
+      - assets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedAssetDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedAssetDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedAssetDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetDetail'
+          description: ''
+    get:
+      operationId: assets_assets_retrieve
+      description: CRUD API for information assets.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this asset.
+        required: true
+      tags:
+      - assets
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetDetail'
+          description: ''
+    delete:
+      operationId: assets_assets_destroy
+      description: CRUD API for information assets.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this asset.
+        required: true
+      tags:
+      - assets
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/assets/review-reminders/:
     get:
       operationId: assets_review_reminders_list
@@ -918,32 +918,6 @@ paths:
                 $ref: '#/components/schemas/AssetReviewReminderLog'
           description: ''
   /api/calendar/events/:
-    post:
-      operationId: calendar_events_create
-      tags:
-      - calendar
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CalendarEventRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/CalendarEventRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/CalendarEventRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CalendarEvent'
-          description: ''
     get:
       operationId: calendar_events_list
       parameters:
@@ -1005,6 +979,32 @@ paths:
                 items:
                   $ref: '#/components/schemas/CalendarEvent'
           description: ''
+    post:
+      operationId: calendar_events_create
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CalendarEventRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
   /api/calendar/events/combined/:
     get:
       operationId: calendar_events_combined_retrieve
@@ -1021,79 +1021,6 @@ paths:
                 $ref: '#/components/schemas/CalendarEvent'
           description: ''
   /api/calendar/events/{id}/:
-    patch:
-      operationId: calendar_events_partial_update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this calendar event.
-        required: true
-      tags:
-      - calendar
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedCalendarEventRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedCalendarEventRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedCalendarEventRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CalendarEvent'
-          description: ''
-    delete:
-      operationId: calendar_events_destroy
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this calendar event.
-        required: true
-      tags:
-      - calendar
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: calendar_events_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this calendar event.
-        required: true
-      tags:
-      - calendar
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CalendarEvent'
-          description: ''
     put:
       operationId: calendar_events_update
       parameters:
@@ -1128,7 +1055,96 @@ paths:
               schema:
                 $ref: '#/components/schemas/CalendarEvent'
           description: ''
+    patch:
+      operationId: calendar_events_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this calendar event.
+        required: true
+      tags:
+      - calendar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarEventRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarEventRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedCalendarEventRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
+    get:
+      operationId: calendar_events_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this calendar event.
+        required: true
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEvent'
+          description: ''
+    delete:
+      operationId: calendar_events_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this calendar event.
+        required: true
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/calendar/preferences/:
+    get:
+      operationId: calendar_preferences_list
+      tags:
+      - calendar
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CalendarNotificationPreference'
+          description: ''
     post:
       operationId: calendar_preferences_create
       tags:
@@ -1153,22 +1169,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CalendarNotificationPreference'
-          description: ''
-    get:
-      operationId: calendar_preferences_list
-      tags:
-      - calendar
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CalendarNotificationPreference'
           description: ''
   /api/calendar/reminders/:
     get:
@@ -1309,35 +1309,6 @@ paths:
                 $ref: '#/components/schemas/CalendarAuditLog'
           description: ''
   /api/catalogs/api/frameworks/:
-    post:
-      operationId: catalogs_api_frameworks_create
-      description: Create a new compliance framework with all required metadata and
-        configuration.
-      summary: Create new compliance framework
-      tags:
-      - Frameworks
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FrameworkDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/FrameworkDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/FrameworkDetailRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FrameworkDetail'
-          description: ''
     get:
       operationId: catalogs_api_frameworks_list
       description: Retrieve a paginated list of compliance frameworks with filtering,
@@ -1395,85 +1366,36 @@ paths:
                   summary: Get active ISO 27001 frameworks
                   description: Example of filtering for active ISO 27001 frameworks
           description: ''
-  /api/catalogs/api/frameworks/{id}/:
-    patch:
-      operationId: catalogs_api_frameworks_partial_update
-      description: Update specific fields of an existing compliance framework.
-      summary: Partially update framework
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this framework.
-        required: true
+    post:
+      operationId: catalogs_api_frameworks_create
+      description: Create a new compliance framework with all required metadata and
+        configuration.
+      summary: Create new compliance framework
       tags:
       - Frameworks
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedFrameworkDetailRequest'
+              $ref: '#/components/schemas/FrameworkDetailRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedFrameworkDetailRequest'
+              $ref: '#/components/schemas/FrameworkDetailRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedFrameworkDetailRequest'
+              $ref: '#/components/schemas/FrameworkDetailRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FrameworkDetail'
           description: ''
-    delete:
-      operationId: catalogs_api_frameworks_destroy
-      description: Delete a compliance framework. This will also remove all associated
-        clauses and mappings.
-      summary: Delete framework
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this framework.
-        required: true
-      tags:
-      - Frameworks
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: catalogs_api_frameworks_retrieve
-      description: Retrieve detailed information about a specific compliance framework
-        including metadata and configuration.
-      summary: Get framework details
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this framework.
-        required: true
-      tags:
-      - Frameworks
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FrameworkDetail'
-          description: ''
+  /api/catalogs/api/frameworks/{id}/:
     put:
       operationId: catalogs_api_frameworks_update
       description: Update an existing compliance framework. Requires all fields.
@@ -1509,6 +1431,84 @@ paths:
               schema:
                 $ref: '#/components/schemas/FrameworkDetail'
           description: ''
+    patch:
+      operationId: catalogs_api_frameworks_partial_update
+      description: Update specific fields of an existing compliance framework.
+      summary: Partially update framework
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this framework.
+        required: true
+      tags:
+      - Frameworks
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedFrameworkDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedFrameworkDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedFrameworkDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FrameworkDetail'
+          description: ''
+    get:
+      operationId: catalogs_api_frameworks_retrieve
+      description: Retrieve detailed information about a specific compliance framework
+        including metadata and configuration.
+      summary: Get framework details
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this framework.
+        required: true
+      tags:
+      - Frameworks
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FrameworkDetail'
+          description: ''
+    delete:
+      operationId: catalogs_api_frameworks_destroy
+      description: Delete a compliance framework. This will also remove all associated
+        clauses and mappings.
+      summary: Delete framework
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this framework.
+        required: true
+      tags:
+      - Frameworks
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/catalogs/api/frameworks/{id}/clauses/:
     get:
       operationId: catalogs_api_frameworks_clauses_list
@@ -1697,35 +1697,6 @@ paths:
         '404':
           description: Framework not found
   /api/catalogs/api/clauses/:
-    post:
-      operationId: catalogs_api_clauses_create
-      description: |-
-        ViewSet for managing framework clauses.
-        Provides CRUD operations and clause-specific endpoints.
-      tags:
-      - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ClauseDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ClauseDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ClauseDetailRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClauseDetail'
-          description: ''
     get:
       operationId: catalogs_api_clauses_list
       description: |-
@@ -1804,86 +1775,36 @@ paths:
                 items:
                   $ref: '#/components/schemas/ClauseList'
           description: ''
-  /api/catalogs/api/clauses/{id}/:
-    patch:
-      operationId: catalogs_api_clauses_partial_update
+    post:
+      operationId: catalogs_api_clauses_create
       description: |-
         ViewSet for managing framework clauses.
         Provides CRUD operations and clause-specific endpoints.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this clause.
-        required: true
       tags:
       - catalogs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedClauseDetailRequest'
+              $ref: '#/components/schemas/ClauseDetailRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedClauseDetailRequest'
+              $ref: '#/components/schemas/ClauseDetailRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedClauseDetailRequest'
+              $ref: '#/components/schemas/ClauseDetailRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ClauseDetail'
           description: ''
-    delete:
-      operationId: catalogs_api_clauses_destroy
-      description: |-
-        ViewSet for managing framework clauses.
-        Provides CRUD operations and clause-specific endpoints.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this clause.
-        required: true
-      tags:
-      - catalogs
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: catalogs_api_clauses_retrieve
-      description: |-
-        ViewSet for managing framework clauses.
-        Provides CRUD operations and clause-specific endpoints.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this clause.
-        required: true
-      tags:
-      - catalogs
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClauseDetail'
-          description: ''
+  /api/catalogs/api/clauses/{id}/:
     put:
       operationId: catalogs_api_clauses_update
       description: |-
@@ -1920,6 +1841,85 @@ paths:
               schema:
                 $ref: '#/components/schemas/ClauseDetail'
           description: ''
+    patch:
+      operationId: catalogs_api_clauses_partial_update
+      description: |-
+        ViewSet for managing framework clauses.
+        Provides CRUD operations and clause-specific endpoints.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this clause.
+        required: true
+      tags:
+      - catalogs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedClauseDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedClauseDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedClauseDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClauseDetail'
+          description: ''
+    get:
+      operationId: catalogs_api_clauses_retrieve
+      description: |-
+        ViewSet for managing framework clauses.
+        Provides CRUD operations and clause-specific endpoints.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this clause.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClauseDetail'
+          description: ''
+    delete:
+      operationId: catalogs_api_clauses_destroy
+      description: |-
+        ViewSet for managing framework clauses.
+        Provides CRUD operations and clause-specific endpoints.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this clause.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/catalogs/api/clauses/{id}/controls/:
     get:
       operationId: catalogs_api_clauses_controls_retrieve
@@ -1990,35 +1990,6 @@ paths:
                 $ref: '#/components/schemas/ClauseDetail'
           description: ''
   /api/catalogs/api/controls/:
-    post:
-      operationId: catalogs_api_controls_create
-      description: |-
-        ViewSet for managing controls.
-        Provides CRUD operations and control-specific endpoints.
-      tags:
-      - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ControlCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ControlCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ControlCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlCreateUpdate'
-          description: ''
     get:
       operationId: catalogs_api_controls_list
       description: |-
@@ -2157,6 +2128,35 @@ paths:
                 items:
                   $ref: '#/components/schemas/ControlList'
           description: ''
+    post:
+      operationId: catalogs_api_controls_create
+      description: |-
+        ViewSet for managing controls.
+        Provides CRUD operations and control-specific endpoints.
+      tags:
+      - catalogs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ControlCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ControlCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ControlCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlCreateUpdate'
+          description: ''
   /api/catalogs/api/controls/by_effectiveness/:
     get:
       operationId: catalogs_api_controls_by_effectiveness_retrieve
@@ -2190,85 +2190,6 @@ paths:
                 $ref: '#/components/schemas/ControlDetail'
           description: ''
   /api/catalogs/api/controls/{id}/:
-    patch:
-      operationId: catalogs_api_controls_partial_update
-      description: |-
-        ViewSet for managing controls.
-        Provides CRUD operations and control-specific endpoints.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this control.
-        required: true
-      tags:
-      - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedControlCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedControlCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedControlCreateUpdateRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlCreateUpdate'
-          description: ''
-    delete:
-      operationId: catalogs_api_controls_destroy
-      description: |-
-        ViewSet for managing controls.
-        Provides CRUD operations and control-specific endpoints.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this control.
-        required: true
-      tags:
-      - catalogs
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: catalogs_api_controls_retrieve
-      description: |-
-        ViewSet for managing controls.
-        Provides CRUD operations and control-specific endpoints.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this control.
-        required: true
-      tags:
-      - catalogs
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlDetail'
-          description: ''
     put:
       operationId: catalogs_api_controls_update
       description: |-
@@ -2305,6 +2226,85 @@ paths:
               schema:
                 $ref: '#/components/schemas/ControlCreateUpdate'
           description: ''
+    patch:
+      operationId: catalogs_api_controls_partial_update
+      description: |-
+        ViewSet for managing controls.
+        Provides CRUD operations and control-specific endpoints.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this control.
+        required: true
+      tags:
+      - catalogs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedControlCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedControlCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedControlCreateUpdateRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlCreateUpdate'
+          description: ''
+    get:
+      operationId: catalogs_api_controls_retrieve
+      description: |-
+        ViewSet for managing controls.
+        Provides CRUD operations and control-specific endpoints.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this control.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlDetail'
+          description: ''
+    delete:
+      operationId: catalogs_api_controls_destroy
+      description: |-
+        ViewSet for managing controls.
+        Provides CRUD operations and control-specific endpoints.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this control.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/catalogs/api/controls/{id}/evidence/:
     get:
       operationId: catalogs_api_controls_evidence_retrieve
@@ -2387,33 +2387,6 @@ paths:
                 $ref: '#/components/schemas/ControlDetail'
           description: ''
   /api/catalogs/api/evidence/:
-    post:
-      operationId: catalogs_api_evidence_create
-      description: ViewSet for managing control evidence.
-      tags:
-      - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ControlEvidenceRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ControlEvidenceRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ControlEvidenceRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlEvidence'
-          description: ''
     get:
       operationId: catalogs_api_evidence_list
       description: ViewSet for managing control evidence.
@@ -2480,80 +2453,34 @@ paths:
                 items:
                   $ref: '#/components/schemas/ControlEvidence'
           description: ''
-  /api/catalogs/api/evidence/{id}/:
-    patch:
-      operationId: catalogs_api_evidence_partial_update
+    post:
+      operationId: catalogs_api_evidence_create
       description: ViewSet for managing control evidence.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this control evidence.
-        required: true
       tags:
       - catalogs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedControlEvidenceRequest'
+              $ref: '#/components/schemas/ControlEvidenceRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedControlEvidenceRequest'
+              $ref: '#/components/schemas/ControlEvidenceRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedControlEvidenceRequest'
+              $ref: '#/components/schemas/ControlEvidenceRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ControlEvidence'
           description: ''
-    delete:
-      operationId: catalogs_api_evidence_destroy
-      description: ViewSet for managing control evidence.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this control evidence.
-        required: true
-      tags:
-      - catalogs
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: catalogs_api_evidence_retrieve
-      description: ViewSet for managing control evidence.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this control evidence.
-        required: true
-      tags:
-      - catalogs
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlEvidence'
-          description: ''
+  /api/catalogs/api/evidence/{id}/:
     put:
       operationId: catalogs_api_evidence_update
       description: ViewSet for managing control evidence.
@@ -2588,6 +2515,79 @@ paths:
               schema:
                 $ref: '#/components/schemas/ControlEvidence'
           description: ''
+    patch:
+      operationId: catalogs_api_evidence_partial_update
+      description: ViewSet for managing control evidence.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this control evidence.
+        required: true
+      tags:
+      - catalogs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedControlEvidenceRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedControlEvidenceRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedControlEvidenceRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlEvidence'
+          description: ''
+    get:
+      operationId: catalogs_api_evidence_retrieve
+      description: ViewSet for managing control evidence.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this control evidence.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlEvidence'
+          description: ''
+    delete:
+      operationId: catalogs_api_evidence_destroy
+      description: ViewSet for managing control evidence.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this control evidence.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/catalogs/api/evidence/{id}/assessments/:
     get:
       operationId: catalogs_api_evidence_assessments_retrieve
@@ -2798,33 +2798,6 @@ paths:
                 $ref: '#/components/schemas/TemplateDocument'
           description: ''
   /api/catalogs/api/mappings/:
-    post:
-      operationId: catalogs_api_mappings_create
-      description: ViewSet for managing framework mappings.
-      tags:
-      - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FrameworkMappingRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/FrameworkMappingRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/FrameworkMappingRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FrameworkMapping'
-          description: ''
     get:
       operationId: catalogs_api_mappings_list
       description: ViewSet for managing framework mappings.
@@ -2877,80 +2850,34 @@ paths:
                 items:
                   $ref: '#/components/schemas/FrameworkMapping'
           description: ''
-  /api/catalogs/api/mappings/{id}/:
-    patch:
-      operationId: catalogs_api_mappings_partial_update
+    post:
+      operationId: catalogs_api_mappings_create
       description: ViewSet for managing framework mappings.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this framework mapping.
-        required: true
       tags:
       - catalogs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedFrameworkMappingRequest'
+              $ref: '#/components/schemas/FrameworkMappingRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedFrameworkMappingRequest'
+              $ref: '#/components/schemas/FrameworkMappingRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedFrameworkMappingRequest'
+              $ref: '#/components/schemas/FrameworkMappingRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FrameworkMapping'
           description: ''
-    delete:
-      operationId: catalogs_api_mappings_destroy
-      description: ViewSet for managing framework mappings.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this framework mapping.
-        required: true
-      tags:
-      - catalogs
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: catalogs_api_mappings_retrieve
-      description: ViewSet for managing framework mappings.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this framework mapping.
-        required: true
-      tags:
-      - catalogs
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FrameworkMapping'
-          description: ''
+  /api/catalogs/api/mappings/{id}/:
     put:
       operationId: catalogs_api_mappings_update
       description: ViewSet for managing framework mappings.
@@ -2985,36 +2912,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/FrameworkMapping'
           description: ''
-  /api/catalogs/api/assessments/:
-    post:
-      operationId: catalogs_api_assessments_create
-      description: Create a new control assessment with all required metadata and
-        assignment information.
-      summary: Create control assessment
+    patch:
+      operationId: catalogs_api_mappings_partial_update
+      description: ViewSet for managing framework mappings.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this framework mapping.
+        required: true
       tags:
-      - Assessments
+      - catalogs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
+              $ref: '#/components/schemas/PatchedFrameworkMappingRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
+              $ref: '#/components/schemas/PatchedFrameworkMappingRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedFrameworkMappingRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ControlAssessmentCreateUpdate'
+                $ref: '#/components/schemas/FrameworkMapping'
           description: ''
+    get:
+      operationId: catalogs_api_mappings_retrieve
+      description: ViewSet for managing framework mappings.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this framework mapping.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FrameworkMapping'
+          description: ''
+    delete:
+      operationId: catalogs_api_mappings_destroy
+      description: ViewSet for managing framework mappings.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this framework mapping.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/catalogs/api/assessments/:
     get:
       operationId: catalogs_api_assessments_list
       description: Retrieve a paginated list of control assessments with comprehensive
@@ -3132,6 +3103,35 @@ paths:
                   summary: Get current user's overdue assessments
                   description: Example of filtering for current user's overdue assessments
           description: ''
+    post:
+      operationId: catalogs_api_assessments_create
+      description: Create a new control assessment with all required metadata and
+        assignment information.
+      summary: Create control assessment
+      tags:
+      - Assessments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ControlAssessmentCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlAssessmentCreateUpdate'
+          description: ''
   /api/catalogs/api/assessments/bulk_create/:
     post:
       operationId: catalogs_api_assessments_bulk_create_create
@@ -3242,83 +3242,6 @@ paths:
                   description: Comprehensive progress report with statistics and breakdowns
           description: ''
   /api/catalogs/api/assessments/{id}/:
-    patch:
-      operationId: catalogs_api_assessments_partial_update
-      description: Update specific fields of an existing control assessment.
-      summary: Partially update assessment
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this control assessment.
-        required: true
-      tags:
-      - Assessments
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedControlAssessmentCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedControlAssessmentCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedControlAssessmentCreateUpdateRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlAssessmentCreateUpdate'
-          description: ''
-    delete:
-      operationId: catalogs_api_assessments_destroy
-      description: Delete a control assessment and all associated evidence links.
-      summary: Delete assessment
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this control assessment.
-        required: true
-      tags:
-      - Assessments
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: catalogs_api_assessments_retrieve
-      description: Retrieve detailed information about a specific control assessment
-        including evidence links and progress.
-      summary: Get assessment details
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this control assessment.
-        required: true
-      tags:
-      - Assessments
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlAssessmentDetail'
-          description: ''
     put:
       operationId: catalogs_api_assessments_update
       description: Update an existing control assessment. Requires all fields.
@@ -3354,6 +3277,83 @@ paths:
               schema:
                 $ref: '#/components/schemas/ControlAssessmentCreateUpdate'
           description: ''
+    patch:
+      operationId: catalogs_api_assessments_partial_update
+      description: Update specific fields of an existing control assessment.
+      summary: Partially update assessment
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this control assessment.
+        required: true
+      tags:
+      - Assessments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedControlAssessmentCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedControlAssessmentCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedControlAssessmentCreateUpdateRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlAssessmentCreateUpdate'
+          description: ''
+    get:
+      operationId: catalogs_api_assessments_retrieve
+      description: Retrieve detailed information about a specific control assessment
+        including evidence links and progress.
+      summary: Get assessment details
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this control assessment.
+        required: true
+      tags:
+      - Assessments
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlAssessmentDetail'
+          description: ''
+    delete:
+      operationId: catalogs_api_assessments_destroy
+      description: Delete a control assessment and all associated evidence links.
+      summary: Delete assessment
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this control assessment.
+        required: true
+      tags:
+      - Assessments
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/catalogs/api/assessments/{id}/bulk_upload_evidence/:
     post:
       operationId: catalogs_api_assessments_bulk_upload_evidence_create
@@ -3561,33 +3561,6 @@ paths:
         '404':
           description: Assessment not found
   /api/catalogs/api/assessment-evidence/:
-    post:
-      operationId: catalogs_api_assessment_evidence_create
-      description: ViewSet for managing assessment evidence links.
-      tags:
-      - catalogs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AssessmentEvidenceRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AssessmentEvidenceRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/AssessmentEvidenceRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssessmentEvidence'
-          description: ''
     get:
       operationId: catalogs_api_assessment_evidence_list
       description: ViewSet for managing assessment evidence links.
@@ -3630,80 +3603,34 @@ paths:
                 items:
                   $ref: '#/components/schemas/AssessmentEvidence'
           description: ''
-  /api/catalogs/api/assessment-evidence/{id}/:
-    patch:
-      operationId: catalogs_api_assessment_evidence_partial_update
+    post:
+      operationId: catalogs_api_assessment_evidence_create
       description: ViewSet for managing assessment evidence links.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this assessment evidence.
-        required: true
       tags:
       - catalogs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedAssessmentEvidenceRequest'
+              $ref: '#/components/schemas/AssessmentEvidenceRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedAssessmentEvidenceRequest'
+              $ref: '#/components/schemas/AssessmentEvidenceRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedAssessmentEvidenceRequest'
+              $ref: '#/components/schemas/AssessmentEvidenceRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssessmentEvidence'
           description: ''
-    delete:
-      operationId: catalogs_api_assessment_evidence_destroy
-      description: ViewSet for managing assessment evidence links.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this assessment evidence.
-        required: true
-      tags:
-      - catalogs
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: catalogs_api_assessment_evidence_retrieve
-      description: ViewSet for managing assessment evidence links.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this assessment evidence.
-        required: true
-      tags:
-      - catalogs
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssessmentEvidence'
-          description: ''
+  /api/catalogs/api/assessment-evidence/{id}/:
     put:
       operationId: catalogs_api_assessment_evidence_update
       description: ViewSet for managing assessment evidence links.
@@ -3738,33 +3665,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/AssessmentEvidence'
           description: ''
-  /api/compliance/artefacts/:
-    post:
-      operationId: compliance_artefacts_create
+    patch:
+      operationId: catalogs_api_assessment_evidence_partial_update
+      description: ViewSet for managing assessment evidence links.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this assessment evidence.
+        required: true
       tags:
-      - compliance
+      - catalogs
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GovernanceArtefactRequest'
+              $ref: '#/components/schemas/PatchedAssessmentEvidenceRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/GovernanceArtefactRequest'
+              $ref: '#/components/schemas/PatchedAssessmentEvidenceRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/GovernanceArtefactRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedAssessmentEvidenceRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GovernanceArtefact'
+                $ref: '#/components/schemas/AssessmentEvidence'
           description: ''
+    get:
+      operationId: catalogs_api_assessment_evidence_retrieve
+      description: ViewSet for managing assessment evidence links.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this assessment evidence.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssessmentEvidence'
+          description: ''
+    delete:
+      operationId: catalogs_api_assessment_evidence_destroy
+      description: ViewSet for managing assessment evidence links.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this assessment evidence.
+        required: true
+      tags:
+      - catalogs
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/compliance/artefacts/:
     get:
       operationId: compliance_artefacts_list
       parameters:
@@ -3850,77 +3824,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedGovernanceArtefactList'
           description: ''
-  /api/compliance/artefacts/{id}/:
-    patch:
-      operationId: compliance_artefacts_partial_update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this governance artefact.
-        required: true
+    post:
+      operationId: compliance_artefacts_create
       tags:
       - compliance
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedGovernanceArtefactRequest'
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedGovernanceArtefactRequest'
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedGovernanceArtefactRequest'
+              $ref: '#/components/schemas/GovernanceArtefactRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GovernanceArtefact'
           description: ''
-    delete:
-      operationId: compliance_artefacts_destroy
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this governance artefact.
-        required: true
-      tags:
-      - compliance
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: compliance_artefacts_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this governance artefact.
-        required: true
-      tags:
-      - compliance
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GovernanceArtefact'
-          description: ''
+  /api/compliance/artefacts/{id}/:
     put:
       operationId: compliance_artefacts_update
       parameters:
@@ -3954,33 +3884,77 @@ paths:
               schema:
                 $ref: '#/components/schemas/GovernanceArtefact'
           description: ''
-  /api/compliance/regulatory-requirements/:
-    post:
-      operationId: compliance_regulatory_requirements_create
+    patch:
+      operationId: compliance_artefacts_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this governance artefact.
+        required: true
       tags:
       - compliance
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+              $ref: '#/components/schemas/PatchedGovernanceArtefactRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+              $ref: '#/components/schemas/PatchedGovernanceArtefactRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/RegulatoryRequirementRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedGovernanceArtefactRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RegulatoryRequirement'
+                $ref: '#/components/schemas/GovernanceArtefact'
           description: ''
+    get:
+      operationId: compliance_artefacts_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this governance artefact.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GovernanceArtefact'
+          description: ''
+    delete:
+      operationId: compliance_artefacts_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this governance artefact.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/compliance/regulatory-requirements/:
     get:
       operationId: compliance_regulatory_requirements_list
       parameters:
@@ -4090,77 +4064,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedRegulatoryRequirementList'
           description: ''
-  /api/compliance/regulatory-requirements/{id}/:
-    patch:
-      operationId: compliance_regulatory_requirements_partial_update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this regulatory requirement.
-        required: true
+    post:
+      operationId: compliance_regulatory_requirements_create
       tags:
       - compliance
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedRegulatoryRequirementRequest'
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedRegulatoryRequirementRequest'
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedRegulatoryRequirementRequest'
+              $ref: '#/components/schemas/RegulatoryRequirementRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RegulatoryRequirement'
           description: ''
-    delete:
-      operationId: compliance_regulatory_requirements_destroy
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this regulatory requirement.
-        required: true
-      tags:
-      - compliance
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: compliance_regulatory_requirements_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this regulatory requirement.
-        required: true
-      tags:
-      - compliance
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RegulatoryRequirement'
-          description: ''
+  /api/compliance/regulatory-requirements/{id}/:
     put:
       operationId: compliance_regulatory_requirements_update
       parameters:
@@ -4194,33 +4124,77 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegulatoryRequirement'
           description: ''
-  /api/compliance/non-conformities/:
-    post:
-      operationId: compliance_non_conformities_create
+    patch:
+      operationId: compliance_regulatory_requirements_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this regulatory requirement.
+        required: true
       tags:
       - compliance
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NonConformityRequest'
+              $ref: '#/components/schemas/PatchedRegulatoryRequirementRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/NonConformityRequest'
+              $ref: '#/components/schemas/PatchedRegulatoryRequirementRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/NonConformityRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedRegulatoryRequirementRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NonConformity'
+                $ref: '#/components/schemas/RegulatoryRequirement'
           description: ''
+    get:
+      operationId: compliance_regulatory_requirements_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this regulatory requirement.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryRequirement'
+          description: ''
+    delete:
+      operationId: compliance_regulatory_requirements_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this regulatory requirement.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/compliance/non-conformities/:
     get:
       operationId: compliance_non_conformities_list
       parameters:
@@ -4318,77 +4292,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedNonConformityList'
           description: ''
-  /api/compliance/non-conformities/{id}/:
-    patch:
-      operationId: compliance_non_conformities_partial_update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this non conformity.
-        required: true
+    post:
+      operationId: compliance_non_conformities_create
       tags:
       - compliance
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedNonConformityRequest'
+              $ref: '#/components/schemas/NonConformityRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedNonConformityRequest'
+              $ref: '#/components/schemas/NonConformityRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedNonConformityRequest'
+              $ref: '#/components/schemas/NonConformityRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/NonConformity'
           description: ''
-    delete:
-      operationId: compliance_non_conformities_destroy
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this non conformity.
-        required: true
-      tags:
-      - compliance
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: compliance_non_conformities_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this non conformity.
-        required: true
-      tags:
-      - compliance
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NonConformity'
-          description: ''
+  /api/compliance/non-conformities/{id}/:
     put:
       operationId: compliance_non_conformities_update
       parameters:
@@ -4422,33 +4352,77 @@ paths:
               schema:
                 $ref: '#/components/schemas/NonConformity'
           description: ''
-  /api/compliance/management-reviews/:
-    post:
-      operationId: compliance_management_reviews_create
+    patch:
+      operationId: compliance_non_conformities_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this non conformity.
+        required: true
       tags:
       - compliance
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ManagementReviewRequest'
+              $ref: '#/components/schemas/PatchedNonConformityRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ManagementReviewRequest'
+              $ref: '#/components/schemas/PatchedNonConformityRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ManagementReviewRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedNonConformityRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ManagementReview'
+                $ref: '#/components/schemas/NonConformity'
           description: ''
+    get:
+      operationId: compliance_non_conformities_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this non conformity.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NonConformity'
+          description: ''
+    delete:
+      operationId: compliance_non_conformities_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this non conformity.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/compliance/management-reviews/:
     get:
       operationId: compliance_management_reviews_list
       parameters:
@@ -4524,77 +4498,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedManagementReviewList'
           description: ''
-  /api/compliance/management-reviews/{id}/:
-    patch:
-      operationId: compliance_management_reviews_partial_update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this management review.
-        required: true
+    post:
+      operationId: compliance_management_reviews_create
       tags:
       - compliance
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedManagementReviewRequest'
+              $ref: '#/components/schemas/ManagementReviewRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedManagementReviewRequest'
+              $ref: '#/components/schemas/ManagementReviewRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedManagementReviewRequest'
+              $ref: '#/components/schemas/ManagementReviewRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManagementReview'
           description: ''
-    delete:
-      operationId: compliance_management_reviews_destroy
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this management review.
-        required: true
-      tags:
-      - compliance
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: compliance_management_reviews_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this management review.
-        required: true
-      tags:
-      - compliance
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ManagementReview'
-          description: ''
+  /api/compliance/management-reviews/{id}/:
     put:
       operationId: compliance_management_reviews_update
       parameters:
@@ -4628,36 +4558,77 @@ paths:
               schema:
                 $ref: '#/components/schemas/ManagementReview'
           description: ''
-  /api/exports/assessment-reports/:
-    post:
-      operationId: exports_assessment_reports_create
-      description: Create a new assessment report configuration. Use the 'generate'
-        action to start report generation.
-      summary: Create assessment report
+    patch:
+      operationId: compliance_management_reviews_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this management review.
+        required: true
       tags:
-      - Reports
+      - compliance
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AssessmentReportCreateRequest'
+              $ref: '#/components/schemas/PatchedManagementReviewRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/AssessmentReportCreateRequest'
+              $ref: '#/components/schemas/PatchedManagementReviewRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/AssessmentReportCreateRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedManagementReviewRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AssessmentReportCreate'
+                $ref: '#/components/schemas/ManagementReview'
           description: ''
+    get:
+      operationId: compliance_management_reviews_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this management review.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagementReview'
+          description: ''
+    delete:
+      operationId: compliance_management_reviews_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this management review.
+        required: true
+      tags:
+      - compliance
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/exports/assessment-reports/:
     get:
       operationId: exports_assessment_reports_list
       description: Retrieve a list of assessment reports created by the current user
@@ -4692,6 +4663,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AssessmentReport'
+          description: ''
+    post:
+      operationId: exports_assessment_reports_create
+      description: Create a new assessment report configuration. Use the 'generate'
+        action to start report generation.
+      summary: Create assessment report
+      tags:
+      - Reports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportCreateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportCreateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportCreateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssessmentReportCreate'
           description: ''
   /api/exports/assessment-reports/assessment_options/:
     get:
@@ -4756,6 +4756,42 @@ paths:
         '500':
           description: Failed to start generation
   /api/exports/assessment-reports/{id}/:
+    put:
+      operationId: exports_assessment_reports_update
+      description: Update an existing assessment report configuration. Cannot update
+        reports that are processing or completed.
+      summary: Update report
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this assessment report.
+        required: true
+      tags:
+      - Reports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AssessmentReportRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssessmentReport'
+          description: ''
     patch:
       operationId: exports_assessment_reports_partial_update
       description: |-
@@ -4815,25 +4851,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/AssessmentReport'
           description: ''
-    delete:
-      operationId: exports_assessment_reports_destroy
-      description: Delete an assessment report and its generated file if it exists.
-      summary: Delete report
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this assessment report.
-        required: true
-      tags:
-      - Reports
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
     get:
       operationId: exports_assessment_reports_retrieve
       description: Retrieve detailed information about a specific assessment report
@@ -4858,11 +4875,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/AssessmentReport'
           description: ''
-    put:
-      operationId: exports_assessment_reports_update
-      description: Update an existing assessment report configuration. Cannot update
-        reports that are processing or completed.
-      summary: Update report
+    delete:
+      operationId: exports_assessment_reports_destroy
+      description: Delete an assessment report and its generated file if it exists.
+      summary: Delete report
       parameters:
       - in: path
         name: id
@@ -4872,28 +4888,12 @@ paths:
         required: true
       tags:
       - Reports
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AssessmentReportRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AssessmentReportRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/AssessmentReportRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssessmentReport'
-          description: ''
+        '204':
+          description: No response body
   /api/exports/assessment-reports/{id}/download/:
     get:
       operationId: exports_assessment_reports_download_retrieve
@@ -4978,33 +4978,6 @@ paths:
                 $ref: '#/components/schemas/AssessmentReport'
           description: ''
   /api/exports/tenant-data-exports/:
-    post:
-      operationId: exports_tenant_data_exports_create
-      description: Create a tenant-wide GRC data export and start asynchronous generation.
-      summary: Create tenant data export
-      tags:
-      - Data Exports
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TenantDataExportCreateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/TenantDataExportCreateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/TenantDataExportCreateRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TenantDataExportCreate'
-          description: ''
     get:
       operationId: exports_tenant_data_exports_list
       description: Retrieve tenant data export jobs requested by the current user.
@@ -5048,6 +5021,33 @@ paths:
                 items:
                   $ref: '#/components/schemas/TenantDataExport'
           description: ''
+    post:
+      operationId: exports_tenant_data_exports_create
+      description: Create a tenant-wide GRC data export and start asynchronous generation.
+      summary: Create tenant data export
+      tags:
+      - Data Exports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantDataExportCreateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TenantDataExportCreateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TenantDataExportCreateRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantDataExportCreate'
+          description: ''
   /api/exports/tenant-data-exports/coverage/:
     get:
       operationId: exports_tenant_data_exports_coverage_retrieve
@@ -5067,25 +5067,6 @@ paths:
                 $ref: '#/components/schemas/TenantDataExport'
           description: ''
   /api/exports/tenant-data-exports/{id}/:
-    delete:
-      operationId: exports_tenant_data_exports_destroy
-      description: Delete a tenant data export job and its generated document reference.
-      summary: Delete tenant data export
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this tenant data export.
-        required: true
-      tags:
-      - Data Exports
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
     get:
       operationId: exports_tenant_data_exports_retrieve
       description: Retrieve status and download metadata for a tenant data export.
@@ -5109,6 +5090,25 @@ paths:
               schema:
                 $ref: '#/components/schemas/TenantDataExport'
           description: ''
+    delete:
+      operationId: exports_tenant_data_exports_destroy
+      description: Delete a tenant data export job and its generated document reference.
+      summary: Delete tenant data export
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this tenant data export.
+        required: true
+      tags:
+      - Data Exports
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/exports/tenant-data-exports/{id}/download/:
     get:
       operationId: exports_tenant_data_exports_download_retrieve
@@ -5190,34 +5190,6 @@ paths:
                 $ref: '#/components/schemas/TenantDataExport'
           description: ''
   /api/risk/risks/:
-    post:
-      operationId: risk_risks_create
-      description: Create a new risk entry with impact and likelihood assessment.
-      summary: Create new risk
-      tags:
-      - Risk Management
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskCreateUpdate'
-          description: ''
     get:
       operationId: risk_risks_list
       description: Retrieve a paginated list of risks with comprehensive filtering,
@@ -5386,6 +5358,34 @@ paths:
                   summary: Get high and critical risks
                   description: Example of filtering for high priority risks
           description: ''
+    post:
+      operationId: risk_risks_create
+      description: Create a new risk entry with impact and likelihood assessment.
+      summary: Create new risk
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskCreateUpdate'
+          description: ''
   /api/risk/risks/bulk_create/:
     post:
       operationId: risk_risks_bulk_create_create
@@ -5446,83 +5446,6 @@ paths:
                 $ref: '#/components/schemas/RiskSummary'
           description: ''
   /api/risk/risks/{id}/:
-    patch:
-      operationId: risk_risks_partial_update
-      description: Update specific fields of an existing risk entry.
-      summary: Partially update risk
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this risk.
-        required: true
-      tags:
-      - Risk Management
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedRiskCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedRiskCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedRiskCreateUpdateRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskCreateUpdate'
-          description: ''
-    delete:
-      operationId: risk_risks_destroy
-      description: Delete a risk entry and all associated notes.
-      summary: Delete risk
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this risk.
-        required: true
-      tags:
-      - Risk Management
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: risk_risks_retrieve
-      description: Retrieve detailed information about a specific risk including notes
-        and history.
-      summary: Get risk details
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this risk.
-        required: true
-      tags:
-      - Risk Management
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskDetail'
-          description: ''
     put:
       operationId: risk_risks_update
       description: Update an existing risk entry. Risk level will be automatically
@@ -5559,6 +5482,83 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskCreateUpdate'
           description: ''
+    patch:
+      operationId: risk_risks_partial_update
+      description: Update specific fields of an existing risk entry.
+      summary: Partially update risk
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk.
+        required: true
+      tags:
+      - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskCreateUpdateRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskCreateUpdate'
+          description: ''
+    get:
+      operationId: risk_risks_retrieve
+      description: Retrieve detailed information about a specific risk including notes
+        and history.
+      summary: Get risk details
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk.
+        required: true
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskDetail'
+          description: ''
+    delete:
+      operationId: risk_risks_destroy
+      description: Delete a risk entry and all associated notes.
+      summary: Delete risk
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk.
+        required: true
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/risk/risks/{id}/add_note/:
     post:
       operationId: risk_risks_add_note_create
@@ -5647,6 +5647,24 @@ paths:
         '404':
           description: Risk not found
   /api/risk/categories/:
+    get:
+      operationId: risk_categories_list
+      description: Retrieve all risk categories with risk counts.
+      summary: List risk categories
+      tags:
+      - Risk Management
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskCategory'
+          description: ''
     post:
       operationId: risk_categories_create
       description: Create a new risk category for organizing risks.
@@ -5675,12 +5693,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskCategory'
           description: ''
-    get:
-      operationId: risk_categories_list
-      description: Retrieve all risk categories with risk counts.
-      summary: List risk categories
+  /api/risk/categories/{id}/:
+    put:
+      operationId: risk_categories_update
+      description: Update an existing risk category.
+      summary: Update risk category
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk category.
+        required: true
       tags:
       - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskCategoryRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -5689,11 +5727,8 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RiskCategory'
+                $ref: '#/components/schemas/RiskCategory'
           description: ''
-  /api/risk/categories/{id}/:
     patch:
       operationId: risk_categories_partial_update
       description: |-
@@ -5731,25 +5766,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskCategory'
           description: ''
-    delete:
-      operationId: risk_categories_destroy
-      description: Delete a risk category. Risks in this category will become uncategorized.
-      summary: Delete risk category
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this risk category.
-        required: true
-      tags:
-      - Risk Management
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
     get:
       operationId: risk_categories_retrieve
       description: Retrieve detailed information about a risk category.
@@ -5773,10 +5789,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskCategory'
           description: ''
-    put:
-      operationId: risk_categories_update
-      description: Update an existing risk category.
-      summary: Update risk category
+    delete:
+      operationId: risk_categories_destroy
+      description: Delete a risk category. Risks in this category will become uncategorized.
+      summary: Delete risk category
       parameters:
       - in: path
         name: id
@@ -5786,18 +5802,19 @@ paths:
         required: true
       tags:
       - Risk Management
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskCategoryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskCategoryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskCategoryRequest'
-        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/risk/matrices/:
+    get:
+      operationId: risk_matrices_list
+      description: Retrieve all available risk assessment matrices.
+      summary: List risk matrices
+      tags:
+      - Risk Management
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -5806,9 +5823,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RiskCategory'
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskMatrix'
           description: ''
-  /api/risk/matrices/:
     post:
       operationId: risk_matrices_create
       description: Create a new risk assessment matrix with custom configuration.
@@ -5837,12 +5855,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskMatrix'
           description: ''
-    get:
-      operationId: risk_matrices_list
-      description: Retrieve all available risk assessment matrices.
-      summary: List risk matrices
+  /api/risk/matrices/{id}/:
+    put:
+      operationId: risk_matrices_update
+      description: Update an existing risk matrix configuration.
+      summary: Update risk matrix
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk matrix.
+        required: true
       tags:
       - Risk Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskMatrixRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -5851,11 +5889,8 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RiskMatrix'
+                $ref: '#/components/schemas/RiskMatrix'
           description: ''
-  /api/risk/matrices/{id}/:
     patch:
       operationId: risk_matrices_partial_update
       description: |-
@@ -5893,26 +5928,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskMatrix'
           description: ''
-    delete:
-      operationId: risk_matrices_destroy
-      description: Delete a risk matrix. Cannot delete if it's the default matrix
-        or in use by risks.
-      summary: Delete risk matrix
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this risk matrix.
-        required: true
-      tags:
-      - Risk Management
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
     get:
       operationId: risk_matrices_retrieve
       description: Retrieve detailed information about a risk matrix including configuration.
@@ -5936,10 +5951,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskMatrix'
           description: ''
-    put:
-      operationId: risk_matrices_update
-      description: Update an existing risk matrix configuration.
-      summary: Update risk matrix
+    delete:
+      operationId: risk_matrices_destroy
+      description: Delete a risk matrix. Cannot delete if it's the default matrix
+        or in use by risks.
+      summary: Delete risk matrix
       parameters:
       - in: path
         name: id
@@ -5949,57 +5965,13 @@ paths:
         required: true
       tags:
       - Risk Management
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskMatrixRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskMatrixRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskMatrixRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskMatrix'
-          description: ''
+        '204':
+          description: No response body
   /api/risk/actions/:
-    post:
-      operationId: risk_actions_create
-      description: Create a new risk action with assignment and scheduling.
-      summary: Create new risk action
-      tags:
-      - Risk Actions
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskActionCreateUpdate'
-          description: ''
     get:
       operationId: risk_actions_list
       description: Retrieve a paginated list of risk actions with comprehensive filtering,
@@ -6180,6 +6152,34 @@ paths:
                 items:
                   $ref: '#/components/schemas/RiskActionList'
           description: ''
+    post:
+      operationId: risk_actions_create
+      description: Create a new risk action with assignment and scheduling.
+      summary: Create new risk action
+      tags:
+      - Risk Actions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionCreateUpdate'
+          description: ''
   /api/risk/actions/bulk_create/:
     post:
       operationId: risk_actions_bulk_create_create
@@ -6238,83 +6238,6 @@ paths:
                 $ref: '#/components/schemas/RiskActionSummary'
           description: ''
   /api/risk/actions/{id}/:
-    patch:
-      operationId: risk_actions_partial_update
-      description: Update specific fields of an existing risk action.
-      summary: Partially update risk action
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this risk action.
-        required: true
-      tags:
-      - Risk Actions
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedRiskActionCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedRiskActionCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedRiskActionCreateUpdateRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskActionCreateUpdate'
-          description: ''
-    delete:
-      operationId: risk_actions_destroy
-      description: Delete a risk action and all associated notes and evidence.
-      summary: Delete risk action
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this risk action.
-        required: true
-      tags:
-      - Risk Actions
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: risk_actions_retrieve
-      description: Retrieve detailed information about a specific risk action including
-        notes and evidence.
-      summary: Get risk action details
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this risk action.
-        required: true
-      tags:
-      - Risk Actions
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskActionDetail'
-          description: ''
     put:
       operationId: risk_actions_update
       description: Update an existing risk action. Progress and status will be validated.
@@ -6350,6 +6273,83 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskActionCreateUpdate'
           description: ''
+    patch:
+      operationId: risk_actions_partial_update
+      description: Update specific fields of an existing risk action.
+      summary: Partially update risk action
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk action.
+        required: true
+      tags:
+      - Risk Actions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskActionCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskActionCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedRiskActionCreateUpdateRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionCreateUpdate'
+          description: ''
+    get:
+      operationId: risk_actions_retrieve
+      description: Retrieve detailed information about a specific risk action including
+        notes and evidence.
+      summary: Get risk action details
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk action.
+        required: true
+      tags:
+      - Risk Actions
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionDetail'
+          description: ''
+    delete:
+      operationId: risk_actions_destroy
+      description: Delete a risk action and all associated notes and evidence.
+      summary: Delete risk action
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this risk action.
+        required: true
+      tags:
+      - Risk Actions
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/risk/actions/{id}/add_note/:
     post:
       operationId: risk_actions_add_note_create
@@ -6488,6 +6488,24 @@ paths:
         '404':
           description: Risk action not found
   /api/risk/reminder-config/:
+    get:
+      operationId: risk_reminder_config_list
+      description: Retrieve risk action reminder configurations for all users.
+      summary: List reminder configurations
+      tags:
+      - Risk Action Reminders
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskActionReminderConfiguration'
+          description: ''
     post:
       operationId: risk_reminder_config_create
       description: Create risk action reminder configuration for current user.
@@ -6515,12 +6533,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskActionReminderConfiguration'
           description: ''
-    get:
-      operationId: risk_reminder_config_list
-      description: Retrieve risk action reminder configurations for all users.
-      summary: List reminder configurations
+  /api/risk/reminder-config/{id}/:
+    put:
+      operationId: risk_reminder_config_update
+      description: Update risk action reminder configuration settings.
+      summary: Update reminder configuration
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Risk Action Reminder
+          Configuration.
+        required: true
       tags:
       - Risk Action Reminders
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
@@ -6529,11 +6567,8 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RiskActionReminderConfiguration'
+                $ref: '#/components/schemas/RiskActionReminderConfiguration'
           description: ''
-  /api/risk/reminder-config/{id}/:
     patch:
       operationId: risk_reminder_config_partial_update
       description: |-
@@ -6575,6 +6610,30 @@ paths:
               schema:
                 $ref: '#/components/schemas/RiskActionReminderConfiguration'
           description: ''
+    get:
+      operationId: risk_reminder_config_retrieve
+      description: Retrieve detailed risk action reminder configuration.
+      summary: Get reminder configuration
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Risk Action Reminder
+          Configuration.
+        required: true
+      tags:
+      - Risk Action Reminders
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskActionReminderConfiguration'
+          description: ''
     delete:
       operationId: risk_reminder_config_destroy
       description: |-
@@ -6601,65 +6660,6 @@ paths:
       responses:
         '204':
           description: No response body
-    get:
-      operationId: risk_reminder_config_retrieve
-      description: Retrieve detailed risk action reminder configuration.
-      summary: Get reminder configuration
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this Risk Action Reminder
-          Configuration.
-        required: true
-      tags:
-      - Risk Action Reminders
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskActionReminderConfiguration'
-          description: ''
-    put:
-      operationId: risk_reminder_config_update
-      description: Update risk action reminder configuration settings.
-      summary: Update reminder configuration
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this Risk Action Reminder
-          Configuration.
-        required: true
-      tags:
-      - Risk Action Reminders
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/RiskActionReminderConfigurationRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RiskActionReminderConfiguration'
-          description: ''
   /api/risk/analytics/action_overview/:
     get:
       operationId: risk_analytics_action_overview_retrieve
@@ -6939,6 +6939,28 @@ paths:
         '500':
           description: Failed to generate trend analysis
   /api/policies/categories/:
+    get:
+      operationId: policies_categories_list
+      description: ViewSet for managing policy categories.
+      parameters:
+      - in: query
+        name: name
+        schema:
+          type: string
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyCategory'
+          description: ''
     post:
       operationId: policies_categories_create
       description: ViewSet for managing policy categories.
@@ -6966,105 +6988,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PolicyCategory'
           description: ''
-    get:
-      operationId: policies_categories_list
-      description: ViewSet for managing policy categories.
-      parameters:
-      - in: query
-        name: name
-        schema:
-          type: string
-      tags:
-      - policies
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PolicyCategory'
-          description: ''
   /api/policies/categories/{id}/:
-    patch:
-      operationId: policies_categories_partial_update
-      description: ViewSet for managing policy categories.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Policy Category.
-        required: true
-      tags:
-      - policies
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedPolicyCategoryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedPolicyCategoryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedPolicyCategoryRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PolicyCategory'
-          description: ''
-    delete:
-      operationId: policies_categories_destroy
-      description: ViewSet for managing policy categories.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Policy Category.
-        required: true
-      tags:
-      - policies
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: policies_categories_retrieve
-      description: ViewSet for managing policy categories.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Policy Category.
-        required: true
-      tags:
-      - policies
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PolicyCategory'
-          description: ''
     put:
       operationId: policies_categories_update
       description: ViewSet for managing policy categories.
@@ -7100,6 +7024,82 @@ paths:
               schema:
                 $ref: '#/components/schemas/PolicyCategory'
           description: ''
+    patch:
+      operationId: policies_categories_partial_update
+      description: ViewSet for managing policy categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Category.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCategoryRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCategoryRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCategoryRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCategory'
+          description: ''
+    get:
+      operationId: policies_categories_retrieve
+      description: ViewSet for managing policy categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Category.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCategory'
+          description: ''
+    delete:
+      operationId: policies_categories_destroy
+      description: ViewSet for managing policy categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Category.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/policies/categories/{id}/policies/:
     get:
       operationId: policies_categories_policies_retrieve
@@ -7125,33 +7125,6 @@ paths:
                 $ref: '#/components/schemas/PolicyCategory'
           description: ''
   /api/policies/policies/:
-    post:
-      operationId: policies_policies_create
-      description: ViewSet for managing policies with versioning support.
-      tags:
-      - policies
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PolicyCreateUpdate'
-          description: ''
     get:
       operationId: policies_policies_list
       description: ViewSet for managing policies with versioning support.
@@ -7257,6 +7230,33 @@ paths:
                 items:
                   $ref: '#/components/schemas/PolicyList'
           description: ''
+    post:
+      operationId: policies_policies_create
+      description: ViewSet for managing policies with versioning support.
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCreateUpdate'
+          description: ''
   /api/policies/policies/acknowledgment_dashboard/:
     get:
       operationId: policies_policies_acknowledgment_dashboard_retrieve
@@ -7306,82 +7306,6 @@ paths:
                 $ref: '#/components/schemas/PolicyDetail'
           description: ''
   /api/policies/policies/{id}/:
-    patch:
-      operationId: policies_policies_partial_update
-      description: ViewSet for managing policies with versioning support.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Policy.
-        required: true
-      tags:
-      - policies
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedPolicyCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedPolicyCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedPolicyCreateUpdateRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PolicyCreateUpdate'
-          description: ''
-    delete:
-      operationId: policies_policies_destroy
-      description: ViewSet for managing policies with versioning support.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Policy.
-        required: true
-      tags:
-      - policies
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: policies_policies_retrieve
-      description: ViewSet for managing policies with versioning support.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Policy.
-        required: true
-      tags:
-      - policies
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PolicyDetail'
-          description: ''
     put:
       operationId: policies_policies_update
       description: ViewSet for managing policies with versioning support.
@@ -7417,6 +7341,82 @@ paths:
               schema:
                 $ref: '#/components/schemas/PolicyCreateUpdate'
           description: ''
+    patch:
+      operationId: policies_policies_partial_update
+      description: ViewSet for managing policies with versioning support.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyCreateUpdateRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyCreateUpdate'
+          description: ''
+    get:
+      operationId: policies_policies_retrieve
+      description: ViewSet for managing policies with versioning support.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDetail'
+          description: ''
+    delete:
+      operationId: policies_policies_destroy
+      description: ViewSet for managing policies with versioning support.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/policies/policies/{id}/acknowledge/:
     post:
       operationId: policies_policies_acknowledge_create
@@ -7538,33 +7538,6 @@ paths:
                 $ref: '#/components/schemas/PolicyDetail'
           description: ''
   /api/policies/versions/:
-    post:
-      operationId: policies_versions_create
-      description: ViewSet for managing policy versions.
-      tags:
-      - policies
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PolicyVersionDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PolicyVersionDetailRequest'
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PolicyVersionDetailRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PolicyVersionDetail'
-          description: ''
     get:
       operationId: policies_versions_list
       description: ViewSet for managing policy versions.
@@ -7646,83 +7619,34 @@ paths:
                 items:
                   $ref: '#/components/schemas/PolicyVersionList'
           description: ''
-  /api/policies/versions/{id}/:
-    patch:
-      operationId: policies_versions_partial_update
+    post:
+      operationId: policies_versions_create
       description: ViewSet for managing policy versions.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Policy Version.
-        required: true
       tags:
       - policies
       requestBody:
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedPolicyVersionDetailRequest'
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedPolicyVersionDetailRequest'
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedPolicyVersionDetailRequest'
+              $ref: '#/components/schemas/PolicyVersionDetailRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PolicyVersionDetail'
           description: ''
-    delete:
-      operationId: policies_versions_destroy
-      description: ViewSet for managing policy versions.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Policy Version.
-        required: true
-      tags:
-      - policies
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: policies_versions_retrieve
-      description: ViewSet for managing policy versions.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Policy Version.
-        required: true
-      tags:
-      - policies
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PolicyVersionDetail'
-          description: ''
+  /api/policies/versions/{id}/:
     put:
       operationId: policies_versions_update
       description: ViewSet for managing policy versions.
@@ -7758,6 +7682,82 @@ paths:
               schema:
                 $ref: '#/components/schemas/PolicyVersionDetail'
           description: ''
+    patch:
+      operationId: policies_versions_partial_update
+      description: ViewSet for managing policy versions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyVersionDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyVersionDetailRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedPolicyVersionDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+    get:
+      operationId: policies_versions_retrieve
+      description: ViewSet for managing policy versions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDetail'
+          description: ''
+    delete:
+      operationId: policies_versions_destroy
+      description: ViewSet for managing policy versions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Policy Version.
+        required: true
+      tags:
+      - policies
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/policies/versions/{id}/activate/:
     post:
       operationId: policies_versions_activate_create
@@ -8149,33 +8149,6 @@ paths:
                 $ref: '#/components/schemas/PolicyDistribution'
           description: ''
   /api/training/categories/:
-    post:
-      operationId: training_categories_create
-      description: ViewSet for managing training categories.
-      tags:
-      - training
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TrainingCategoryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/TrainingCategoryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/TrainingCategoryRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TrainingCategory'
-          description: ''
     get:
       operationId: training_categories_list
       description: ViewSet for managing training categories.
@@ -8206,83 +8179,34 @@ paths:
                 items:
                   $ref: '#/components/schemas/TrainingCategory'
           description: ''
-  /api/training/categories/{id}/:
-    patch:
-      operationId: training_categories_partial_update
+    post:
+      operationId: training_categories_create
       description: ViewSet for managing training categories.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this training category.
-        required: true
       tags:
       - training
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedTrainingCategoryRequest'
+              $ref: '#/components/schemas/TrainingCategoryRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedTrainingCategoryRequest'
+              $ref: '#/components/schemas/TrainingCategoryRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedTrainingCategoryRequest'
+              $ref: '#/components/schemas/TrainingCategoryRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrainingCategory'
           description: ''
-    delete:
-      operationId: training_categories_destroy
-      description: ViewSet for managing training categories.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this training category.
-        required: true
-      tags:
-      - training
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: training_categories_retrieve
-      description: ViewSet for managing training categories.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this training category.
-        required: true
-      tags:
-      - training
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TrainingCategory'
-          description: ''
+  /api/training/categories/{id}/:
     put:
       operationId: training_categories_update
       description: ViewSet for managing training categories.
@@ -8318,34 +8242,83 @@ paths:
               schema:
                 $ref: '#/components/schemas/TrainingCategory'
           description: ''
-  /api/training/videos/:
-    post:
-      operationId: training_videos_create
-      description: ViewSet for managing training videos.
+    patch:
+      operationId: training_categories_partial_update
+      description: ViewSet for managing training categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training category.
+        required: true
       tags:
       - training
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+              $ref: '#/components/schemas/PatchedTrainingCategoryRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+              $ref: '#/components/schemas/PatchedTrainingCategoryRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/TrainingVideoDetailRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedTrainingCategoryRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TrainingVideoDetail'
+                $ref: '#/components/schemas/TrainingCategory'
           description: ''
+    get:
+      operationId: training_categories_retrieve
+      description: ViewSet for managing training categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training category.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingCategory'
+          description: ''
+    delete:
+      operationId: training_categories_destroy
+      description: ViewSet for managing training categories.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training category.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/training/videos/:
     get:
       operationId: training_videos_list
       description: ViewSet for managing training videos.
@@ -8463,6 +8436,33 @@ paths:
                 items:
                   $ref: '#/components/schemas/TrainingVideoList'
           description: ''
+    post:
+      operationId: training_videos_create
+      description: ViewSet for managing training videos.
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TrainingVideoDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingVideoDetail'
+          description: ''
   /api/training/videos/analytics/:
     get:
       operationId: training_videos_analytics_retrieve
@@ -8480,82 +8480,6 @@ paths:
                 $ref: '#/components/schemas/TrainingVideoDetail'
           description: ''
   /api/training/videos/{id}/:
-    patch:
-      operationId: training_videos_partial_update
-      description: ViewSet for managing training videos.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this training video.
-        required: true
-      tags:
-      - training
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedTrainingVideoDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedTrainingVideoDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedTrainingVideoDetailRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TrainingVideoDetail'
-          description: ''
-    delete:
-      operationId: training_videos_destroy
-      description: ViewSet for managing training videos.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this training video.
-        required: true
-      tags:
-      - training
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: training_videos_retrieve
-      description: ViewSet for managing training videos.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this training video.
-        required: true
-      tags:
-      - training
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TrainingVideoDetail'
-          description: ''
     put:
       operationId: training_videos_update
       description: ViewSet for managing training videos.
@@ -8591,6 +8515,82 @@ paths:
               schema:
                 $ref: '#/components/schemas/TrainingVideoDetail'
           description: ''
+    patch:
+      operationId: training_videos_partial_update
+      description: ViewSet for managing training videos.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training video.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedTrainingVideoDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedTrainingVideoDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedTrainingVideoDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingVideoDetail'
+          description: ''
+    get:
+      operationId: training_videos_retrieve
+      description: ViewSet for managing training videos.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training video.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingVideoDetail'
+          description: ''
+    delete:
+      operationId: training_videos_destroy
+      description: ViewSet for managing training videos.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this training video.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/training/videos/{id}/track_view/:
     post:
       operationId: training_videos_track_view_create
@@ -8628,33 +8628,6 @@ paths:
                 $ref: '#/components/schemas/TrainingVideoDetail'
           description: ''
   /api/training/campaigns/:
-    post:
-      operationId: training_campaigns_create
-      description: ViewSet for managing security awareness campaigns.
-      tags:
-      - training
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
-          description: ''
     get:
       operationId: training_campaigns_list
       description: ViewSet for managing security awareness campaigns.
@@ -8776,6 +8749,33 @@ paths:
                 items:
                   $ref: '#/components/schemas/SecurityAwarenessCampaignList'
           description: ''
+    post:
+      operationId: training_campaigns_create
+      description: ViewSet for managing security awareness campaigns.
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SecurityAwarenessCampaignDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
   /api/training/campaigns/analytics/:
     get:
       operationId: training_campaigns_analytics_retrieve
@@ -8809,82 +8809,6 @@ paths:
                 $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
           description: ''
   /api/training/campaigns/{id}/:
-    patch:
-      operationId: training_campaigns_partial_update
-      description: ViewSet for managing security awareness campaigns.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this security awareness campaign.
-        required: true
-      tags:
-      - training
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedSecurityAwarenessCampaignDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedSecurityAwarenessCampaignDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedSecurityAwarenessCampaignDetailRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
-          description: ''
-    delete:
-      operationId: training_campaigns_destroy
-      description: ViewSet for managing security awareness campaigns.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this security awareness campaign.
-        required: true
-      tags:
-      - training
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: training_campaigns_retrieve
-      description: ViewSet for managing security awareness campaigns.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this security awareness campaign.
-        required: true
-      tags:
-      - training
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
-          description: ''
     put:
       operationId: training_campaigns_update
       description: ViewSet for managing security awareness campaigns.
@@ -8920,6 +8844,82 @@ paths:
               schema:
                 $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
           description: ''
+    patch:
+      operationId: training_campaigns_partial_update
+      description: ViewSet for managing security awareness campaigns.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this security awareness campaign.
+        required: true
+      tags:
+      - training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedSecurityAwarenessCampaignDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedSecurityAwarenessCampaignDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedSecurityAwarenessCampaignDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
+    get:
+      operationId: training_campaigns_retrieve
+      description: ViewSet for managing security awareness campaigns.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this security awareness campaign.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityAwarenessCampaignDetail'
+          description: ''
+    delete:
+      operationId: training_campaigns_destroy
+      description: ViewSet for managing security awareness campaigns.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this security awareness campaign.
+        required: true
+      tags:
+      - training
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/training/campaigns/{id}/send_now/:
     post:
       operationId: training_campaigns_send_now_create
@@ -9185,32 +9185,6 @@ paths:
                 $ref: '#/components/schemas/VideoView'
           description: ''
   /api/knowledge/categories/:
-    post:
-      operationId: knowledge_categories_create
-      tags:
-      - knowledge
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/KnowledgeCategoryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/KnowledgeCategoryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/KnowledgeCategoryRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KnowledgeCategory'
-          description: ''
     get:
       operationId: knowledge_categories_list
       parameters:
@@ -9282,77 +9256,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedKnowledgeCategoryList'
           description: ''
-  /api/knowledge/categories/{id}/:
-    patch:
-      operationId: knowledge_categories_partial_update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this knowledge category.
-        required: true
+    post:
+      operationId: knowledge_categories_create
       tags:
       - knowledge
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedKnowledgeCategoryRequest'
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedKnowledgeCategoryRequest'
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedKnowledgeCategoryRequest'
+              $ref: '#/components/schemas/KnowledgeCategoryRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeCategory'
           description: ''
-    delete:
-      operationId: knowledge_categories_destroy
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this knowledge category.
-        required: true
-      tags:
-      - knowledge
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: knowledge_categories_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this knowledge category.
-        required: true
-      tags:
-      - knowledge
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KnowledgeCategory'
-          description: ''
+  /api/knowledge/categories/{id}/:
     put:
       operationId: knowledge_categories_update
       parameters:
@@ -9386,33 +9316,77 @@ paths:
               schema:
                 $ref: '#/components/schemas/KnowledgeCategory'
           description: ''
-  /api/knowledge/articles/:
-    post:
-      operationId: knowledge_articles_create
+    patch:
+      operationId: knowledge_categories_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this knowledge category.
+        required: true
       tags:
       - knowledge
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+              $ref: '#/components/schemas/PatchedKnowledgeCategoryRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+              $ref: '#/components/schemas/PatchedKnowledgeCategoryRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedKnowledgeCategoryRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/KnowledgeArticleDetail'
+                $ref: '#/components/schemas/KnowledgeCategory'
           description: ''
+    get:
+      operationId: knowledge_categories_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this knowledge category.
+        required: true
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeCategory'
+          description: ''
+    delete:
+      operationId: knowledge_categories_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this knowledge category.
+        required: true
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/knowledge/articles/:
     get:
       operationId: knowledge_articles_list
       parameters:
@@ -9510,6 +9484,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedKnowledgeArticleListList'
           description: ''
+    post:
+      operationId: knowledge_articles_create
+      tags:
+      - knowledge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/KnowledgeArticleDetailRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeArticleDetail'
+          description: ''
   /api/knowledge/articles/contextual/:
     get:
       operationId: knowledge_articles_contextual_retrieve
@@ -9527,73 +9527,6 @@ paths:
                 $ref: '#/components/schemas/KnowledgeArticleDetail'
           description: ''
   /api/knowledge/articles/{slug}/:
-    patch:
-      operationId: knowledge_articles_partial_update
-      parameters:
-      - in: path
-        name: slug
-        schema:
-          type: string
-        required: true
-      tags:
-      - knowledge
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedKnowledgeArticleDetailRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedKnowledgeArticleDetailRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedKnowledgeArticleDetailRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KnowledgeArticleDetail'
-          description: ''
-    delete:
-      operationId: knowledge_articles_destroy
-      parameters:
-      - in: path
-        name: slug
-        schema:
-          type: string
-        required: true
-      tags:
-      - knowledge
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: knowledge_articles_retrieve
-      parameters:
-      - in: path
-        name: slug
-        schema:
-          type: string
-        required: true
-      tags:
-      - knowledge
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KnowledgeArticleDetail'
-          description: ''
     put:
       operationId: knowledge_articles_update
       parameters:
@@ -9626,6 +9559,73 @@ paths:
               schema:
                 $ref: '#/components/schemas/KnowledgeArticleDetail'
           description: ''
+    patch:
+      operationId: knowledge_articles_partial_update
+      parameters:
+      - in: path
+        name: slug
+        schema:
+          type: string
+        required: true
+      tags:
+      - knowledge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedKnowledgeArticleDetailRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedKnowledgeArticleDetailRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedKnowledgeArticleDetailRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeArticleDetail'
+          description: ''
+    get:
+      operationId: knowledge_articles_retrieve
+      parameters:
+      - in: path
+        name: slug
+        schema:
+          type: string
+        required: true
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeArticleDetail'
+          description: ''
+    delete:
+      operationId: knowledge_articles_destroy
+      parameters:
+      - in: path
+        name: slug
+        schema:
+          type: string
+        required: true
+      tags:
+      - knowledge
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/knowledge/articles/{slug}/revisions/:
     get:
       operationId: knowledge_articles_revisions_retrieve
@@ -10078,34 +10078,6 @@ paths:
         '500':
           description: Analytics service unavailable
   /api/vendors/vendors/:
-    post:
-      operationId: vendors_vendors_create
-      description: Create a new vendor profile with comprehensive vendor information.
-      summary: Create vendor
-      tags:
-      - Vendors
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorCreateUpdate'
-          description: ''
     get:
       operationId: vendors_vendors_list
       description: Retrieve a paginated list of vendors with filtering, search, and
@@ -10317,6 +10289,34 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorList'
           description: ''
+    post:
+      operationId: vendors_vendors_create
+      description: Create a new vendor profile with comprehensive vendor information.
+      summary: Create vendor
+      tags:
+      - Vendors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorCreateUpdate'
+          description: ''
   /api/vendors/vendors/bulk_create/:
     post:
       operationId: vendors_vendors_bulk_create_create
@@ -10415,6 +10415,41 @@ paths:
                 $ref: '#/components/schemas/VendorSummary'
           description: ''
   /api/vendors/vendors/{id}/:
+    put:
+      operationId: vendors_vendors_update
+      description: Update an existing vendor profile with new information.
+      summary: Update vendor
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor.
+        required: true
+      tags:
+      - Vendors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorCreateUpdate'
+          description: ''
     patch:
       operationId: vendors_vendors_partial_update
       description: |-
@@ -10479,25 +10514,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/VendorCreateUpdate'
           description: ''
-    delete:
-      operationId: vendors_vendors_destroy
-      description: Delete a vendor profile and all associated data.
-      summary: Delete vendor
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor.
-        required: true
-      tags:
-      - Vendors
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
     get:
       operationId: vendors_vendors_retrieve
       description: Retrieve detailed information about a specific vendor including
@@ -10522,10 +10538,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/VendorDetail'
           description: ''
-    put:
-      operationId: vendors_vendors_update
-      description: Update an existing vendor profile with new information.
-      summary: Update vendor
+    delete:
+      operationId: vendors_vendors_destroy
+      description: Delete a vendor profile and all associated data.
+      summary: Delete vendor
       parameters:
       - in: path
         name: id
@@ -10535,28 +10551,12 @@ paths:
         required: true
       tags:
       - Vendors
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorCreateUpdateRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorCreateUpdate'
-          description: ''
+        '204':
+          description: No response body
   /api/vendors/vendors/{id}/add_note/:
     post:
       operationId: vendors_vendors_add_note_create
@@ -10638,37 +10638,6 @@ paths:
                 $ref: '#/components/schemas/VendorDetail'
           description: ''
   /api/vendors/categories/:
-    post:
-      operationId: vendors_categories_create
-      description: |-
-        **Vendor Category Management**
-
-        Manage vendor categories for classification and organization.
-        Categories help organize vendors by business type, risk level, and compliance requirements.
-      tags:
-      - Vendor Categories
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/VendorCategoryRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/VendorCategoryRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/VendorCategoryRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorCategory'
-          description: ''
     get:
       operationId: vendors_categories_list
       description: |-
@@ -10703,92 +10672,38 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorCategory'
           description: ''
-  /api/vendors/categories/{id}/:
-    patch:
-      operationId: vendors_categories_partial_update
+    post:
+      operationId: vendors_categories_create
       description: |-
         **Vendor Category Management**
 
         Manage vendor categories for classification and organization.
         Categories help organize vendors by business type, risk level, and compliance requirements.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor category.
-        required: true
       tags:
       - Vendor Categories
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedVendorCategoryRequest'
+              $ref: '#/components/schemas/VendorCategoryRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedVendorCategoryRequest'
+              $ref: '#/components/schemas/VendorCategoryRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedVendorCategoryRequest'
+              $ref: '#/components/schemas/VendorCategoryRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/VendorCategory'
           description: ''
-    delete:
-      operationId: vendors_categories_destroy
-      description: |-
-        **Vendor Category Management**
-
-        Manage vendor categories for classification and organization.
-        Categories help organize vendors by business type, risk level, and compliance requirements.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor category.
-        required: true
-      tags:
-      - Vendor Categories
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: vendors_categories_retrieve
-      description: |-
-        **Vendor Category Management**
-
-        Manage vendor categories for classification and organization.
-        Categories help organize vendors by business type, risk level, and compliance requirements.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor category.
-        required: true
-      tags:
-      - Vendor Categories
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorCategory'
-          description: ''
+  /api/vendors/categories/{id}/:
     put:
       operationId: vendors_categories_update
       description: |-
@@ -10827,37 +10742,92 @@ paths:
               schema:
                 $ref: '#/components/schemas/VendorCategory'
           description: ''
-  /api/vendors/contacts/:
-    post:
-      operationId: vendors_contacts_create
+    patch:
+      operationId: vendors_categories_partial_update
       description: |-
-        **Vendor Contact Management**
+        **Vendor Category Management**
 
-        Manage contact persons for vendors with different roles and responsibilities.
+        Manage vendor categories for classification and organization.
+        Categories help organize vendors by business type, risk level, and compliance requirements.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor category.
+        required: true
       tags:
-      - Vendor Contacts
+      - Vendor Categories
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VendorContactRequest'
+              $ref: '#/components/schemas/PatchedVendorCategoryRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/VendorContactRequest'
+              $ref: '#/components/schemas/PatchedVendorCategoryRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/VendorContactRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedVendorCategoryRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VendorContact'
+                $ref: '#/components/schemas/VendorCategory'
           description: ''
+    get:
+      operationId: vendors_categories_retrieve
+      description: |-
+        **Vendor Category Management**
+
+        Manage vendor categories for classification and organization.
+        Categories help organize vendors by business type, risk level, and compliance requirements.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor category.
+        required: true
+      tags:
+      - Vendor Categories
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorCategory'
+          description: ''
+    delete:
+      operationId: vendors_categories_destroy
+      description: |-
+        **Vendor Category Management**
+
+        Manage vendor categories for classification and organization.
+        Categories help organize vendors by business type, risk level, and compliance requirements.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor category.
+        required: true
+      tags:
+      - Vendor Categories
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/vendors/contacts/:
     get:
       operationId: vendors_contacts_list
       description: |-
@@ -10969,89 +10939,37 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorContact'
           description: ''
-  /api/vendors/contacts/{id}/:
-    patch:
-      operationId: vendors_contacts_partial_update
+    post:
+      operationId: vendors_contacts_create
       description: |-
         **Vendor Contact Management**
 
         Manage contact persons for vendors with different roles and responsibilities.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor contact.
-        required: true
       tags:
       - Vendor Contacts
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedVendorContactRequest'
+              $ref: '#/components/schemas/VendorContactRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedVendorContactRequest'
+              $ref: '#/components/schemas/VendorContactRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedVendorContactRequest'
+              $ref: '#/components/schemas/VendorContactRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/VendorContact'
           description: ''
-    delete:
-      operationId: vendors_contacts_destroy
-      description: |-
-        **Vendor Contact Management**
-
-        Manage contact persons for vendors with different roles and responsibilities.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor contact.
-        required: true
-      tags:
-      - Vendor Contacts
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: vendors_contacts_retrieve
-      description: |-
-        **Vendor Contact Management**
-
-        Manage contact persons for vendors with different roles and responsibilities.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor contact.
-        required: true
-      tags:
-      - Vendor Contacts
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorContact'
-          description: ''
+  /api/vendors/contacts/{id}/:
     put:
       operationId: vendors_contacts_update
       description: |-
@@ -11089,37 +11007,89 @@ paths:
               schema:
                 $ref: '#/components/schemas/VendorContact'
           description: ''
-  /api/vendors/services/:
-    post:
-      operationId: vendors_services_create
+    patch:
+      operationId: vendors_contacts_partial_update
       description: |-
-        **Vendor Service Management**
+        **Vendor Contact Management**
 
-        Manage services provided by vendors including categorization and risk assessment.
+        Manage contact persons for vendors with different roles and responsibilities.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor contact.
+        required: true
       tags:
-      - Vendor Services
+      - Vendor Contacts
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VendorServiceRequest'
+              $ref: '#/components/schemas/PatchedVendorContactRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/VendorServiceRequest'
+              $ref: '#/components/schemas/PatchedVendorContactRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/VendorServiceRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedVendorContactRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VendorService'
+                $ref: '#/components/schemas/VendorContact'
           description: ''
+    get:
+      operationId: vendors_contacts_retrieve
+      description: |-
+        **Vendor Contact Management**
+
+        Manage contact persons for vendors with different roles and responsibilities.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor contact.
+        required: true
+      tags:
+      - Vendor Contacts
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorContact'
+          description: ''
+    delete:
+      operationId: vendors_contacts_destroy
+      description: |-
+        **Vendor Contact Management**
+
+        Manage contact persons for vendors with different roles and responsibilities.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor contact.
+        required: true
+      tags:
+      - Vendor Contacts
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/vendors/services/:
     get:
       operationId: vendors_services_list
       description: |-
@@ -11295,89 +11265,37 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorService'
           description: ''
-  /api/vendors/services/{id}/:
-    patch:
-      operationId: vendors_services_partial_update
+    post:
+      operationId: vendors_services_create
       description: |-
         **Vendor Service Management**
 
         Manage services provided by vendors including categorization and risk assessment.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor service.
-        required: true
       tags:
       - Vendor Services
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedVendorServiceRequest'
+              $ref: '#/components/schemas/VendorServiceRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedVendorServiceRequest'
+              $ref: '#/components/schemas/VendorServiceRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedVendorServiceRequest'
+              $ref: '#/components/schemas/VendorServiceRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/VendorService'
           description: ''
-    delete:
-      operationId: vendors_services_destroy
-      description: |-
-        **Vendor Service Management**
-
-        Manage services provided by vendors including categorization and risk assessment.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor service.
-        required: true
-      tags:
-      - Vendor Services
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: vendors_services_retrieve
-      description: |-
-        **Vendor Service Management**
-
-        Manage services provided by vendors including categorization and risk assessment.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor service.
-        required: true
-      tags:
-      - Vendor Services
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorService'
-          description: ''
+  /api/vendors/services/{id}/:
     put:
       operationId: vendors_services_update
       description: |-
@@ -11415,37 +11333,89 @@ paths:
               schema:
                 $ref: '#/components/schemas/VendorService'
           description: ''
-  /api/vendors/notes/:
-    post:
-      operationId: vendors_notes_create
+    patch:
+      operationId: vendors_services_partial_update
       description: |-
-        **Vendor Note Management**
+        **Vendor Service Management**
 
-        Manage notes and comments about vendors for tracking interactions and decisions.
+        Manage services provided by vendors including categorization and risk assessment.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor service.
+        required: true
       tags:
-      - Vendor Notes
+      - Vendor Services
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VendorNoteRequest'
+              $ref: '#/components/schemas/PatchedVendorServiceRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/VendorNoteRequest'
+              $ref: '#/components/schemas/PatchedVendorServiceRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/VendorNoteRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedVendorServiceRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VendorNote'
+                $ref: '#/components/schemas/VendorService'
           description: ''
+    get:
+      operationId: vendors_services_retrieve
+      description: |-
+        **Vendor Service Management**
+
+        Manage services provided by vendors including categorization and risk assessment.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor service.
+        required: true
+      tags:
+      - Vendor Services
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorService'
+          description: ''
+    delete:
+      operationId: vendors_services_destroy
+      description: |-
+        **Vendor Service Management**
+
+        Manage services provided by vendors including categorization and risk assessment.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor service.
+        required: true
+      tags:
+      - Vendor Services
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/vendors/notes/:
     get:
       operationId: vendors_notes_list
       description: |-
@@ -11479,89 +11449,37 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorNote'
           description: ''
-  /api/vendors/notes/{id}/:
-    patch:
-      operationId: vendors_notes_partial_update
+    post:
+      operationId: vendors_notes_create
       description: |-
         **Vendor Note Management**
 
         Manage notes and comments about vendors for tracking interactions and decisions.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor note.
-        required: true
       tags:
       - Vendor Notes
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedVendorNoteRequest'
+              $ref: '#/components/schemas/VendorNoteRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedVendorNoteRequest'
+              $ref: '#/components/schemas/VendorNoteRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedVendorNoteRequest'
+              $ref: '#/components/schemas/VendorNoteRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/VendorNote'
           description: ''
-    delete:
-      operationId: vendors_notes_destroy
-      description: |-
-        **Vendor Note Management**
-
-        Manage notes and comments about vendors for tracking interactions and decisions.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor note.
-        required: true
-      tags:
-      - Vendor Notes
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: vendors_notes_retrieve
-      description: |-
-        **Vendor Note Management**
-
-        Manage notes and comments about vendors for tracking interactions and decisions.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this vendor note.
-        required: true
-      tags:
-      - Vendor Notes
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorNote'
-          description: ''
+  /api/vendors/notes/{id}/:
     put:
       operationId: vendors_notes_update
       description: |-
@@ -11599,38 +11517,89 @@ paths:
               schema:
                 $ref: '#/components/schemas/VendorNote'
           description: ''
-  /api/vendors/tasks/:
-    post:
-      operationId: vendors_tasks_create
+    patch:
+      operationId: vendors_notes_partial_update
       description: |-
-        **Vendor Task Management**
+        **Vendor Note Management**
 
-        Comprehensive task management for vendor-related activities including contract renewals,
-        security reviews, compliance assessments, and automated task generation.
+        Manage notes and comments about vendors for tracking interactions and decisions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor note.
+        required: true
       tags:
-      - Vendor Tasks
+      - Vendor Notes
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
+              $ref: '#/components/schemas/PatchedVendorNoteRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
+              $ref: '#/components/schemas/PatchedVendorNoteRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
-        required: true
+              $ref: '#/components/schemas/PatchedVendorNoteRequest'
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '201':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VendorTaskCreateUpdate'
+                $ref: '#/components/schemas/VendorNote'
           description: ''
+    get:
+      operationId: vendors_notes_retrieve
+      description: |-
+        **Vendor Note Management**
+
+        Manage notes and comments about vendors for tracking interactions and decisions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor note.
+        required: true
+      tags:
+      - Vendor Notes
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorNote'
+          description: ''
+    delete:
+      operationId: vendors_notes_destroy
+      description: |-
+        **Vendor Note Management**
+
+        Manage notes and comments about vendors for tracking interactions and decisions.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this vendor note.
+        required: true
+      tags:
+      - Vendor Notes
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/vendors/tasks/:
     get:
       operationId: vendors_tasks_list
       description: |-
@@ -11963,6 +11932,37 @@ paths:
                 items:
                   $ref: '#/components/schemas/VendorTaskList'
           description: ''
+    post:
+      operationId: vendors_tasks_create
+      description: |-
+        **Vendor Task Management**
+
+        Comprehensive task management for vendor-related activities including contract renewals,
+        security reviews, compliance assessments, and automated task generation.
+      tags:
+      - Vendor Tasks
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VendorTaskCreateUpdateRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorTaskCreateUpdate'
+          description: ''
   /api/vendors/tasks/bulk_action/:
     post:
       operationId: vendors_tasks_bulk_action_create
@@ -12099,91 +12099,6 @@ paths:
                 $ref: '#/components/schemas/VendorTaskDetail'
           description: ''
   /api/vendors/tasks/{id}/:
-    patch:
-      operationId: vendors_tasks_partial_update
-      description: |-
-        **Vendor Task Management**
-
-        Comprehensive task management for vendor-related activities including contract renewals,
-        security reviews, compliance assessments, and automated task generation.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this Vendor Task.
-        required: true
-      tags:
-      - Vendor Tasks
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedVendorTaskCreateUpdateRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedVendorTaskCreateUpdateRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedVendorTaskCreateUpdateRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorTaskCreateUpdate'
-          description: ''
-    delete:
-      operationId: vendors_tasks_destroy
-      description: |-
-        **Vendor Task Management**
-
-        Comprehensive task management for vendor-related activities including contract renewals,
-        security reviews, compliance assessments, and automated task generation.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this Vendor Task.
-        required: true
-      tags:
-      - Vendor Tasks
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: vendors_tasks_retrieve
-      description: |-
-        **Vendor Task Management**
-
-        Comprehensive task management for vendor-related activities including contract renewals,
-        security reviews, compliance assessments, and automated task generation.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this Vendor Task.
-        required: true
-      tags:
-      - Vendor Tasks
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VendorTaskDetail'
-          description: ''
     put:
       operationId: vendors_tasks_update
       description: |-
@@ -12222,6 +12137,91 @@ paths:
               schema:
                 $ref: '#/components/schemas/VendorTaskCreateUpdate'
           description: ''
+    patch:
+      operationId: vendors_tasks_partial_update
+      description: |-
+        **Vendor Task Management**
+
+        Comprehensive task management for vendor-related activities including contract renewals,
+        security reviews, compliance assessments, and automated task generation.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Vendor Task.
+        required: true
+      tags:
+      - Vendor Tasks
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedVendorTaskCreateUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedVendorTaskCreateUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedVendorTaskCreateUpdateRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorTaskCreateUpdate'
+          description: ''
+    get:
+      operationId: vendors_tasks_retrieve
+      description: |-
+        **Vendor Task Management**
+
+        Comprehensive task management for vendor-related activities including contract renewals,
+        security reviews, compliance assessments, and automated task generation.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Vendor Task.
+        required: true
+      tags:
+      - Vendor Tasks
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VendorTaskDetail'
+          description: ''
+    delete:
+      operationId: vendors_tasks_destroy
+      description: |-
+        **Vendor Task Management**
+
+        Comprehensive task management for vendor-related activities including contract renewals,
+        security reviews, compliance assessments, and automated task generation.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Vendor Task.
+        required: true
+      tags:
+      - Vendor Tasks
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/vendors/tasks/{id}/update_status/:
     post:
       operationId: vendors_tasks_update_status_create
@@ -12259,32 +12259,6 @@ paths:
                 $ref: '#/components/schemas/VendorTaskDetail'
           description: ''
   /api/vuln/targets/:
-    post:
-      operationId: vuln_targets_create
-      tags:
-      - vuln
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ScanTargetRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ScanTargetRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ScanTargetRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScanTarget'
-          description: ''
     get:
       operationId: vuln_targets_list
       parameters:
@@ -12342,80 +12316,33 @@ paths:
                 items:
                   $ref: '#/components/schemas/ScanTarget'
           description: ''
-  /api/vuln/targets/{id}/:
-    patch:
-      operationId: vuln_targets_partial_update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this scan target.
-        required: true
+    post:
+      operationId: vuln_targets_create
       tags:
       - vuln
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedScanTargetRequest'
+              $ref: '#/components/schemas/ScanTargetRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedScanTargetRequest'
+              $ref: '#/components/schemas/ScanTargetRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedScanTargetRequest'
+              $ref: '#/components/schemas/ScanTargetRequest'
+        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScanTarget'
           description: ''
-    delete:
-      operationId: vuln_targets_destroy
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this scan target.
-        required: true
-      tags:
-      - vuln
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: vuln_targets_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this scan target.
-        required: true
-      tags:
-      - vuln
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScanTarget'
-          description: ''
+  /api/vuln/targets/{id}/:
     put:
       operationId: vuln_targets_update
       parameters:
@@ -12450,6 +12377,79 @@ paths:
               schema:
                 $ref: '#/components/schemas/ScanTarget'
           description: ''
+    patch:
+      operationId: vuln_targets_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan target.
+        required: true
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedScanTargetRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedScanTargetRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedScanTargetRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanTarget'
+          description: ''
+    get:
+      operationId: vuln_targets_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan target.
+        required: true
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanTarget'
+          description: ''
+    delete:
+      operationId: vuln_targets_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan target.
+        required: true
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/vuln/targets/{id}/start-scan/:
     post:
       operationId: vuln_targets_start_scan_create
@@ -12486,32 +12486,6 @@ paths:
                 $ref: '#/components/schemas/ScanTarget'
           description: ''
   /api/vuln/schedules/:
-    post:
-      operationId: vuln_schedules_create
-      tags:
-      - vuln
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ScanScheduleRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ScanScheduleRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ScanScheduleRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScanSchedule'
-          description: ''
     get:
       operationId: vuln_schedules_list
       parameters:
@@ -12558,6 +12532,32 @@ paths:
                 items:
                   $ref: '#/components/schemas/ScanSchedule'
           description: ''
+    post:
+      operationId: vuln_schedules_create
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ScanScheduleRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanSchedule'
+          description: ''
   /api/vuln/schedules/run-due/:
     post:
       operationId: vuln_schedules_run_due_create
@@ -12586,79 +12586,6 @@ paths:
                 $ref: '#/components/schemas/ScanSchedule'
           description: ''
   /api/vuln/schedules/{id}/:
-    patch:
-      operationId: vuln_schedules_partial_update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this scan schedule.
-        required: true
-      tags:
-      - vuln
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedScanScheduleRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedScanScheduleRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedScanScheduleRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScanSchedule'
-          description: ''
-    delete:
-      operationId: vuln_schedules_destroy
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this scan schedule.
-        required: true
-      tags:
-      - vuln
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: vuln_schedules_retrieve
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this scan schedule.
-        required: true
-      tags:
-      - vuln
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ScanSchedule'
-          description: ''
     put:
       operationId: vuln_schedules_update
       parameters:
@@ -12693,6 +12620,79 @@ paths:
               schema:
                 $ref: '#/components/schemas/ScanSchedule'
           description: ''
+    patch:
+      operationId: vuln_schedules_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan schedule.
+        required: true
+      tags:
+      - vuln
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedScanScheduleRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedScanScheduleRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedScanScheduleRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanSchedule'
+          description: ''
+    get:
+      operationId: vuln_schedules_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan schedule.
+        required: true
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanSchedule'
+          description: ''
+    delete:
+      operationId: vuln_schedules_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this scan schedule.
+        required: true
+      tags:
+      - vuln
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/vuln/jobs/:
     get:
       operationId: vuln_jobs_list
@@ -13175,6 +13175,23 @@ paths:
         '400':
           description: Invalid module or tenant already has a non-trial subscription
   /api/limit-overrides/:
+    get:
+      operationId: limit_overrides_list
+      description: ViewSet for managing limit override requests with approval workflow.
+      tags:
+      - limit-overrides
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LimitOverrideRequest'
+          description: ''
     post:
       operationId: limit_overrides_create
       description: Create a new limit override request.
@@ -13201,23 +13218,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LimitOverrideCreate'
-          description: ''
-    get:
-      operationId: limit_overrides_list
-      description: ViewSet for managing limit override requests with approval workflow.
-      tags:
-      - limit-overrides
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/LimitOverrideRequest'
           description: ''
   /api/limit-overrides/approved_pending_application/:
     get:
@@ -13252,79 +13252,6 @@ paths:
                 $ref: '#/components/schemas/LimitOverrideRequest'
           description: ''
   /api/limit-overrides/{id}/:
-    patch:
-      operationId: limit_overrides_partial_update
-      description: ViewSet for managing limit override requests with approval workflow.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this limit override request.
-        required: true
-      tags:
-      - limit-overrides
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedLimitOverrideRequestRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedLimitOverrideRequestRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedLimitOverrideRequestRequest'
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LimitOverrideRequest'
-          description: ''
-    delete:
-      operationId: limit_overrides_destroy
-      description: ViewSet for managing limit override requests with approval workflow.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this limit override request.
-        required: true
-      tags:
-      - limit-overrides
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
-    get:
-      operationId: limit_overrides_retrieve
-      description: ViewSet for managing limit override requests with approval workflow.
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this limit override request.
-        required: true
-      tags:
-      - limit-overrides
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LimitOverrideRequest'
-          description: ''
     put:
       operationId: limit_overrides_update
       description: ViewSet for managing limit override requests with approval workflow.
@@ -13359,6 +13286,79 @@ paths:
               schema:
                 $ref: '#/components/schemas/LimitOverrideRequest'
           description: ''
+    patch:
+      operationId: limit_overrides_partial_update
+      description: ViewSet for managing limit override requests with approval workflow.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this limit override request.
+        required: true
+      tags:
+      - limit-overrides
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedLimitOverrideRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedLimitOverrideRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedLimitOverrideRequestRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LimitOverrideRequest'
+          description: ''
+    get:
+      operationId: limit_overrides_retrieve
+      description: ViewSet for managing limit override requests with approval workflow.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this limit override request.
+        required: true
+      tags:
+      - limit-overrides
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LimitOverrideRequest'
+          description: ''
+    delete:
+      operationId: limit_overrides_destroy
+      description: ViewSet for managing limit override requests with approval workflow.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this limit override request.
+        required: true
+      tags:
+      - limit-overrides
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/limit-overrides/{id}/apply_override/:
     post:
       operationId: limit_overrides_apply_override_create
@@ -13497,6 +13497,25 @@ paths:
                 $ref: '#/components/schemas/ApprovalAction'
           description: ''
   /api/documents/:
+    get:
+      operationId: documents_list
+      description: Retrieve a paginated list of documents uploaded by users in the
+        current tenant with secure access control.
+      summary: List documents
+      tags:
+      - Documents
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DocumentList'
+          description: ''
     post:
       operationId: documents_create
       description: Upload a new document file to secure tenant-isolated storage with
@@ -13537,25 +13556,6 @@ paths:
           description: Invalid file or data
         '403':
           description: Document limit exceeded for current plan
-    get:
-      operationId: documents_list
-      description: Retrieve a paginated list of documents uploaded by users in the
-        current tenant with secure access control.
-      summary: List documents
-      tags:
-      - Documents
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DocumentList'
-          description: ''
   /api/documents/plan_usage/:
     get:
       operationId: documents_plan_usage_retrieve
@@ -13591,6 +13591,38 @@ paths:
                 $ref: '#/components/schemas/Document'
           description: ''
   /api/documents/{id}/:
+    put:
+      operationId: documents_update
+      description: Update document metadata. File cannot be changed after upload.
+      summary: Update document
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this document.
+        required: true
+      tags:
+      - Documents
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/DocumentRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/DocumentRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+          description: ''
     patch:
       operationId: documents_partial_update
       description: |-
@@ -13647,26 +13679,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Document'
           description: ''
-    delete:
-      operationId: documents_destroy
-      description: Delete a document and its file from storage. Only the uploader
-        can delete documents.
-      summary: Delete document
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this document.
-        required: true
-      tags:
-      - Documents
-      security:
-      - cookieAuth: []
-      - SessionAuth: []
-      responses:
-        '204':
-          description: No response body
     get:
       operationId: documents_retrieve
       description: Retrieve detailed information about a specific document including
@@ -13691,10 +13703,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Document'
           description: ''
-    put:
-      operationId: documents_update
-      description: Update document metadata. File cannot be changed after upload.
-      summary: Update document
+    delete:
+      operationId: documents_destroy
+      description: Delete a document and its file from storage. Only the uploader
+        can delete documents.
+      summary: Delete document
       parameters:
       - in: path
         name: id
@@ -13704,25 +13717,12 @@ paths:
         required: true
       tags:
       - Documents
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/DocumentRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/DocumentRequest'
-        required: true
       security:
       - cookieAuth: []
       - SessionAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Document'
-          description: ''
+        '204':
+          description: No response body
   /api/documents/{id}/access_logs/:
     get:
       operationId: documents_access_logs_retrieve
@@ -13826,6 +13826,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AuditEvent'
+          description: ''
+  /api/tenant-email-settings/:
+    get:
+      operationId: tenant_email_settings_retrieve
+      description: Read and update the current tenant's outbound email identity settings.
+      tags:
+      - Tenant settings
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantEmailSettings'
+          description: ''
+    patch:
+      operationId: tenant_email_settings_partial_update
+      description: Read and update the current tenant's outbound email identity settings.
+      tags:
+      - Tenant settings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedTenantEmailSettingsRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedTenantEmailSettingsRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedTenantEmailSettingsRequest'
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantEmailSettings'
           description: ''
 components:
   schemas:
@@ -19973,6 +20015,26 @@ components:
             type: integer
           description: Specific users to receive this campaign (if not sending to
             all)
+    PatchedTenantEmailSettingsRequest:
+      type: object
+      properties:
+        email_sender_name:
+          type: string
+          maxLength: 200
+        email_sender_address:
+          oneOf:
+          - type: string
+            format: email
+            maxLength: 254
+          - type: string
+            maxLength: 0
+        email_reply_to:
+          oneOf:
+          - type: string
+            format: email
+            maxLength: 254
+          - type: string
+            maxLength: 0
     PatchedTrainingCategoryRequest:
       type: object
       description: Serializer for training categories.
@@ -24186,6 +24248,36 @@ components:
         export_format:
           $ref: '#/components/schemas/ExportFormatEnum'
         selected_modules: {}
+    TenantEmailSettings:
+      type: object
+      properties:
+        email_sender_name:
+          type: string
+          maxLength: 200
+        email_sender_address:
+          oneOf:
+          - type: string
+            format: email
+            maxLength: 254
+          - type: string
+            maxLength: 0
+        email_reply_to:
+          oneOf:
+          - type: string
+            format: email
+            maxLength: 254
+          - type: string
+            maxLength: 0
+        sender_email_verified:
+          type: boolean
+          readOnly: true
+        sender_email_verified_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - sender_email_verified
+      - sender_email_verified_at
     TrainingCategory:
       type: object
       description: Serializer for training categories.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8730,9 +8730,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "brace-expansion": "5.0.9",
     "fast-uri": "3.1.5",
     "js-yaml": "4.3.1",
+    "nanoid": "3.3.17",
     "postcss": "8.5.23",
     "sharp": "0.35.3"
   }

--- a/frontend/src/lib/api/generated/schema.d.ts
+++ b/frontend/src/lib/api/generated/schema.d.ts
@@ -5181,6 +5181,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/tenant-email-settings/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Read and update the current tenant's outbound email identity settings. */
+        get: operations["tenant_email_settings_retrieve"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** @description Read and update the current tenant's outbound email identity settings. */
+        patch: operations["tenant_email_settings_partial_update"];
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -8244,6 +8262,11 @@ export interface components {
             /** @description Specific users to receive this campaign (if not sending to all) */
             target_users?: number[];
         };
+        PatchedTenantEmailSettingsRequest: {
+            email_sender_name?: string;
+            email_sender_address?: string;
+            email_reply_to?: string;
+        };
         /** @description Serializer for training categories. */
         PatchedTrainingCategoryRequest: {
             name?: string;
@@ -10162,6 +10185,14 @@ export interface components {
             title?: string;
             export_format?: components["schemas"]["ExportFormatEnum"];
             selected_modules?: unknown;
+        };
+        TenantEmailSettings: {
+            email_sender_name?: string;
+            email_sender_address?: string;
+            email_reply_to?: string;
+            readonly sender_email_verified: boolean;
+            /** Format: date-time */
+            readonly sender_email_verified_at: string;
         };
         /** @description Serializer for training categories. */
         TrainingCategory: {
@@ -22661,6 +22692,50 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AuditEvent"];
+                };
+            };
+        };
+    };
+    tenant_email_settings_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TenantEmailSettings"];
+                };
+            };
+        };
+    };
+    tenant_email_settings_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedTenantEmailSettingsRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedTenantEmailSettingsRequest"];
+                "multipart/form-data": components["schemas"]["PatchedTenantEmailSettingsRequest"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TenantEmailSettings"];
                 };
             };
         };


### PR DESCRIPTION
Part of #180.

Adds tenant-level sender name, sender address, reply-to address, and read-only verification state. Tenant staff can read/update settings through a protected API endpoint; updates are tenant-audited. Central email fallback remains unchanged until verification and provider selection are implemented in follow-up slices.

Checks: Ruff lint, Ruff format, targeted compilation, and diff check pass locally.