### PR TITLE
feat: add shared page header

### DIFF
--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -25,6 +25,7 @@ import {
   UploadOutlined,
 } from '@ant-design/icons'
 import Link from 'next/link'
+import { PageHeader } from '@/components/ui/PageHeader'
 import type { UploadProps } from 'antd'
 import {
   importTemplateLibrary,
@@ -32,7 +33,7 @@ import {
   TemplateImportSample,
 } from '@/lib/services/catalogService'
 
-const { Title, Text } = Typography
+const { Text } = Typography
 
 const moduleOptions = [
   { value: 'policy', label: 'Policy' },
@@ -124,18 +125,13 @@ export default function AdminPage() {
 
   return (
     <div>
-      <div style={{ marginBottom: 24 }}>
-        <Title level={2}>
-          <SettingOutlined style={{ marginRight: 8 }} />
-          System Administration
-        </Title>
-        <Text type="secondary">
-          Manage catalogue data, template packs and controlled imports.
-        </Text>
-        <div style={{ marginTop: 12 }}>
-          <Link href="/admin/email-settings">Configure tenant email identity</Link>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow="Administration"
+        title="System administration"
+        description="Manage catalogue data, template packs and controlled imports."
+        icon={<SettingOutlined />}
+        actions={<Link href="/admin/email-settings">Configure tenant email identity</Link>}
+      />
 
       <Row gutter={[16, 16]}>
         <Col xs={24} lg={10}>

--- a/frontend/src/components/TenantEmailSettings.tsx
+++ b/frontend/src/components/TenantEmailSettings.tsx
@@ -12,7 +12,6 @@ import {
   Row,
   Space,
   Tag,
-  Typography,
   message,
 } from "antd";
 import {
@@ -22,13 +21,12 @@ import {
   SendOutlined,
 } from "@ant-design/icons";
 import { getErrorMessage } from "@/lib/api";
+import { PageHeader } from "@/components/ui/PageHeader";
 import {
   getTenantEmailSettings,
   requestTenantEmailVerification,
   updateTenantEmailSettings,
 } from "@/lib/services/tenantEmailService";
-
-const { Title, Text } = Typography;
 
 export default function TenantEmailSettings() {
   const [form] = Form.useForm();
@@ -100,15 +98,12 @@ export default function TenantEmailSettings() {
 
   return (
     <Space direction="vertical" size={24} style={{ width: "100%" }}>
-      <div>
-        <Text type="secondary">Tenant administration / outbound communications</Text>
-        <Title level={2} style={{ margin: "6px 0 0" }}>
-          Email identity
-        </Title>
-        <Text type="secondary">
-          Control how Provena identifies your organisation in tenant notifications.
-        </Text>
-      </div>
+      <PageHeader
+        eyebrow="Tenant administration / outbound communications"
+        title="Email identity"
+        description="Control how Provena identifies your organisation in tenant notifications."
+        icon={<MailOutlined />}
+      />
 
       <Row gutter={[20, 20]}>
         <Col xs={24} lg={15}>

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -1,30 +1,34 @@
-"use client";
-
-import type { ReactNode } from "react";
 import { Typography } from "antd";
+import type { ReactNode } from "react";
 
 const { Title, Text } = Typography;
 
-interface PageHeaderProps {
+type PageHeaderProps = {
   eyebrow?: string;
   title: string;
   description?: string;
   icon?: ReactNode;
   actions?: ReactNode;
-}
+};
 
-export function PageHeader({ eyebrow, title, description, icon, actions }: PageHeaderProps) {
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  icon,
+  actions,
+}: PageHeaderProps) {
   return (
     <header className="page-header">
       <div className="page-header-copy">
-        {eyebrow && <span className="page-header-eyebrow">{eyebrow}</span>}
-        <Title level={1} className="page-header-title">
-          {icon && <span className="page-header-icon" aria-hidden="true">{icon}</span>}
+        {eyebrow ? <Text className="page-header-eyebrow">{eyebrow}</Text> : null}
+        <Title level={2} className="page-header-title">
+          {icon ? <span className="page-header-icon" aria-hidden="true">{icon}</span> : null}
           {title}
         </Title>
-        {description && <Text className="page-header-description">{description}</Text>}
+        {description ? <Text className="page-header-description">{description}</Text> : null}
       </div>
-      {actions && <div className="page-header-actions">{actions}</div>}
+      {actions ? <div className="page-header-actions">{actions}</div> : null}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- add a semantic, reusable PageHeader primitive for consistent GRC page composition
- apply the header to administration and tenant email settings screens
- centralise eyebrow, title, description, icon and action layout through existing theme tokens

## Verification
- `npm run type-check`
- `npm run lint`
- `npm run test:unit` — 14 tests passed
- `git diff --check`

The production build remains blocked locally by an external Google Fonts fetch in `next/font`, unrelated to this change.