### PR TITLE
feat: enable Stripe Tax at checkout

### DIFF
--- a/app/billing/services.py
+++ b/app/billing/services.py
@@ -6,6 +6,16 @@ from core.models import Tenant, Plan, Subscription, Document
 User = get_user_model()
 
 
+def stripe_checkout_tax_parameters() -> dict[str, object]:
+    """Return the Stripe Checkout settings required for automatic tax collection."""
+    return {
+        "automatic_tax": {"enabled": True},
+        "billing_address_collection": "required",
+        "tax_id_collection": {"enabled": True},
+        "customer_update": {"address": "auto", "name": "auto"},
+    }
+
+
 class PlanEnforcementService:
     """
     Service class for checking plan limits and features.

--- a/app/billing/test_tax_checkout.py
+++ b/app/billing/test_tax_checkout.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django_tenants.utils import schema_context
+
+from core.models import Plan
+
+
+@pytest.mark.django_db
+def test_checkout_enables_stripe_tax_and_tax_id_collection(tenant_client, test_tenant, admin_user):
+    with schema_context("public"):
+        Plan.objects.create(
+            name="Basic",
+            slug="basic",
+            price_monthly=49,
+            stripe_price_id="price_basic",
+        )
+
+    tenant_client.force_authenticate(user=admin_user)
+    customer = SimpleNamespace(id="cus_test_123")
+    session = SimpleNamespace(id="cs_test_123", url="https://checkout.stripe.test/session")
+
+    with (
+        patch("billing.views.stripe.Customer.create", return_value=customer),
+        patch("billing.views.stripe.checkout.Session.create", return_value=session) as create,
+    ):
+        response = tenant_client.post(
+            "/api/billing/create_checkout_session/",
+            {"plan": "basic"},
+            format="json",
+        )
+
+    assert response.status_code == 200
+    assert create.call_args.kwargs["automatic_tax"] == {"enabled": True}
+    assert create.call_args.kwargs["billing_address_collection"] == "required"
+    assert create.call_args.kwargs["tax_id_collection"] == {"enabled": True}
+    assert create.call_args.kwargs["customer_update"] == {
+        "address": "auto",
+        "name": "auto",
+    }

--- a/app/billing/views.py
+++ b/app/billing/views.py
@@ -26,6 +26,7 @@ from .audit import (
     billing_changed_values,
     snapshot_subscription,
 )
+from .services import stripe_checkout_tax_parameters
 
 logger = logging.getLogger(__name__)
 
@@ -212,6 +213,7 @@ class BillingViewSet(viewsets.ViewSet):
                     success_url=f"{settings.SITE_DOMAIN}/billing/success?session_id={{CHECKOUT_SESSION_ID}}",
                     cancel_url=f"{settings.SITE_DOMAIN}/billing/cancel",
                     metadata={"tenant_id": tenant.id, "plan_id": plan.id},
+                    **stripe_checkout_tax_parameters(),
                 )
 
             return Response({"checkout_url": session.url, "session_id": session.id})

--- a/docs/adr/0041-stripe-billing-tax-model.md
+++ b/docs/adr/0041-stripe-billing-tax-model.md
@@ -49,6 +49,57 @@ The implementation will proceed in separate, testable slices:
 3. Reconcile invoice and tax metadata from signed, idempotent webhooks.
 4. Provide finance/admin exports containing invoice and tax evidence references, without sensitive payment payloads.
 
+## Checkout safeguards and known trade-offs
+
+The Stripe-hosted Checkout flow will collect a billing address and, where
+applicable, a tax identifier. This deliberately sends those values to Stripe;
+the application does not receive or persist the tax identifier entered in
+Checkout. The tenant must document Stripe as a billing and tax-data processor
+in its privacy and data-processing notices.
+
+The following behaviours are intentional and must be visible in the product
+and support documentation:
+
+- A required billing address can add friction to checkout.
+- `customer_update[address] = auto` allows the latest Checkout address to
+  replace the saved Stripe Customer address.
+- Stripe does not display tax-ID collection when the Customer already has a
+  tax ID; the billing profile and Stripe Customer must therefore remain
+  reconcilable.
+- `automatic_tax` calculates tax only for jurisdictions and products that are
+  configured in Stripe Tax. Enabling the Checkout flag is not evidence that
+  the business is registered or compliant.
+- Stripe Tax calculation and reporting do not, by themselves, transfer the
+  business's responsibility for VAT returns or remittance.
+
+## Firm follow-up sequence
+
+These are release gates for the remaining #177 work, in order:
+
+1. **Stripe Tax readiness** — configure UK registration, product tax codes,
+   tax behaviour and seller details in the Stripe account; add a production
+   readiness check that blocks tax-enabled release when registration is
+   missing.
+2. **Tax-profile synchronisation** — reconcile the tenant profile with the
+   Stripe Customer, record provider status and validation timestamps, and
+   handle replacement or removal of an existing tax ID without logging its
+   value.
+3. **Invoice reconciliation** — consume signed, idempotent invoice and
+   subscription webhooks; persist invoice ID, status, currency, taxable amount,
+   tax amount, tax treatment and hosted-invoice URL, with refund and credit
+   note handling.
+4. **Finance and admin evidence** — provide exports of invoice and tax-evidence
+   references, reconciliation failures and refund adjustments. Exports must
+   exclude payment methods, complete webhook payloads and raw secrets.
+5. **Remittance operations** — document UK VAT return ownership, filing
+   frequency, evidence retention and refund amendments. Reassess Stripe filing
+   partners or a merchant-of-record provider before material international
+   expansion.
+
+Until these gates are complete, the product must describe Stripe Tax as a
+calculation and evidence service, not as a substitute for tax registration,
+filing or remittance advice.
+
 VAT identifier validation must be treated as an external verification result with a timestamp and provider status; it must not be treated as proof of registration indefinitely. Reverse-charge treatment must be decided from the validated customer and transaction context, not from a client-supplied flag alone.
 
 ## Consequences
@@ -58,4 +109,3 @@ VAT identifier validation must be treated as an external verification result wit
 - The business remains responsible for VAT registration, returns and remittance while Stripe supplies calculation and evidence capabilities.
 - Tax configuration, VAT registration status and invoice evidence become part of the audited billing domain.
 - The product must not promise global tax compliance until registrations, evidence retention and reporting obligations for each market are explicitly assessed.
-


### PR DESCRIPTION
Implements the next #177 billing tax slice.

- Enables Stripe automatic tax on subscription Checkout Sessions.
- Requires billing address collection and allows Stripe to update the Customer name/address.
- Enables Stripe-hosted tax ID collection, so the application does not receive or persist the entered identifier.
- Adds focused Checkout parameter coverage.

Invoice reconciliation, tax-profile validation and remittance exports remain follow-up work under #177.