### PR TITLE
chore: make pre-commit setup reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,5 @@ shell:
 	docker compose exec web python manage.py shell_plus || docker compose exec web python manage.py shell
 test:
 	docker compose exec web pytest -q
+setup-hooks:
+	python -m pre_commit install --install-hooks

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # aximcyber
 A Multi-tenant Information Security GRC SaaS Application
+
+## Developer setup
+
+Install the pinned development tooling and configure the repository hooks:
+
+```bash
+python -m pip install -r requirements-dev.txt
+make setup-hooks
+```
+
+The hooks run Ruff formatting and linting, Bandit, and the repository's other
+pre-commit checks before commits. CI remains the authoritative check for every
+pull request.


### PR DESCRIPTION
Make local quality checks reproducible for fresh clones.

- Adds `make setup-hooks` using the pinned `requirements-dev.txt` pre-commit package.
- Documents dependency installation and hook setup in README.
- CI remains the authoritative pull-request gate.

Refs #90