### PR TITLE
feat: add tenant email settings UI

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -4,6 +4,13 @@ import { Form, Input, Button, Alert } from "antd";
 import { login } from "@/lib/auth";
 import { useRouter } from "next/navigation";
 
+function safeNext(value: string | null) {
+  if (!value || !value.startsWith("/") || value.startsWith("//") || value.includes("\\")) {
+    return "/";
+  }
+  return value;
+}
+
 type LoginFormValues = {
   email: string;
   password: string;
@@ -18,7 +25,8 @@ export default function LoginPage() {
     try {
       setError(null);
       await login(values.email, values.password, values.otp);
-      router.push("/");
+      const next = new URLSearchParams(window.location.search).get("next");
+      router.push(safeNext(next));
     } catch (e) {
       if (e instanceof Error) {
         setError(e.message || "Login failed");

--- a/frontend/src/app/account/email-verification/page.tsx
+++ b/frontend/src/app/account/email-verification/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { Alert, Card, Result, Spin, Typography } from "antd";
+import { useSearchParams } from "next/navigation";
+import { confirmTenantEmailVerification } from "@/lib/services/tenantEmailService";
+import { getErrorMessage } from "@/lib/api";
+
+function Confirmation() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+  const [state, setState] = useState<"loading" | "success" | "error">("loading");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!token) {
+      setState("error");
+      setError("This verification link is missing its token.");
+      return;
+    }
+
+    void confirmTenantEmailVerification(token)
+      .then(() => setState("success"))
+      .catch((requestError: unknown) => {
+        setState("error");
+        setError(getErrorMessage(requestError));
+      });
+  }, [token]);
+
+  if (state === "loading") {
+    return <Spin size="large" />;
+  }
+
+  if (state === "error") {
+    return <Alert type="error" showIcon message="Verification failed" description={error} />;
+  }
+
+  return (
+    <Result
+      status="success"
+      title="Sender email verified"
+      subTitle="Your tenant email identity is now ready for use."
+    />
+  );
+}
+
+export default function EmailVerificationPage() {
+  return (
+    <Card style={{ maxWidth: 640, margin: "48px auto" }}>
+      <Typography.Title level={3}>Confirm sender email</Typography.Title>
+      <Typography.Paragraph type="secondary">
+        Confirming the email address configured for your tenant.
+      </Typography.Paragraph>
+      <Suspense fallback={<Spin size="large" />}>
+        <Confirmation />
+      </Suspense>
+    </Card>
+  );
+}

--- a/frontend/src/app/admin/email-settings/page.tsx
+++ b/frontend/src/app/admin/email-settings/page.tsx
@@ -1,0 +1,5 @@
+import TenantEmailSettings from "@/components/TenantEmailSettings";
+
+export default function AdminEmailSettingsPage() {
+  return <TenantEmailSettings />;
+}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -24,6 +24,7 @@ import {
   SettingOutlined,
   UploadOutlined,
 } from '@ant-design/icons'
+import Link from 'next/link'
 import type { UploadProps } from 'antd'
 import {
   importTemplateLibrary,
@@ -131,6 +132,9 @@ export default function AdminPage() {
         <Text type="secondary">
           Manage catalogue data, template packs and controlled imports.
         </Text>
+        <div style={{ marginTop: 12 }}>
+          <Link href="/admin/email-settings">Configure tenant email identity</Link>
+        </div>
       </div>
 
       <Row gutter={[16, 16]}>

--- a/frontend/src/components/AuthWrapper.test.tsx
+++ b/frontend/src/components/AuthWrapper.test.tsx
@@ -54,7 +54,7 @@ describe("AuthWrapper", () => {
     );
 
     await waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith("/login");
+      expect(pushMock).toHaveBeenCalledWith("/login?next=%2F");
     });
     expect(screen.queryByText("Protected content")).not.toBeInTheDocument();
   });

--- a/frontend/src/components/AuthWrapper.tsx
+++ b/frontend/src/components/AuthWrapper.tsx
@@ -30,7 +30,8 @@ export default function AuthWrapper({ children }: AuthWrapperProps) {
         })
         .catch(() => {
           if (cancelled) return;
-          router.push('/login');
+          const next = `${pathname}${window.location.search}`;
+          router.push(`/login?next=${encodeURIComponent(next)}`);
         });
       return () => {
         cancelled = true;

--- a/frontend/src/components/TenantEmailSettings.tsx
+++ b/frontend/src/components/TenantEmailSettings.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Descriptions,
+  Form,
+  Input,
+  Row,
+  Space,
+  Tag,
+  Typography,
+  message,
+} from "antd";
+import {
+  CheckCircleOutlined,
+  MailOutlined,
+  SafetyCertificateOutlined,
+  SendOutlined,
+} from "@ant-design/icons";
+import { getErrorMessage } from "@/lib/api";
+import {
+  getTenantEmailSettings,
+  requestTenantEmailVerification,
+  updateTenantEmailSettings,
+} from "@/lib/services/tenantEmailService";
+
+const { Title, Text } = Typography;
+
+export default function TenantEmailSettings() {
+  const [form] = Form.useForm();
+  const [settings, setSettings] = useState<Awaited<ReturnType<typeof getTenantEmailSettings>> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [sending, setSending] = useState(false);
+
+  const loadSettings = useCallback(async () => {
+    try {
+      const data = await getTenantEmailSettings();
+      setSettings(data);
+      form.setFieldsValue({
+        email_sender_name: data.email_sender_name,
+        email_sender_address: data.email_sender_address,
+        email_reply_to: data.email_reply_to,
+      });
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [form]);
+
+  useEffect(() => {
+    void loadSettings();
+  }, [loadSettings]);
+
+  const saveSettings = async (values: Record<string, string>) => {
+    setSaving(true);
+    try {
+      const data = await updateTenantEmailSettings(values);
+      setSettings(data);
+      message.success("Email identity settings saved");
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const sendVerification = async () => {
+    setSending(true);
+    try {
+      const response = await requestTenantEmailVerification();
+      message.success(
+        `Verification email sent. It expires ${new Date(response.expires_at ?? "").toLocaleString()}.`,
+      );
+      await loadSettings();
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (!settings && !loading) {
+    return (
+      <Alert
+        type="error"
+        showIcon
+        message="Email identity settings are unavailable"
+        description="Your account may not have tenant administrator access."
+      />
+    );
+  }
+
+  const verified = Boolean(settings?.sender_email_verified);
+
+  return (
+    <Space direction="vertical" size={24} style={{ width: "100%" }}>
+      <div>
+        <Text type="secondary">Tenant administration / outbound communications</Text>
+        <Title level={2} style={{ margin: "6px 0 0" }}>
+          Email identity
+        </Title>
+        <Text type="secondary">
+          Control how Provena identifies your organisation in tenant notifications.
+        </Text>
+      </div>
+
+      <Row gutter={[20, 20]}>
+        <Col xs={24} lg={15}>
+          <Card loading={loading} title={<Space><MailOutlined /> Sender details</Space>}>
+            <Form form={form} layout="vertical" onFinish={saveSettings} requiredMark="optional">
+              <Form.Item
+                label="Sender name"
+                name="email_sender_name"
+                rules={[{ max: 255, message: "Use 255 characters or fewer." }]}
+              >
+                <Input placeholder="Acme Corporation" />
+              </Form.Item>
+              <Form.Item
+                label="Sender email address"
+                name="email_sender_address"
+                rules={[{ type: "email", message: "Enter a valid email address." }]}
+                extra="A new address must be verified before it is used for tenant mail."
+              >
+                <Input placeholder="notifications@acme.example" />
+              </Form.Item>
+              <Form.Item
+                label="Reply-to address"
+                name="email_reply_to"
+                rules={[{ type: "email", message: "Enter a valid email address." }]}
+              >
+                <Input placeholder="support@acme.example" />
+              </Form.Item>
+              <Button type="primary" htmlType="submit" loading={saving}>
+                Save settings
+              </Button>
+            </Form>
+          </Card>
+        </Col>
+
+        <Col xs={24} lg={9}>
+          <Card title={<Space><SafetyCertificateOutlined /> Verification</Space>}>
+            <Space direction="vertical" size={16} style={{ width: "100%" }}>
+              <div>
+                {verified ? (
+                  <Tag color="success" icon={<CheckCircleOutlined />}>Verified sender</Tag>
+                ) : (
+                  <Tag color="warning">Verification required</Tag>
+                )}
+              </div>
+              <Descriptions size="small" column={1}>
+                <Descriptions.Item label="Address">
+                  {settings?.email_sender_address || "Not configured"}
+                </Descriptions.Item>
+                <Descriptions.Item label="Verified at">
+                  {settings?.sender_email_verified_at
+                    ? new Date(settings.sender_email_verified_at).toLocaleString()
+                    : "Not yet verified"}
+                </Descriptions.Item>
+              </Descriptions>
+              <Alert
+                type={verified ? "success" : "info"}
+                showIcon
+                message={verified ? "Ready for tenant notifications" : "Confirm the sender address"}
+                description={
+                  verified
+                    ? "The configured address has confirmed ownership."
+                    : "We will email a one-time confirmation link to the configured sender address."
+                }
+              />
+              <Button
+                block
+                icon={<SendOutlined />}
+                onClick={() => void sendVerification()}
+                loading={sending}
+                disabled={!settings?.email_sender_address}
+              >
+                {verified ? "Send verification again" : "Send verification email"}
+              </Button>
+            </Space>
+          </Card>
+        </Col>
+      </Row>
+    </Space>
+  );
+}

--- a/frontend/src/lib/services/tenantEmailService.ts
+++ b/frontend/src/lib/services/tenantEmailService.ts
@@ -1,0 +1,38 @@
+import api from "@/lib/api";
+import type { OperationRequestBody, OperationResponse } from "@/lib/api/types";
+
+export type TenantEmailSettings = OperationResponse<"tenant_email_settings_retrieve", 200>;
+export type TenantEmailSettingsPayload = OperationRequestBody<
+  "tenant_email_settings_partial_update"
+>;
+export type SenderVerificationResponse = OperationResponse<
+  "tenant_email_settings_verification_create",
+  202
+>;
+
+export async function getTenantEmailSettings() {
+  const { data } = await api.get<TenantEmailSettings>("/tenant-email-settings/");
+  return data;
+}
+
+export async function updateTenantEmailSettings(payload: TenantEmailSettingsPayload) {
+  const { data } = await api.patch<TenantEmailSettings>(
+    "/tenant-email-settings/",
+    payload,
+  );
+  return data;
+}
+
+export async function requestTenantEmailVerification() {
+  const { data } = await api.post<SenderVerificationResponse>(
+    "/tenant-email-settings/verification/",
+  );
+  return data;
+}
+
+export async function confirmTenantEmailVerification(token: string) {
+  const { data } = await api.post<
+    OperationResponse<"tenant_email_settings_verification_confirm_create", 200>
+  >("/tenant-email-settings/verification/confirm/", { token });
+  return data;
+}


### PR DESCRIPTION
## Summary
- add a typed frontend service for tenant email identity and verification endpoints
- add admin sender details and verification status screens
- add the emailed confirmation route with sign-in return-path preservation
- add the admin navigation link and update AuthWrapper coverage

## Verification
- `npm run test:unit` — 14 tests passed
- `npm run type-check`
- `npm run lint`
- `npm run build`