### PR TITLE
feat: extract accessible risk visualisations

### DIFF
--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -25,6 +25,7 @@ import {
   UploadOutlined,
 } from '@ant-design/icons'
 import Link from 'next/link'
+import { PageHeader } from '@/components/ui/PageHeader'
 import type { UploadProps } from 'antd'
 import {
   importTemplateLibrary,
@@ -32,7 +33,7 @@ import {
   TemplateImportSample,
 } from '@/lib/services/catalogService'
 
-const { Title, Text } = Typography
+const { Text } = Typography
 
 const moduleOptions = [
   { value: 'policy', label: 'Policy' },
@@ -124,18 +125,13 @@ export default function AdminPage() {
 
   return (
     <div>
-      <div style={{ marginBottom: 24 }}>
-        <Title level={2}>
-          <SettingOutlined style={{ marginRight: 8 }} />
-          System Administration
-        </Title>
-        <Text type="secondary">
-          Manage catalogue data, template packs and controlled imports.
-        </Text>
-        <div style={{ marginTop: 12 }}>
-          <Link href="/admin/email-settings">Configure tenant email identity</Link>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow="Administration"
+        title="System administration"
+        description="Manage catalogue data, template packs and controlled imports."
+        icon={<SettingOutlined />}
+        actions={<Link href="/admin/email-settings">Configure tenant email identity</Link>}
+      />
 
       <Row gutter={[16, 16]}>
         <Col xs={24} lg={10}>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -75,6 +75,7 @@ html.dark-mode .page-header { --line: #35504e; --ink: #e8f2ef; --ink-soft: #b4c8
 .heatmap-content { flex: 1; }
 .heatmap-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 5px; max-width: 330px; aspect-ratio: 1; }
 .heat-cell { display: flex; align-items: center; justify-content: center; color: rgba(16,43,46,.78); font-weight: 700; font-size: 13px; min-width: 0; transition: transform .15s ease; }
+.heat-cell:focus-visible { outline: 3px solid var(--teal-deep, #08756d); outline-offset: 2px; position: relative; z-index: 2; }
 .heat-cell:hover { transform: scale(1.08); z-index: 1; box-shadow: 0 4px 12px rgba(16,43,46,.15); }
 .heat-1, .heat-2, .heat-3 { background: #d7eee8; }.heat-4, .heat-5, .heat-6 { background: #c4e3dc; }.heat-7, .heat-8, .heat-9 { background: #f3e7c5; }.heat-10, .heat-12, .heat-15 { background: #e8bd83; }.heat-16, .heat-20, .heat-25 { background: #ce7363; color: #fff; }
 .heatmap-x-axis { display: flex; justify-content: space-between; max-width: 330px; margin-top: 9px; color: var(--ink-soft); font-size: 9px; letter-spacing: .1em; }.heatmap-x-axis span:nth-child(2) { color: var(--ink-soft); }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -32,6 +32,7 @@ import {
 import dayjs, { type Dayjs } from "dayjs";
 import { analyticsService, type DashboardMetric, type ExecutiveDashboard } from "@/lib/services/analyticsService";
 import { riskService, type Risk } from "@/lib/services/riskService";
+import { RiskHeatMap, TrendLine } from "@/components/ui/GRCVisualisations";
 
 const { Title, Text } = Typography;
 
@@ -72,50 +73,6 @@ function formatMetric(value: number, suffix = "") {
 
 function riskTone(level: string) {
   return level === "critical" ? "critical" : level === "high" ? "high" : level === "medium" ? "medium" : "low";
-}
-
-function RiskHeatMap({ risks }: { risks: Risk[] }) {
-  const cells = useMemo(() => {
-    const counts = new Map<string, number>();
-    risks.forEach((risk) => {
-      const key = `${risk.impact}-${risk.likelihood}`;
-      counts.set(key, (counts.get(key) ?? 0) + 1);
-    });
-    return Array.from({ length: 25 }, (_, index) => {
-      const impact = Math.floor(index / 5) + 1;
-      const likelihood = (index % 5) + 1;
-      return { impact, likelihood, count: counts.get(`${impact}-${likelihood}`) ?? 0 };
-    });
-  }, [risks]);
-
-  return (
-    <div className="heatmap-wrap">
-      <div className="heatmap-y-label">IMPACT</div>
-      <div className="heatmap-content">
-        <div className="heatmap-grid" role="img" aria-label="Risk heat map showing impact against likelihood">
-          {cells.map((cell) => (
-            <Tooltip key={`${cell.impact}-${cell.likelihood}`} title={`${cell.count} risk${cell.count === 1 ? "" : "s"} · impact ${cell.impact}, likelihood ${cell.likelihood}`}>
-              <div className={`heat-cell heat-${Math.min(cell.impact * cell.likelihood, 25)}`}>
-                {cell.count > 0 ? cell.count : ""}
-              </div>
-            </Tooltip>
-          ))}
-        </div>
-        <div className="heatmap-x-axis"><span>Low</span><span>LIKELIHOOD</span><span>High</span></div>
-      </div>
-    </div>
-  );
-}
-
-function TrendLine({ data, colour = "#0b8f84" }: { data: number[]; colour?: string }) {
-  if (!data.length) return <div className="trend-empty">No trend data</div>;
-  const max = Math.max(...data, 1);
-  const points = data.map((value, index) => `${(index / Math.max(data.length - 1, 1)) * 100},${36 - (value / max) * 30}`).join(" ");
-  return (
-    <svg className="trend-line" viewBox="0 0 100 40" preserveAspectRatio="none" aria-label="Trend line" role="img">
-      <polyline points={points} fill="none" stroke={colour} strokeWidth="2.4" vectorEffect="non-scaling-stroke" />
-    </svg>
-  );
 }
 
 export default function DashboardPage() {

--- a/frontend/src/components/TenantEmailSettings.tsx
+++ b/frontend/src/components/TenantEmailSettings.tsx
@@ -12,7 +12,6 @@ import {
   Row,
   Space,
   Tag,
-  Typography,
   message,
 } from "antd";
 import {
@@ -22,13 +21,12 @@ import {
   SendOutlined,
 } from "@ant-design/icons";
 import { getErrorMessage } from "@/lib/api";
+import { PageHeader } from "@/components/ui/PageHeader";
 import {
   getTenantEmailSettings,
   requestTenantEmailVerification,
   updateTenantEmailSettings,
 } from "@/lib/services/tenantEmailService";
-
-const { Title, Text } = Typography;
 
 export default function TenantEmailSettings() {
   const [form] = Form.useForm();
@@ -100,15 +98,12 @@ export default function TenantEmailSettings() {
 
   return (
     <Space direction="vertical" size={24} style={{ width: "100%" }}>
-      <div>
-        <Text type="secondary">Tenant administration / outbound communications</Text>
-        <Title level={2} style={{ margin: "6px 0 0" }}>
-          Email identity
-        </Title>
-        <Text type="secondary">
-          Control how Provena identifies your organisation in tenant notifications.
-        </Text>
-      </div>
+      <PageHeader
+        eyebrow="Tenant administration / outbound communications"
+        title="Email identity"
+        description="Control how Provena identifies your organisation in tenant notifications."
+        icon={<MailOutlined />}
+      />
 
       <Row gutter={[20, 20]}>
         <Col xs={24} lg={15}>

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -16,6 +16,7 @@ import {
   DatabaseOutlined
 } from "@ant-design/icons";
 import { useTheme } from "@/theme";
+import { designTokens } from "@/themeTokens";
 
 interface EmptyStateProps {
   type?: 'default' | 'search' | 'filter' | 'error' | 'maintenance' | 'assessments' | 'risks' | 'vendors' | 'policies' | 'training' | 'vulnerabilities' | 'evidence';
@@ -134,13 +135,13 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   const titleStyle = {
     fontSize: size === 'small' ? 16 : size === 'large' ? 20 : 18,
     fontWeight: 600,
-    color: isDark ? '#F8FAFC' : '#0F172A',
+    color: isDark ? designTokens.color.dark.text : designTokens.color.light.text,
     marginBottom: 8,
   };
 
   const descriptionStyle = {
     fontSize: size === 'small' ? 13 : 14,
-    color: isDark ? '#94A3B8' : '#64748B',
+    color: isDark ? designTokens.color.dark.textSecondary : designTokens.color.light.textSecondary,
     marginBottom: action || secondaryAction ? 24 : 0,
     maxWidth: 400,
     margin: '0 auto',
@@ -149,7 +150,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
 
   const iconStyle = {
     fontSize: size === 'small' ? 48 : size === 'large' ? 72 : 64,
-    color: isDark ? '#475569' : '#CBD5E1',
+    color: isDark ? designTokens.color.dark.textTertiary : designTokens.color.light.textTertiary,
     marginBottom: 16,
   };
 

--- a/frontend/src/components/ui/GRCVisualisations.tsx
+++ b/frontend/src/components/ui/GRCVisualisations.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Progress, Typography } from "antd";
+import { useMemo } from "react";
+import { Progress, Tooltip, Typography } from "antd";
 
 const { Text } = Typography;
 
@@ -54,4 +55,43 @@ export function TrendSparkline({ values, label }: { values: number[]; label: str
 
 export function TrendPanel({ values, label, heading }: { values: number[]; label: string; heading: string }) {
   return <section className="grc-viz-panel" aria-labelledby={`${heading.toLowerCase().replaceAll(" ", "-")}-title`}><div className="grc-viz-heading"><div><span className="section-kicker">MOVEMENT</span><h3 id={`${heading.toLowerCase().replaceAll(" ", "-")}-title`}>{heading}</h3></div></div><TrendSparkline values={values} label={label} /></section>;
+}
+
+type RiskPosition = { impact: number; likelihood: number };
+
+export function RiskHeatMap({ risks }: { risks: RiskPosition[] }) {
+  const cells = useMemo(() => {
+    const counts = new Map<string, number>();
+    risks.forEach((risk) => {
+      const key = `${risk.impact}-${risk.likelihood}`;
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    });
+    return Array.from({ length: 25 }, (_, index) => {
+      const impact = Math.floor(index / 5) + 1;
+      const likelihood = (index % 5) + 1;
+      return { impact, likelihood, count: counts.get(`${impact}-${likelihood}`) ?? 0 };
+    });
+  }, [risks]);
+
+  return (
+    <div className="heatmap-wrap">
+      <div className="heatmap-y-label">IMPACT</div>
+      <div className="heatmap-content">
+        <div className="heatmap-grid" role="grid" aria-label="Risk heat map showing impact against likelihood">
+          {cells.map((cell) => {
+            const label = `${cell.count} risk${cell.count === 1 ? "" : "s"}, impact ${cell.impact}, likelihood ${cell.likelihood}`;
+            return <Tooltip key={`${cell.impact}-${cell.likelihood}`} title={label}><div className={`heat-cell heat-${Math.min(cell.impact * cell.likelihood, 25)}`} role="gridcell" tabIndex={0} aria-label={label}>{cell.count > 0 ? cell.count : ""}</div></Tooltip>;
+          })}
+        </div>
+        <div className="heatmap-x-axis"><span>Low</span><span>LIKELIHOOD</span><span>High</span></div>
+      </div>
+    </div>
+  );
+}
+
+export function TrendLine({ data, colour = "#0b8f84" }: { data: number[]; colour?: string }) {
+  if (!data.length) return <div className="trend-empty">No trend data</div>;
+  const max = Math.max(...data, 1);
+  const points = data.map((value, index) => `${(index / Math.max(data.length - 1, 1)) * 100},${36 - (value / max) * 30}`).join(" ");
+  return <svg className="trend-line" viewBox="0 0 100 40" preserveAspectRatio="none" aria-label="Trend line" role="img"><polyline points={points} fill="none" stroke={colour} strokeWidth="2.4" vectorEffect="non-scaling-stroke" /></svg>;
 }

--- a/frontend/src/components/ui/Loading.tsx
+++ b/frontend/src/components/ui/Loading.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Spin, Space, Typography } from 'antd'
 import { LoadingOutlined } from '@ant-design/icons'
 import { useTheme } from '@/theme'
+import { designTokens } from '@/themeTokens'
 
 const { Text } = Typography
 
@@ -29,7 +30,7 @@ export const Loading: React.FC<LoadingProps> = ({
 
   const antIcon = <LoadingOutlined style={{
     fontSize: size === 'small' ? 16 : size === 'large' ? 32 : 24,
-    color: '#2F6FED'
+    color: designTokens.color.primary
   }} spin />
 
   if (children) {

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -1,30 +1,34 @@
-"use client";
-
-import type { ReactNode } from "react";
 import { Typography } from "antd";
+import type { ReactNode } from "react";
 
 const { Title, Text } = Typography;
 
-interface PageHeaderProps {
+type PageHeaderProps = {
   eyebrow?: string;
   title: string;
   description?: string;
   icon?: ReactNode;
   actions?: ReactNode;
-}
+};
 
-export function PageHeader({ eyebrow, title, description, icon, actions }: PageHeaderProps) {
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  icon,
+  actions,
+}: PageHeaderProps) {
   return (
     <header className="page-header">
       <div className="page-header-copy">
-        {eyebrow && <span className="page-header-eyebrow">{eyebrow}</span>}
-        <Title level={1} className="page-header-title">
-          {icon && <span className="page-header-icon" aria-hidden="true">{icon}</span>}
+        {eyebrow ? <Text className="page-header-eyebrow">{eyebrow}</Text> : null}
+        <Title level={2} className="page-header-title">
+          {icon ? <span className="page-header-icon" aria-hidden="true">{icon}</span> : null}
           {title}
         </Title>
-        {description && <Text className="page-header-description">{description}</Text>}
+        {description ? <Text className="page-header-description">{description}</Text> : null}
       </div>
-      {actions && <div className="page-header-actions">{actions}</div>}
+      {actions ? <div className="page-header-actions">{actions}</div> : null}
     </header>
   );
 }

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { ConfigProvider, theme } from "antd";
 import { createContext, useContext, useState, useEffect } from "react";
+import { designTokens, type ThemeMode } from "./themeTokens";
 
-type ThemeMode = 'light' | 'dark';
 
 interface ThemeContextType {
   mode: ThemeMode;
@@ -17,37 +17,6 @@ export const useTheme = () => {
     throw new Error('useTheme must be used within AppTheme');
   }
   return context;
-};
-
-// Professional color palette
-const colors = {
-  primary: "#0B8F84",
-  success: "#0EB57D",
-  warning: "#FFB020",
-  error: "#E5484D",
-  info: "#256D8A",
-  light: {
-    bg: "#FFFFFF",
-    bgLayout: "#F7F8FA",
-    bgContainer: "#FFFFFF",
-    border: "#E7EBF0",
-    text: "#0F172A",
-    textSecondary: "#64748B",
-    textTertiary: "#94A3B8",
-    sider: "#0F1219",
-    header: "#FFFFFF",
-  },
-  dark: {
-    bg: "#0F1419",
-    bgLayout: "#151B23",
-    bgContainer: "#1E2532",
-    border: "#2A3441",
-    text: "#F8FAFC",
-    textSecondary: "#CBD5E1",
-    textTertiary: "#94A3B8",
-    sider: "#0F1419",
-    header: "#1E2532",
-  }
 };
 
 export const AppTheme = ({ children }: { children: React.ReactNode }) => {
@@ -87,7 +56,7 @@ export const AppTheme = ({ children }: { children: React.ReactNode }) => {
   };
 
   const isDark = mode === 'dark';
-  const colorScheme = isDark ? colors.dark : colors.light;
+  const colorScheme = isDark ? designTokens.color.dark : designTokens.color.light;
 
   return (
     <ThemeContext.Provider value={{ mode, toggleMode }}>
@@ -96,23 +65,23 @@ export const AppTheme = ({ children }: { children: React.ReactNode }) => {
           algorithm: isDark ? theme.darkAlgorithm : theme.defaultAlgorithm,
           token: {
             fontFamily: 'Inter, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif',
-            colorPrimary: colors.primary,
-            colorSuccess: colors.success,
-            colorWarning: colors.warning,
-            colorError: colors.error,
-            colorInfo: colors.info,
-            borderRadius: 8,
-            borderRadiusLG: 8,
-            borderRadiusSM: 6,
+            colorPrimary: designTokens.color.primary,
+            colorSuccess: designTokens.color.success,
+            colorWarning: designTokens.color.warning,
+            colorError: designTokens.color.error,
+            colorInfo: designTokens.color.info,
+            borderRadius: designTokens.radius.default,
+            borderRadiusLG: designTokens.radius.default,
+            borderRadiusSM: designTokens.radius.small,
             colorBorder: colorScheme.border,
             colorBgLayout: colorScheme.bgLayout,
             colorBgContainer: colorScheme.bgContainer,
             colorText: colorScheme.text,
             colorTextSecondary: colorScheme.textSecondary,
             colorTextTertiary: colorScheme.textTertiary,
-            controlHeight: 40,
-            controlHeightLG: 48,
-            controlHeightSM: 32,
+            controlHeight: designTokens.size.control,
+            controlHeightLG: designTokens.size.controlLarge,
+            controlHeightSM: designTokens.size.controlSmall,
             fontSize: 14,
             fontSizeLG: 16,
             fontSizeSM: 12,
@@ -134,19 +103,19 @@ export const AppTheme = ({ children }: { children: React.ReactNode }) => {
               triggerColor: colorScheme.text,
             },
             Card: {
-              borderRadiusLG: 8,
+              borderRadiusLG: designTokens.radius.default,
               boxShadow: isDark
                 ? "0 6px 24px rgba(0,0,0,0.15)"
                 : "0 6px 24px rgba(15,18,25,0.06)",
               headerBg: "transparent",
             },
             Button: {
-              borderRadius: 6,
-              controlHeight: 40,
+              borderRadius: designTokens.radius.small,
+              controlHeight: designTokens.size.control,
               fontWeight: 600,
             },
             Tag: {
-              borderRadiusSM: 20,
+              borderRadiusSM: designTokens.radius.pill,
             },
             Table: {
               borderColor: colorScheme.border,
@@ -154,13 +123,13 @@ export const AppTheme = ({ children }: { children: React.ReactNode }) => {
               rowHoverBg: isDark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.02)",
             },
             Input: {
-              borderRadius: 8,
+              borderRadius: designTokens.radius.default,
             },
             Select: {
               borderRadius: 8,
             },
             Modal: {
-              borderRadiusLG: 8,
+              borderRadiusLG: designTokens.radius.default,
             },
             Tooltip: {
               colorBgSpotlight: colorScheme.sider,

--- a/frontend/src/themeTokens.ts
+++ b/frontend/src/themeTokens.ts
@@ -1,0 +1,43 @@
+export const designTokens = {
+  color: {
+    primary: "#0B8F84",
+    success: "#0EB57D",
+    warning: "#FFB020",
+    error: "#E5484D",
+    info: "#256D8A",
+    light: {
+      bg: "#FFFFFF",
+      bgLayout: "#F7F8FA",
+      bgContainer: "#FFFFFF",
+      border: "#E7EBF0",
+      text: "#0F172A",
+      textSecondary: "#64748B",
+      textTertiary: "#94A3B8",
+      sider: "#0F1219",
+      header: "#FFFFFF",
+    },
+    dark: {
+      bg: "#0F1419",
+      bgLayout: "#151B23",
+      bgContainer: "#1E2532",
+      border: "#2A3441",
+      text: "#F8FAFC",
+      textSecondary: "#CBD5E1",
+      textTertiary: "#94A3B8",
+      sider: "#0F1419",
+      header: "#1E2532",
+    },
+  },
+  radius: {
+    small: 6,
+    default: 8,
+    pill: 20,
+  },
+  size: {
+    controlSmall: 32,
+    control: 40,
+    controlLarge: 48,
+  },
+} as const;
+
+export type ThemeMode = "light" | "dark";


### PR DESCRIPTION
## Summary
- extract the dashboard risk heat map and trend line into the shared GRC visualisation kit
- preserve existing analytics visualisation exports
- make heat-map cells keyboard-focusable with coordinate/count ARIA labels and visible focus treatment

This continues #88 after the dashboard, page-header and token foundation slices.

## Verification
- `npm run type-check`
- `npm run lint`
- `npm run test:unit` — 14 tests passed
- `git diff --check`