### PR TITLE
fix: make navigation actions truthful

### DIFF
--- a/docs/adr/0042-evidence-led-product-design-workflow.md
+++ b/docs/adr/0042-evidence-led-product-design-workflow.md
@@ -1,0 +1,35 @@
+# ADR-0042: Evidence-led product design workflow
+
+## Status
+
+Accepted
+
+## Context
+
+GRC Suite must support dense, high-consequence work without presenting generic dashboard templates, decorative empty states or actions that imply unavailable workflows. The local browser review of 11 August 2026 found visual inconsistency alongside functional dead ends. The platform already uses Ant Design, custom theme tokens and Playwright, but needs a repeatable decision process before further visual rework.
+
+## Decision
+
+Use an evidence-led workflow for material frontend changes.
+
+1. **Audit the live flow first.** Capture fresh desktop and mobile screenshots of the relevant workflow, test primary actions and record console, navigation and accessibility defects as issues.
+2. **Separate functional integrity from visual work.** Broken links, simulated actions and unavailable back-end capabilities must be fixed or made explicitly unavailable before visual polish.
+3. **Explore before implementation.** Use Superdesign to analyse the existing frontend and create reviewable visual directions. Product Design is used for screenshot-led audit, visual exploration and implementation QA.
+4. **Maintain an application-owned design reference.** Curated external `DESIGN.md` sources may inform the work, but GRC Suite keeps its own `frontend/DESIGN.md` containing approved tokens, layout rules, interaction states and component guidance. It must not copy another product's branding.
+5. **Verify in the browser.** Frontend PRs that change a material workflow require desktop and mobile screenshot inspection, keyboard-path checks for primary controls, and no new console errors. Playwright remains the automated regression gate.
+
+## Consequences
+
+- Design proposals become reviewable before code commits, reducing rework and generic implementation drift.
+- Functional truthfulness is a release requirement: visible actions work, or have an accessible unavailable state with a clear reason.
+- The dashboard redesign in #392 follows this ADR after navigation integrity (#388) and real global search (#389).
+
+## Alternatives considered
+
+- Adopt a third-party design system wholesale: rejected because it would dilute the GRC product identity and retain external brand constraints.
+- Continue ad-hoc page-by-page styling: rejected because it makes quality, accessibility and consistency difficult to review.
+
+## References
+
+- ADR-0031: Frontend design-system evolution.
+- Issues #388, #389 and #392.

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -156,6 +156,25 @@ export async function mockAuthenticatedGrcApi(page: Page) {
       return;
     }
 
+    if (path === "/api/auth/profile/" && request.method() === "GET") {
+      await fulfilJson(route, {
+        email: "user@example.com",
+        first_name: "Test",
+        last_name: "User",
+      });
+      return;
+    }
+
+    if (path === "/api/auth/profile/" && request.method() === "PATCH") {
+      await fulfilJson(route, await request.postDataJSON());
+      return;
+    }
+
+    if (path === "/api/auth/logout/" && request.method() === "POST") {
+      await fulfilJson(route, { message: "Logout successful" });
+      return;
+    }
+
     if (path === "/api/billing/current_subscription/" && request.method() === "GET") {
       await fulfilJson(route, {
         enabled_module_keys: [

--- a/frontend/e2e/navigation-integrity.smoke.spec.ts
+++ b/frontend/e2e/navigation-integrity.smoke.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { mockAuthenticatedGrcApi } from "./helpers/api";
+
+test("assessment setup and account menu expose only working actions", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+
+  await page.goto("/login?tenant=demo");
+  await page.getByLabel("Email").fill("user@example.com");
+  await page.getByLabel("Password").fill("E2ePassw0rd!");
+  await page.getByRole("button", { name: "Login" }).click();
+
+  await page.getByRole("link", { name: "Assessments", exact: true }).click();
+  await expect(page).toHaveURL(/\/assessments$/);
+  await expect(page.getByRole("heading", { name: "Prepare your assessment catalogue" })).toBeVisible();
+
+  await page.getByRole("link", { name: "Import a framework" }).click();
+  await expect(page).toHaveURL(/\/admin$/);
+  await expect(page.getByRole("heading", { name: "System administration" })).toBeVisible();
+
+  await page.getByText("TU", { exact: true }).click();
+  await page.getByRole("link", { name: "Profile settings" }).click();
+  await expect(page).toHaveURL(/\/account\/profile$/);
+  await expect(page.getByRole("heading", { name: "Profile settings" })).toBeVisible();
+
+  await page.getByText("TU", { exact: true }).click();
+  await page.getByRole("menuitem", { name: "Sign Out" }).click();
+  await expect(page).toHaveURL(/\/login$/);
+});

--- a/frontend/src/app/account/profile/page.tsx
+++ b/frontend/src/app/account/profile/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Alert, Button, Card, Form, Input, Spin, message } from "antd";
+import { UserOutlined } from "@ant-design/icons";
+import { PageHeader } from "@/components/ui";
+import api, { getErrorMessage } from "@/lib/api";
+
+type Profile = {
+  email: string;
+  first_name: string;
+  last_name: string;
+};
+
+export default function ProfilePage() {
+  const [form] = Form.useForm<Profile>();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    void api.get<Profile>("/auth/profile/")
+      .then(({ data }) => form.setFieldsValue(data))
+      .catch((requestError: unknown) => setError(getErrorMessage(requestError)))
+      .finally(() => setLoading(false));
+  }, [form]);
+
+  const saveProfile = async (values: Profile) => {
+    setSaving(true);
+    setError("");
+    try {
+      const { data } = await api.patch<Profile>("/auth/profile/", values);
+      form.setFieldsValue(data);
+      message.success("Profile updated");
+    } catch (requestError) {
+      setError(getErrorMessage(requestError));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <PageHeader
+        eyebrow="ACCOUNT"
+        title="Profile settings"
+        description="Keep your personal details accurate for assignment and audit records."
+        icon={<UserOutlined />}
+      />
+      <Card style={{ maxWidth: 640 }}>
+        {error && <Alert type="error" showIcon title="Profile could not be updated" description={error} style={{ marginBottom: 16 }} />}
+        {loading ? <Spin /> : (
+          <Form form={form} layout="vertical" onFinish={saveProfile}>
+            <Form.Item label="Work email" name="email">
+              <Input disabled />
+            </Form.Item>
+            <Form.Item label="First name" name="first_name" rules={[{ required: true, message: "Enter your first name" }]}>
+              <Input autoComplete="given-name" />
+            </Form.Item>
+            <Form.Item label="Last name" name="last_name" rules={[{ required: true, message: "Enter your last name" }]}>
+              <Input autoComplete="family-name" />
+            </Form.Item>
+            <Button type="primary" htmlType="submit" loading={saving}>Save changes</Button>
+          </Form>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/app/assessments/page.tsx
+++ b/frontend/src/app/assessments/page.tsx
@@ -1,30 +1,39 @@
 'use client'
 
 import React from 'react'
-import { Card, Space, Button } from 'antd'
-import { CheckSquareOutlined, PlusOutlined } from '@ant-design/icons'
+import { Alert, Button, Card, Space } from 'antd'
+import { CheckSquareOutlined, DatabaseOutlined } from '@ant-design/icons'
+import Link from 'next/link'
 import { PageHeader } from '@/components/ui'
 
 export default function AssessmentsPage() {
   return (
     <div>
-      <PageHeader eyebrow="ASSURANCE PROGRAMME" title="Compliance assessments" description="Conduct and track compliance assessments across frameworks." icon={<CheckSquareOutlined />} actions={<Button type="primary" icon={<PlusOutlined />}>Start assessment</Button>} />
+      <PageHeader
+        eyebrow="ASSURANCE PROGRAMME"
+        title="Compliance assessments"
+        description="Control assessments become available after a framework catalogue has been imported."
+        icon={<CheckSquareOutlined />}
+        actions={<Button type="primary" icon={<DatabaseOutlined />} href="/admin">Import a framework</Button>}
+      />
 
       <Card>
         <div style={{ textAlign: 'center', padding: '50px 0' }}>
           <CheckSquareOutlined style={{ fontSize: '64px', color: '#1890ff', marginBottom: 16 }} />
-          <h2>Compliance Assessment Center</h2>
+          <h2>Prepare your assessment catalogue</h2>
           <p style={{ display: 'block', marginBottom: 24 }}>
-            Manage compliance assessments for various frameworks including
-            SOC 2, ISO 27001, NIST CSF, and custom organizational standards.
+            Import an approved framework pack to create the controls your team will assess.
           </p>
+          <Alert
+            type="info"
+            showIcon
+            title="Assessment setup is catalogue-led"
+            description="The previous assessment wizard only simulated a completed assessment and did not create an auditable control assessment. It is unavailable until the real workflow is connected."
+            style={{ maxWidth: 640, margin: '0 auto 24px', textAlign: 'left' }}
+          />
           <Space>
-            <Button type="primary" icon={<PlusOutlined />}>
-              Start Assessment
-            </Button>
-            <Button>
-              View All Assessments
-            </Button>
+            <Button type="primary" icon={<DatabaseOutlined />} href="/admin">Import framework catalogue</Button>
+            <Link href="/policies/dashboard">Review policy readiness</Link>
           </Space>
         </div>
       </Card>

--- a/frontend/src/app/risk/page.tsx
+++ b/frontend/src/app/risk/page.tsx
@@ -187,7 +187,7 @@ export default function RiskPage() {
 
   // Handle Create Assessment
   const handleCreateAssessment = () => {
-    router.push('/assessments/create')
+    router.push('/assessments')
   }
 
   // Handle Risk ID click (navigate to risk details)

--- a/frontend/src/app/vendors/page.tsx
+++ b/frontend/src/app/vendors/page.tsx
@@ -422,7 +422,7 @@ export default function VendorsPage() {
               <Text type="secondary" style={{ fontSize: '12px' }}>
                 Conduct vendor security evaluations
               </Text>
-              <Button type="link" style={{ padding: 0 }} onClick={() => router.push('/assessments/create?type=vendor')}>
+              <Button type="link" style={{ padding: 0 }} onClick={() => router.push('/assessments')}>
                 Start Assessment →
               </Button>
             </Space>
@@ -450,7 +450,7 @@ export default function VendorsPage() {
               <Text type="secondary" style={{ fontSize: '12px' }}>
                 Evaluate vendor risk profiles
               </Text>
-              <Button type="link" style={{ padding: 0 }} onClick={() => router.push('/assessments/create?type=vendor')}>
+              <Button type="link" style={{ padding: 0 }} onClick={() => router.push('/assessments')}>
                 Assess Risk →
               </Button>
             </Space>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
-import { Layout, Menu, Avatar, Typography, Dropdown, Space, Switch, Badge } from "antd";
+import { Layout, Menu, Avatar, Typography, Dropdown, Space, Switch, message } from "antd";
 import {
   HomeOutlined,
   CheckSquareOutlined,
@@ -15,20 +15,23 @@ import {
   BulbFilled,
   UserOutlined,
   LogoutOutlined,
-  BellOutlined,
   DatabaseOutlined,
   QuestionCircleOutlined
 } from "@ant-design/icons";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useTheme } from "@/theme";
 import { SearchBar } from "@/components/ui";
 import { getCurrentSubscription } from "@/lib/services/billingService";
+import { checkSession, logout } from "@/lib/auth";
 
 const { Header, Sider, Content } = Layout;
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const { mode, toggleMode } = useTheme();
+  const router = useRouter();
   const [enabledModules, setEnabledModules] = useState<string[] | null>(null);
+  const [user, setUser] = useState<{ first_name?: string; last_name?: string; email?: string } | null>(null);
 
   useEffect(() => {
     let mounted = true;
@@ -43,6 +46,30 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       mounted = false;
     };
   }, []);
+
+  useEffect(() => {
+    let mounted = true;
+    checkSession()
+      .then((session) => {
+        if (mounted) setUser(session);
+      })
+      .catch(() => {
+        if (mounted) setUser(null);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleSignOut = async () => {
+    try {
+      await logout();
+      router.replace("/login");
+      router.refresh();
+    } catch {
+      message.error("We could not end this session. Please try again.");
+    }
+  };
 
   const menuItems = useMemo(() => {
     const allItems = [
@@ -66,7 +93,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     {
       key: 'profile',
       icon: <UserOutlined />,
-      label: 'Profile Settings',
+      label: <Link href="/account/profile">Profile settings</Link>,
     },
     {
       key: 'theme',
@@ -94,15 +121,18 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       icon: <LogoutOutlined />,
       label: 'Sign Out',
       danger: true,
+      onClick: () => void handleSignOut(),
     },
   ];
 
-  const tenantMenuItems = [
-    { key: "tenant", label: "Switch Tenant", disabled: true },
-    { key: 'div2', type: 'divider' as const },
-    { key: "acme", label: "Acme Corp" },
-    { key: "demo", label: "Demo Company", disabled: true },
-  ];
+  const displayName = [user?.first_name, user?.last_name].filter(Boolean).join(" ") || user?.email || "Account";
+  const initials = displayName
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
 
   return (
     <Layout style={{ minHeight: "100vh" }}>
@@ -166,28 +196,6 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
           <div style={{ marginLeft: "auto" }}>
             <Space size={20}>
-              <Badge count={3}>
-                <BellOutlined style={{
-                  fontSize: 18,
-                  color: mode === 'dark' ? '#CBD5E1' : '#64748B',
-                  cursor: 'pointer'
-                }} />
-              </Badge>
-
-              <Dropdown
-                menu={{ items: tenantMenuItems }}
-                placement="bottomRight"
-                trigger={['click']}
-              >
-                <a style={{
-                  color: mode === 'dark' ? '#F8FAFC' : '#0F172A',
-                  fontWeight: 500,
-                  textDecoration: 'none'
-                }}>
-                  Acme Corp ▾
-                </a>
-              </Dropdown>
-
               <Dropdown
                 menu={{ items: userMenuItems }}
                 placement="bottomRight"
@@ -201,7 +209,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                   }}
                   size={36}
                 >
-                  AC
+                  {initials || <UserOutlined />}
                 </Avatar>
               </Dropdown>
             </Space>

--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -54,7 +54,8 @@ describe("auth helpers", () => {
     );
   });
 
-  it("clears the in-memory token on logout", async () => {
+  it("ends the tenant-scoped session on logout", async () => {
+    window.history.replaceState({}, "", "http://localhost:3000/login?tenant=demo");
     const fetchMock = vi.fn().mockResolvedValue({ ok: true });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -64,6 +65,10 @@ describe("auth helpers", () => {
       "/api/auth/logout/",
       expect.objectContaining({
         credentials: "include",
+        headers: {
+          "X-Tenancy-Mode": "header",
+          "X-Tenant-Id": "demo",
+        },
         method: "POST",
       }),
     );

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -44,7 +44,17 @@ export async function checkSession() {
 }
 
 export async function logout() {
-  await fetch(`${getApiBaseUrl()}/auth/logout/`, {
-    method: "POST", credentials: "include"
+  const tenant = getTenantFromHost();
+  const headers: Record<string, string> = {};
+  if (tenant) {
+    headers["X-Tenancy-Mode"] = "header";
+    headers["X-Tenant-Id"] = tenant;
+  }
+
+  const response = await fetch(`${getApiBaseUrl()}/auth/logout/`, {
+    method: "POST",
+    credentials: "include",
+    headers,
   });
+  if (!response.ok) throw new Error("Logout failed");
 }


### PR DESCRIPTION
## Summary\n- replace the simulated assessment entry point with the supported catalogue-import setup path\n- route risk and vendor assessment prompts away from the non-persisting wizard\n- make Profile settings and Sign out functional, including tenant-scoped session logout\n- add a browser regression test covering assessment setup, profile navigation and logout\n- add ADR-0042 to govern the evidence-led design workflow for #389 and #392\n\n## Scope\nThis is the first functional-integrity slice for #388. The remaining module placeholders and search work remain tracked in #388 and #389.\n\n## Verification\n- \n- \n-  — 13 passed\n-  — 8 passed\n- \n\nRelates to #388