### PR TITLE
feat: align scans page with shared template

### DIFF
--- a/frontend/src/app/scans/page.tsx
+++ b/frontend/src/app/scans/page.tsx
@@ -1,32 +1,28 @@
 'use client'
 
 import React from 'react'
-import { Card, Typography, Space, Button } from 'antd'
+import { Card, Space, Button } from 'antd'
 import { RadarChartOutlined, PlusOutlined } from '@ant-design/icons'
-
-const { Title, Text } = Typography
+import { PageHeader } from '@/components/ui'
 
 export default function ScansPage() {
   return (
     <div>
-      <div style={{ marginBottom: 24 }}>
-        <Title level={2}>
-          <RadarChartOutlined style={{ marginRight: 8 }} />
-          Vulnerability Scanning
-        </Title>
-        <Text type="secondary">
-          Monitor and manage security vulnerabilities across your infrastructure
-        </Text>
-      </div>
+      <PageHeader
+        eyebrow="SECURITY OPERATIONS"
+        title="Vulnerability scanning"
+        description="Monitor and manage security vulnerabilities across your infrastructure."
+        icon={<RadarChartOutlined />}
+      />
 
       <Card>
         <div style={{ textAlign: 'center', padding: '50px 0' }}>
           <RadarChartOutlined style={{ fontSize: '64px', color: '#1890ff', marginBottom: 16 }} />
-          <Title level={3}>Vulnerability Management</Title>
-          <Text type="secondary" style={{ display: 'block', marginBottom: 24 }}>
+          <h2>Vulnerability management</h2>
+          <p style={{ color: 'var(--ink-soft, #466166)', display: 'block', marginBottom: 24 }}>
             Import scan results from tools like OpenVAS and Nessus,
             track remediation progress, and manage security findings.
-          </Text>
+          </p>
           <Space>
             <Button type="primary" icon={<PlusOutlined />}>
               Import Scan Results


### PR DESCRIPTION
## Summary
- adopt the shared PageHeader for vulnerability scanning
- use semantic page content headings
- preserve the current informational scanning workflow without inventing backend behaviour

## Verification
- npm run type-check
- npm run lint
- npm run build
- npm run test:unit

Refs #88