### PR TITLE
feat: complete shared detail templates

### DIFF
--- a/frontend/src/app/risk/[id]/page.tsx
+++ b/frontend/src/app/risk/[id]/page.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useState, useEffect } from 'react'
 import { Card, Typography, Space, Button, Row, Col, Descriptions, Tag, Progress, Divider, message, Modal, Form, Input, Select } from 'antd'
 import { SafetyOutlined, EditOutlined, DeleteOutlined, ArrowLeftOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
 import { useRouter, useParams } from 'next/navigation'
-import { Breadcrumb, StatusTag, PriorityTag, Loading } from '@/components/ui'
+import { Breadcrumb, EmptyState, PageHeader, StatusTag, PriorityTag, Loading } from '@/components/ui'
 import { riskService, type Risk } from '@/lib/services/riskService'
 
 const { Title, Text, Paragraph } = Typography
@@ -82,16 +82,7 @@ export default function RiskDetailPage() {
   }
 
   if (!risk) {
-    return (
-      <div style={{ textAlign: 'center', padding: '50px' }}>
-        <Title level={3}>Risk Not Found</Title>
-        <Text type="secondary">The risk you&apos;re looking for doesn&apos;t exist or has been deleted.</Text>
-        <br />
-        <Button type="primary" onClick={() => router.push('/risk')} style={{ marginTop: 16 }}>
-          Back to Risk Management
-        </Button>
-      </div>
-    )
+    return <EmptyState type="risks" title="Risk not found" description="The selected risk does not exist or has been deleted." action={{ text: "Back to risk management", onClick: () => router.push('/risk') }} />
   }
 
   return (
@@ -111,16 +102,17 @@ export default function RiskDetailPage() {
         </Space>
       </div>
 
+      <PageHeader
+        eyebrow="RISK & RESILIENCE"
+        title={risk.title}
+        description={`Risk ${risk.risk_id} · Review ownership, treatment, controls and exposure.`}
+        icon={<SafetyOutlined />}
+      />
+
       <Row gutter={[24, 24]}>
         {/* Main Risk Information */}
         <Col xs={24} lg={16}>
           <Card
-            title={
-              <Space>
-                <SafetyOutlined />
-                <Text strong>{risk.title}</Text>
-              </Space>
-            }
             extra={
               <Space>
                 <Button icon={<EditOutlined />} onClick={handleEditRisk}>

--- a/frontend/src/app/vendors/[id]/page.tsx
+++ b/frontend/src/app/vendors/[id]/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import React, { useCallback, useState, useEffect } from 'react'
-import { Card, Typography, Space, Button, Row, Col, Descriptions, Tag, Progress, Divider, message, Modal, Form, Input, Avatar } from 'antd'
+import { Card, Typography, Space, Button, Row, Col, Descriptions, Tag, Progress, Divider, message, Modal, Form, Input } from 'antd'
 import { TeamOutlined, EditOutlined, DeleteOutlined, ArrowLeftOutlined, GlobalOutlined } from '@ant-design/icons'
 import { useRouter, useParams } from 'next/navigation'
-import { Breadcrumb, StatusTag, PriorityTag, Loading } from '@/components/ui'
+import { Breadcrumb, EmptyState, PageHeader, StatusTag, PriorityTag, Loading } from '@/components/ui'
 import { vendorService, type Vendor } from '@/lib/services/vendorService'
 
 const { Title, Text, Paragraph } = Typography
@@ -82,16 +82,7 @@ export default function VendorDetailPage() {
   }
 
   if (!vendor) {
-    return (
-      <div style={{ textAlign: 'center', padding: '50px' }}>
-        <Title level={3}>Vendor Not Found</Title>
-        <Text type="secondary">The vendor you&apos;re looking for doesn&apos;t exist or has been deleted.</Text>
-        <br />
-        <Button type="primary" onClick={() => router.push('/vendors')} style={{ marginTop: 16 }}>
-          Back to Vendor Management
-        </Button>
-      </div>
-    )
+    return <EmptyState type="vendors" title="Vendor not found" description="The selected vendor does not exist or has been deleted." action={{ text: "Back to vendor management", onClick: () => router.push('/vendors') }} />
   }
 
   const typeLabels: { [key: string]: string } = {
@@ -120,25 +111,17 @@ export default function VendorDetailPage() {
         </Space>
       </div>
 
+      <PageHeader
+        eyebrow="THIRD-PARTY ASSURANCE"
+        title={vendor.name}
+        description={`Vendor ${vendor.vendor_id} · Review profile, risk and assurance details.`}
+        icon={<TeamOutlined />}
+      />
+
       <Row gutter={[24, 24]}>
         {/* Main Vendor Information */}
         <Col xs={24} lg={16}>
           <Card
-            title={
-              <Space>
-                <Avatar size="large" style={{ backgroundColor: '#2F6FED' }}>
-                  {vendor.name.substring(0, 2).toUpperCase()}
-                </Avatar>
-                <div>
-                  <Text strong style={{ fontSize: '18px' }}>{vendor.name}</Text>
-                  <br />
-                  <Text type="secondary">{vendor.vendor_id}</Text>
-                  {vendor.legal_name && vendor.legal_name !== vendor.name && (
-                    <><br /><Text type="secondary" style={{ fontSize: '12px' }}>Legal: {vendor.legal_name}</Text></>
-                  )}
-                </div>
-              </Space>
-            }
             extra={
               <Space>
                 <Button icon={<EditOutlined />} onClick={handleEditVendor}>

--- a/frontend/src/app/vendors/[id]/page.tsx
+++ b/frontend/src/app/vendors/[id]/page.tsx
@@ -114,7 +114,7 @@ export default function VendorDetailPage() {
       <PageHeader
         eyebrow="THIRD-PARTY ASSURANCE"
         title={vendor.name}
-        description={`Vendor ${vendor.vendor_id} · Review profile, risk and assurance details.`}
+        description={`${vendor.legal_name && vendor.legal_name !== vendor.name ? `${vendor.legal_name} · ` : ''}Vendor ${vendor.vendor_id} · Review profile, risk and assurance details.`}
         icon={<TeamOutlined />}
       />
 

--- a/frontend/src/app/vendors/contracts/page.tsx
+++ b/frontend/src/app/vendors/contracts/page.tsx
@@ -4,9 +4,9 @@ import React from 'react'
 import { Card, Typography, Space, Button, Table, Tag } from 'antd'
 import { TeamOutlined, ArrowLeftOutlined, ClockCircleOutlined, WarningOutlined } from '@ant-design/icons'
 import { useRouter } from 'next/navigation'
-import { Breadcrumb } from '@/components/ui'
+import { Breadcrumb, PageHeader } from '@/components/ui'
 
-const { Title, Text } = Typography
+const { Text } = Typography
 
 export default function VendorContractsPage() {
   const router = useRouter()
@@ -110,13 +110,12 @@ export default function VendorContractsPage() {
         </Space>
       </div>
 
-      <Title level={2}>
-        <ClockCircleOutlined style={{ marginRight: 8 }} />
-        Contract Management
-      </Title>
-      <Text type="secondary">
-        Track vendor contracts, renewals, and expirations
-      </Text>
+      <PageHeader
+        eyebrow="THIRD-PARTY ASSURANCE"
+        title="Contract management"
+        description="Track vendor contracts, renewals, and expirations."
+        icon={<ClockCircleOutlined />}
+      />
 
       <Card style={{ marginTop: 24 }}>
         <Table


### PR DESCRIPTION
## Summary
This consolidates the remaining page-template work into one PR to reduce CI overhead.

- use the shared PageHeader and EmptyState on risk detail
- use the shared PageHeader and EmptyState on vendor detail
- use the shared PageHeader on vendor contract management
- preserve existing detail, edit/delete, table, modal, and navigation behaviour

## Verification
- npm run type-check
- npm run lint
- npm run build
- npm run test:unit

Refs #88