### PR TITLE
feat: align policy dashboard with shared templates

### DIFF
--- a/frontend/src/app/policies/dashboard/page.tsx
+++ b/frontend/src/app/policies/dashboard/page.tsx
@@ -14,8 +14,6 @@ import {
   Tag,
   Table,
   Badge,
-  Empty,
-  Spin,
   message,
   Space
 } from 'antd'
@@ -31,8 +29,9 @@ import {
   WarningOutlined
 } from '@ant-design/icons'
 import { api } from '@/lib/api'
+import { EmptyState, Loading, PageHeader } from '@/components/ui'
 
-const { Title, Text } = Typography
+const { Text } = Typography
 const { Search } = Input
 const { Option } = Select
 
@@ -257,35 +256,18 @@ export default function PolicyDashboardPage() {
   ]
 
   if (loading) {
-    return (
-      <div style={{ textAlign: 'center', padding: '50px' }}>
-        <Spin size="large" />
-        <div style={{ marginTop: 16 }}>Loading dashboard data...</div>
-      </div>
-    )
+    return <Loading message="Loading dashboard data..." />
   }
 
   return (
     <div>
-      {/* Header */}
-      <div style={{ marginBottom: 24, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <div>
-          <Title level={2}>
-            <DashboardOutlined style={{ marginRight: 8 }} />
-            Policy Acknowledgment Dashboard
-          </Title>
-          <Text type="secondary">
-            Monitor policy acknowledgment rates and compliance status across your organization
-          </Text>
-        </div>
-        <Button
-          icon={<ReloadOutlined />}
-          onClick={fetchDashboardData}
-          loading={loading}
-        >
-          Refresh
-        </Button>
-      </div>
+      <PageHeader
+        eyebrow="POLICY GOVERNANCE"
+        title="Policy acknowledgment dashboard"
+        description="Monitor policy acknowledgment rates and compliance status across your organisation."
+        icon={<DashboardOutlined />}
+        actions={<Button icon={<ReloadOutlined />} onClick={fetchDashboardData}>Refresh</Button>}
+      />
 
       {/* Overview Stats */}
       <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
@@ -407,12 +389,12 @@ export default function PolicyDashboardPage() {
         }
       >
         {filteredData.length === 0 ? (
-          <Empty
-            description={
-              dashboardData.length === 0
-                ? "No policies found"
-                : "No policies match your current filters"
-            }
+          <EmptyState
+            size="small"
+            headingLevel={3}
+            type={dashboardData.length === 0 ? 'policies' : 'filter'}
+            title={dashboardData.length === 0 ? 'No policies found' : 'No matching policies'}
+            description={dashboardData.length === 0 ? 'Published policies will appear here once they are available.' : 'Try changing your search or filters.'}
           />
         ) : (
           <Table

--- a/frontend/src/app/policies/page.tsx
+++ b/frontend/src/app/policies/page.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import React, { useEffect, useState } from 'react'
-import { Card, Row, Col, Typography, Button, Empty, Spin, message, Badge, Tag } from 'antd'
+import { Card, Row, Col, Typography, Button, message, Badge, Tag } from 'antd'
 import { FileTextOutlined, CheckCircleOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
 import { api, getErrorMessage } from '@/lib/api'
 import { useTheme } from '@/theme'
+import { EmptyState, Loading, PageHeader } from '@/components/ui'
 
-const { Title, Text, Paragraph } = Typography
+const { Text, Paragraph } = Typography
 
 interface PolicyForAcknowledgment {
   distribution_id: string
@@ -158,38 +159,24 @@ export default function PoliciesPage() {
   }
 
   if (loading) {
-    return (
-      <div style={{ textAlign: 'center', padding: '50px' }}>
-        <Spin size="large" />
-        <div style={{ marginTop: 16 }}>Loading your policies...</div>
-      </div>
-    )
+    return <Loading message="Loading your policies..." />
   }
 
   return (
     <div>
-      <div style={{ marginBottom: 24 }}>
-        <Title level={2}>
-          <FileTextOutlined style={{ marginRight: 8 }} />
-          Policy Acknowledgments
-        </Title>
-        <Text type="secondary">
-          Review and acknowledge the policies assigned to you. These policies require your acknowledgment to ensure compliance.
-        </Text>
-      </div>
+      <PageHeader
+        eyebrow="POLICY GOVERNANCE"
+        title="Policy acknowledgments"
+        description="Review and acknowledge the policies assigned to you so your organisation stays aligned with its standards."
+        icon={<FileTextOutlined />}
+      />
 
       {policies.length === 0 ? (
-        <Card>
-          <Empty
-            image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description={
-              <span>
-                <CheckCircleOutlined style={{ color: '#52c41a', marginRight: 8 }} />
-                All caught up! You have no policies requiring acknowledgment.
-              </span>
-            }
-          />
-        </Card>
+        <EmptyState
+          title="All caught up"
+          description="You have no policies requiring acknowledgment. New assignments will appear here."
+          icon={<CheckCircleOutlined />}
+        />
       ) : (
         <>
           <div style={{ marginBottom: 16 }}>


### PR DESCRIPTION
## Summary
- adopt the shared PageHeader for the policy administration dashboard
- use the shared Loading component for initial loading
- use the shared EmptyState component for empty and filtered table states

## Verification
- npm run type-check
- npm run lint
- npm run build
- npm run test:unit

Refs #88