### PR TITLE
fix: stabilise local entitlements and module actions

### DIFF
--- a/app/billing/views.py
+++ b/app/billing/views.py
@@ -19,7 +19,7 @@ from drf_spectacular.types import OpenApiTypes
 
 from core.models import InvoiceEvidence, Tenant, Plan, Subscription, BillingEvent
 from .serializers import PlanSerializer, SubscriptionSerializer
-from .entitlements import MODULE_BY_KEY
+from .entitlements import MODULE_BY_KEY, get_default_modules_for_plan
 from .tenant_access import get_public_tenant
 from .audit import (
     audit_subscription_change,
@@ -97,6 +97,25 @@ class BillingViewSet(viewsets.ViewSet):
     serializer_class = SubscriptionSerializer
     permission_classes = [IsAuthenticated]
 
+    @staticmethod
+    def _get_or_create_free_plan():
+        """Provide the baseline entitlement needed by a newly provisioned tenant."""
+        return Plan.objects.get_or_create(
+            slug="free",
+            defaults={
+                "name": "Free",
+                "description": "Perfect for getting started with basic GRC needs",
+                "price_monthly": 0,
+                "max_users": 3,
+                "max_documents": 50,
+                "max_frameworks": 1,
+                "has_api_access": False,
+                "has_advanced_reporting": False,
+                "has_priority_support": False,
+                "included_modules": get_default_modules_for_plan("free"),
+            },
+        )
+
     @extend_schema(
         summary="Get current subscription",
         description="Retrieve the current tenant's subscription details including plan, status, and billing information.",
@@ -115,7 +134,7 @@ class BillingViewSet(viewsets.ViewSet):
                 subscription = getattr(tenant, "subscription", None)
 
                 if not subscription:
-                    free_plan = Plan.objects.get(slug="free")
+                    free_plan, _ = self._get_or_create_free_plan()
                     subscription = Subscription.objects.create(
                         tenant=tenant,
                         plan=free_plan,

--- a/app/core/tests.py
+++ b/app/core/tests.py
@@ -372,6 +372,27 @@ class TestBillingAPI:
             for module in response.data["module_catalog"]
         )
 
+    def test_current_subscription_provisions_free_plan_when_missing(self, api_client, test_tenant):
+        """A new local tenant can load the shell before plan setup has been run manually."""
+        with schema_context("public"):
+            Plan.objects.filter(slug="free").delete()
+
+        with tenant_context(test_tenant):
+            user = User.objects.create_user(
+                username="free-plan-user",
+                email="free-plan-user@example.com",
+                password="testpass123",
+            )
+
+        api_client.defaults["HTTP_HOST"] = f"{test_tenant.schema_name}.localhost"
+        api_client.force_authenticate(user=user)
+
+        response = api_client.get("/api/billing/current_subscription/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["plan"]["slug"] == "free"
+        assert response.data["enabled_module_keys"] == ["frameworks"]
+
     def test_single_module_trial_blocks_direct_api_bypass(self, test_tenant):
         """Test trial tenants cannot reach APIs outside the selected module."""
         with schema_context("public"):

--- a/frontend/src/app/risk/page.tsx
+++ b/frontend/src/app/risk/page.tsx
@@ -447,12 +447,12 @@ export default function RiskPage() {
           <Card hoverable>
             <Space direction="vertical" size={8}>
               <InfoCircleOutlined style={{ fontSize: '24px', color: '#2F6FED' }} />
-              <Text strong>Risk Reports</Text>
+              <Text strong>Risk Analytics</Text>
               <Text type="secondary" style={{ fontSize: '12px' }}>
-                Generate executive and detailed reports
+                Review executive and detailed risk trends
               </Text>
-              <Button type="link" style={{ padding: 0 }} onClick={() => router.push('/reports')}>
-                Generate Report →
+              <Button type="link" style={{ padding: 0 }} onClick={() => router.push('/analytics')}>
+                Open Analytics →
               </Button>
             </Space>
           </Card>

--- a/frontend/src/app/scans/page.tsx
+++ b/frontend/src/app/scans/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { Card, Space, Button } from 'antd'
+import { Alert, Card, Space, Button } from 'antd'
 import { RadarChartOutlined, PlusOutlined } from '@ant-design/icons'
 import { PageHeader } from '@/components/ui'
 
@@ -20,14 +20,20 @@ export default function ScansPage() {
           <RadarChartOutlined style={{ fontSize: '64px', color: '#1890ff', marginBottom: 16 }} />
           <h2>Vulnerability management</h2>
           <p style={{ color: 'var(--ink-soft, #466166)', display: 'block', marginBottom: 24 }}>
-            Import scan results from tools like OpenVAS and Nessus,
-            track remediation progress, and manage security findings.
+            Scanner connections are not configured for this tenant yet. Vulnerability workflows will become available once an integration is enabled.
           </p>
+          <Alert
+            type="info"
+            showIcon
+            title="Scanner integration required"
+            description="Configure an approved scanner connection before importing findings or viewing vulnerability records."
+            style={{ maxWidth: 640, margin: '0 auto 24px', textAlign: 'left' }}
+          />
           <Space>
-            <Button type="primary" icon={<PlusOutlined />}>
+            <Button type="primary" icon={<PlusOutlined />} disabled>
               Import Scan Results
             </Button>
-            <Button>
+            <Button disabled>
               View Vulnerabilities
             </Button>
           </Space>

--- a/frontend/src/app/vendors/page.tsx
+++ b/frontend/src/app/vendors/page.tsx
@@ -450,7 +450,7 @@ export default function VendorsPage() {
               <Text type="secondary" style={{ fontSize: '12px' }}>
                 Evaluate vendor risk profiles
               </Text>
-              <Button type="link" style={{ padding: 0 }} onClick={() => router.push('/vendors/risk-assessment')}>
+              <Button type="link" style={{ padding: 0 }} onClick={() => router.push('/assessments/create?type=vendor')}>
                 Assess Risk →
               </Button>
             </Space>


### PR DESCRIPTION
## Summary\n- provision the required free plan on first authenticated entitlement lookup, preventing a first-run dashboard 500\n- cover the free-plan provisioning path with backend tests\n- route Risk Analytics and vendor risk assessment actions to supported experiences\n- replace clickable scanner placeholders with an explicit unavailable state\n\n## Verification\n- focused backend subscription tests: 3 passed\n- frontend type-check and lint passed\n- frontend unit tests: 13 passed\n- Playwright E2E: 7 passed\n\nCloses #393. Delivers the confirmed dangling-action slice of #388; mock-data module replacement remains tracked there.