### PR TITLE
fix: load policy acknowledgements from API

### DIFF
--- a/frontend/e2e/critical-grc-flows.smoke.spec.ts
+++ b/frontend/e2e/critical-grc-flows.smoke.spec.ts
@@ -14,8 +14,12 @@ test("users can acknowledge assigned policies", async ({ page }) => {
   await signIn(page);
 
   let acknowledgementRequestSent = false;
+  let pendingPoliciesRequestSent = false;
   page.on("request", (request) => {
     const url = new URL(request.url());
+    if (url.pathname === "/api/policies/policies/my_policies/" && request.method() === "GET") {
+      pendingPoliciesRequestSent = true;
+    }
     if (url.pathname === "/api/policies/policies/1/acknowledge/" && request.method() === "POST") {
       acknowledgementRequestSent = true;
     }
@@ -25,14 +29,34 @@ test("users can acknowledge assigned policies", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Policy Acknowledgments" })).toBeVisible();
   await expect(page.getByText("Information Security Policy")).toBeVisible();
-  await expect(page.getByText("2 policies require your acknowledgment")).toBeVisible();
+  await expect(page.getByText("1 policies require your acknowledgment")).toBeVisible();
+  await expect.poll(() => pendingPoliciesRequestSent).toBe(true);
 
   const policyCard = page.locator(".ant-card").filter({ hasText: "Information Security Policy" });
   await policyCard.getByRole("button", { name: "Acknowledge" }).click();
 
   await expect.poll(() => acknowledgementRequestSent).toBe(true);
   await expect(page.getByText("Information Security Policy")).toHaveCount(0);
-  await expect(page.getByText("1 policies require your acknowledgment")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "All caught up" })).toBeVisible();
+});
+
+test("policy acknowledgements show a retryable error when the API is unavailable", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+  await page.route("**/api/policies/policies/my_policies/", async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "Policy service unavailable." }),
+    });
+  });
+  await signIn(page);
+
+  await page.goto("/policies?tenant=demo");
+
+  await expect(page.getByRole("heading", { name: "Policies could not be loaded" })).toBeVisible();
+  await expect(page.getByText("Policy service unavailable.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+  await expect(page.getByText("Information Security Policy")).toHaveCount(0);
 });
 
 test("users can open a vendor profile from the vendor directory", async ({ page }) => {

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -126,6 +126,32 @@ const executiveDashboard = {
   recent_activities: [],
 };
 
+const pendingPolicies = [
+  {
+    distribution_id: "1",
+    policy: {
+      id: "1",
+      title: "Information Security Policy",
+      policy_code: "ISP-001",
+      category: "Security",
+      policy_type: "Mandatory",
+    },
+    version: {
+      id: "1",
+      version_number: "2.1",
+      effective_date: "2026-07-15",
+      summary: "Security requirements for workforce access and business operations.",
+      document: null,
+    },
+    distribution: {
+      distributed_at: "2026-07-10T10:00:00Z",
+      reminder_count: 1,
+      last_reminder_sent: "2026-08-01T10:00:00Z",
+      is_overdue: true,
+    },
+  },
+];
+
 async function fulfilJson(route: Route, body: unknown, status = 200) {
   await route.fulfill({
     status,
@@ -263,6 +289,11 @@ export async function mockAuthenticatedGrcApi(page: Page) {
         vendor_type_choices: [{ value: "service_provider", label: "Service Provider" }],
         risk_level_choices: [{ value: "high", label: "High" }],
       });
+      return;
+    }
+
+    if (path === "/api/policies/policies/my_policies/" && request.method() === "GET") {
+      await fulfilJson(route, { count: pendingPolicies.length, policies: pendingPolicies });
       return;
     }
 

--- a/frontend/src/app/policies/page.tsx
+++ b/frontend/src/app/policies/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Card, Row, Col, Typography, Button, message, Badge, Tag } from 'antd'
 import { FileTextOutlined, CheckCircleOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
 import { api, getErrorMessage } from '@/lib/api'
@@ -36,82 +36,28 @@ interface PolicyForAcknowledgment {
 export default function PoliciesPage() {
   const [policies, setPolicies] = useState<PolicyForAcknowledgment[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [acknowledging, setAcknowledging] = useState<string | null>(null)
   const { mode } = useTheme()
   const isDark = mode === 'dark'
 
-  useEffect(() => {
-    fetchMyPolicies()
-  }, [])
-
-  const fetchMyPolicies = async () => {
+  const fetchMyPolicies = useCallback(async () => {
     try {
       setLoading(true)
-
-      // Mock data for development
-      const mockPolicies = [
-        {
-          distribution_id: '1',
-          policy: {
-            id: '1',
-            title: 'Information Security Policy',
-            policy_code: 'ISP-001',
-            category: 'Security',
-            policy_type: 'Mandatory'
-          },
-          version: {
-            id: '1',
-            version_number: '2.1',
-            effective_date: '2024-01-15',
-            summary: 'Updated security policy with new remote work guidelines and multi-factor authentication requirements.',
-            document: null
-          },
-          distribution: {
-            distributed_at: '2024-08-15T10:00:00Z',
-            reminder_count: 1,
-            last_reminder_sent: '2024-08-22T10:00:00Z',
-            is_overdue: true
-          }
-        },
-        {
-          distribution_id: '2',
-          policy: {
-            id: '2',
-            title: 'Data Privacy & Protection Policy',
-            policy_code: 'DPP-001',
-            category: 'Privacy',
-            policy_type: 'Mandatory'
-          },
-          version: {
-            id: '2',
-            version_number: '1.3',
-            effective_date: '2024-03-01',
-            summary: 'Comprehensive data privacy policy aligned with GDPR and CCPA requirements.',
-            document: '/documents/privacy-policy-v1.3.pdf'
-          },
-          distribution: {
-            distributed_at: '2024-08-10T09:00:00Z',
-            reminder_count: 0,
-            last_reminder_sent: null,
-            is_overdue: false
-          }
-        }
-      ]
-
-      // Simulate API delay
-      await new Promise(resolve => setTimeout(resolve, 600))
-      setPolicies(mockPolicies)
-
-      // Uncomment when backend is ready:
-      // const response = await api.get('/policies/policies/my_policies/')
-      // setPolicies(response.data.policies || [])
-    } catch (error) {
-      console.error('Failed to fetch policies:', error)
-      message.error('Backend not available - showing demo data')
+      setLoadError(null)
+      const response = await api.get<{ policies?: PolicyForAcknowledgment[] }>('/policies/policies/my_policies/')
+      setPolicies(response.data.policies || [])
+    } catch (error: unknown) {
+      setPolicies([])
+      setLoadError(getErrorMessage(error))
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
+
+  useEffect(() => {
+    void fetchMyPolicies()
+  }, [fetchMyPolicies])
 
   const handleAcknowledge = async (policyId: string) => {
     try {
@@ -146,7 +92,7 @@ export default function PoliciesPage() {
   }
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+  return new Date(dateString).toLocaleDateString('en-GB', {
       year: 'numeric',
       month: 'long',
       day: 'numeric'
@@ -171,7 +117,14 @@ export default function PoliciesPage() {
         icon={<FileTextOutlined />}
       />
 
-      {policies.length === 0 ? (
+      {loadError ? (
+        <EmptyState
+          type="error"
+          title="Policies could not be loaded"
+          description={loadError}
+          action={{ text: "Try again", onClick: () => void fetchMyPolicies() }}
+        />
+      ) : policies.length === 0 ? (
         <EmptyState
           title="All caught up"
           description="You have no policies requiring acknowledgment. New assignments will appear here."


### PR DESCRIPTION
## Summary
- replace static policy acknowledgement data with the existing tenant-scoped `my_policies` API
- show truthful empty and retryable error states rather than demo policies
- retain the real acknowledgement action and use British-English date formatting
- add browser coverage for the API-backed path and service failure state

## Verification
- `npm run type-check`
- `npm run lint`
- `npm run test:unit` (13 passed)
- `npm run test:e2e` (9 passed)
- `pre-commit run --all-files`

Continues #388; the broader navigation and module integrity audit remains open.