### PR TITLE
fix: load training library from API

### DIFF
--- a/frontend/e2e/critical-grc-flows.smoke.spec.ts
+++ b/frontend/e2e/critical-grc-flows.smoke.spec.ts
@@ -59,6 +59,48 @@ test("policy acknowledgements show a retryable error when the API is unavailable
   await expect(page.getByText("Information Security Policy")).toHaveCount(0);
 });
 
+test("training library loads live content and routes to the selected video", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+  await signIn(page);
+
+  let videosRequestSent = false;
+  let categoriesRequestSent = false;
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    videosRequestSent ||= url.pathname === "/api/training/videos/" && request.method() === "GET";
+    categoriesRequestSent ||= url.pathname === "/api/training/categories/" && request.method() === "GET";
+  });
+
+  await page.goto("/training?tenant=demo");
+
+  await expect(page.getByRole("heading", { name: "Training library" })).toBeVisible();
+  await expect(page.getByText("Recognising phishing attempts")).toBeVisible();
+  await expect.poll(() => videosRequestSent && categoriesRequestSent).toBe(true);
+
+  await page.getByText("Recognising phishing attempts").click();
+  await expect(page).toHaveURL(/\/training\/video\/training-video-1/);
+  await expect(page.getByRole("heading", { name: "Recognising phishing attempts" })).toBeVisible();
+});
+
+test("training library shows a retryable error when the API is unavailable", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+  await page.route("**/api/training/videos/", async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "Training service unavailable." }),
+    });
+  });
+  await signIn(page);
+
+  await page.goto("/training?tenant=demo");
+
+  await expect(page.getByRole("heading", { name: "Training content could not be loaded" })).toBeVisible();
+  await expect(page.getByText("Training service unavailable.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+  await expect(page.getByText("Recognising phishing attempts")).toHaveCount(0);
+});
+
 test("users can open a vendor profile from the vendor directory", async ({ page }) => {
   await mockAuthenticatedGrcApi(page);
   await signIn(page);

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -152,6 +152,29 @@ const pendingPolicies = [
   },
 ];
 
+const trainingCategory = {
+  id: "training-category-1",
+  name: "Security Awareness",
+  description: "Practical training for everyone in the organisation.",
+  color: "#0F766E",
+  is_active: true,
+  videos_count: 1,
+};
+
+const trainingVideo = {
+  id: "training-video-1",
+  title: "Recognising phishing attempts",
+  description: "Identify suspicious messages and report them promptly.",
+  category_name: trainingCategory.name,
+  category_color: trainingCategory.color,
+  video_provider: "custom",
+  duration_minutes: 12,
+  difficulty_level: "beginner",
+  view_count: 24,
+  created_by_name: "Security team",
+  created_at: "2026-08-01T09:00:00Z",
+};
+
 async function fulfilJson(route: Route, body: unknown, status = 200) {
   await route.fulfill({
     status,
@@ -299,6 +322,27 @@ export async function mockAuthenticatedGrcApi(page: Page) {
 
     if (path === "/api/policies/policies/1/acknowledge/" && request.method() === "POST") {
       await fulfilJson(route, { status: "acknowledged" });
+      return;
+    }
+
+    if (path === "/api/training/videos/" && request.method() === "GET") {
+      await fulfilJson(route, { results: [trainingVideo], count: 1, next: null, previous: null });
+      return;
+    }
+
+    if (path === "/api/training/categories/" && request.method() === "GET") {
+      await fulfilJson(route, { results: [trainingCategory], count: 1, next: null, previous: null });
+      return;
+    }
+
+    if (path === "/api/training/videos/training-video-1/" && request.method() === "GET") {
+      await fulfilJson(route, {
+        ...trainingVideo,
+        category_details: trainingCategory,
+        video_url: "https://example.test/training/phishing",
+        embed_url: "https://example.test/training/phishing",
+        created_by_details: { name: "Security team", email: "security@example.test" },
+      });
       return;
     }
 

--- a/frontend/src/app/training/page.tsx
+++ b/frontend/src/app/training/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
-import { Card, Row, Col, Typography, Button, Select, Input, Tag, message } from 'antd'
+import React, { useCallback, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Card, Row, Col, Typography, Button, Select, Input, Tag } from 'antd'
 import { PlayCircleOutlined, SearchOutlined, ClockCircleOutlined, UserOutlined } from '@ant-design/icons'
-import { api } from '@/lib/api'
+import { api, getErrorMessage } from '@/lib/api'
 import { EmptyState, Loading, PageHeader } from '@/components/ui'
 
 const { Text, Paragraph } = Typography
@@ -34,151 +35,42 @@ interface TrainingVideo {
 }
 
 export default function TrainingPage() {
+  const router = useRouter()
   const [videos, setVideos] = useState<TrainingVideo[]>([])
   const [categories, setCategories] = useState<TrainingCategory[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
   const [selectedCategory, setSelectedCategory] = useState<string>('')
   const [selectedDifficulty, setSelectedDifficulty] = useState<string>('')
 
-  useEffect(() => {
-    fetchData()
-  }, [])
-
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     try {
       setLoading(true)
-
-      // Mock data for development
-      const mockCategories = [
-        {
-          id: '1',
-          name: 'Security Awareness',
-          description: 'General security awareness training',
-          color: '#f5222d',
-          videos_count: 12
-        },
-        {
-          id: '2',
-          name: 'Phishing Prevention',
-          description: 'How to identify and avoid phishing attacks',
-          color: '#fa8c16',
-          videos_count: 8
-        },
-        {
-          id: '3',
-          name: 'Data Protection',
-          description: 'Data handling and privacy best practices',
-          color: '#1890ff',
-          videos_count: 15
-        },
-        {
-          id: '4',
-          name: 'Incident Response',
-          description: 'How to respond to security incidents',
-          color: '#722ed1',
-          videos_count: 10
-        }
-      ]
-
-      const mockVideos = [
-        {
-          id: '1',
-          title: 'Introduction to Cybersecurity',
-          description: 'Learn the fundamentals of cybersecurity and why it matters for every employee.',
-          category_name: 'Security Awareness',
-          category_color: '#f5222d',
-          video_provider: 'internal',
-          duration_minutes: 15,
-          difficulty_level: 'beginner',
-          view_count: 234,
-          created_by_name: 'Security Team',
-          created_at: '2024-08-01T10:00:00Z'
-        },
-        {
-          id: '2',
-          title: 'Spotting Phishing Emails',
-          description: 'Learn to identify common phishing techniques and protect yourself from email-based attacks.',
-          category_name: 'Phishing Prevention',
-          category_color: '#fa8c16',
-          video_provider: 'internal',
-          duration_minutes: 22,
-          difficulty_level: 'intermediate',
-          view_count: 189,
-          created_by_name: 'Training Team',
-          created_at: '2024-07-28T14:30:00Z'
-        },
-        {
-          id: '3',
-          title: 'Password Security Best Practices',
-          description: 'Create strong passwords and use multi-factor authentication to secure your accounts.',
-          category_name: 'Security Awareness',
-          category_color: '#f5222d',
-          video_provider: 'internal',
-          duration_minutes: 18,
-          difficulty_level: 'beginner',
-          view_count: 312,
-          created_by_name: 'Security Team',
-          created_at: '2024-07-25T09:15:00Z'
-        },
-        {
-          id: '4',
-          title: 'Data Classification Guidelines',
-          description: 'Understand how to properly classify and handle sensitive organizational data.',
-          category_name: 'Data Protection',
-          category_color: '#1890ff',
-          video_provider: 'internal',
-          duration_minutes: 28,
-          difficulty_level: 'intermediate',
-          view_count: 156,
-          created_by_name: 'Compliance Team',
-          created_at: '2024-07-20T11:45:00Z'
-        }
-      ]
-
-      // Simulate API delay
-      await new Promise(resolve => setTimeout(resolve, 700))
-
-      // Try to fetch from API first, fallback to mock data
-      try {
-        const [videosResponse, categoriesResponse] = await Promise.all([
-          api.get('/training/videos/'),
-          api.get('/training/categories/')
-        ])
-
-        setVideos(videosResponse.data.results || videosResponse.data)
-        setCategories(categoriesResponse.data.results || categoriesResponse.data)
-      } catch (apiError) {
-        console.log('API not available, using mock data:', apiError)
-        setVideos(mockVideos)
-        setCategories(mockCategories)
-      }
-    } catch (error) {
-      console.error('Failed to fetch training data:', error)
-      message.error('Backend not available - showing demo data')
+      setLoadError(null)
+      const [videosResponse, categoriesResponse] = await Promise.all([
+        api.get<{ results?: TrainingVideo[] } | TrainingVideo[]>('/training/videos/'),
+        api.get<{ results?: TrainingCategory[] } | TrainingCategory[]>('/training/categories/')
+      ])
+      const videoData = videosResponse.data
+      const categoryData = categoriesResponse.data
+      setVideos(Array.isArray(videoData) ? videoData : videoData.results || [])
+      setCategories(Array.isArray(categoryData) ? categoryData : categoryData.results || [])
+    } catch (error: unknown) {
+      setVideos([])
+      setCategories([])
+      setLoadError(getErrorMessage(error))
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
+
+  useEffect(() => {
+    void fetchData()
+  }, [fetchData])
 
   const handleVideoClick = (video: TrainingVideo) => {
-    // Track video view
-    trackVideoView(video.id)
-
-    // Navigate to video player page
-    window.location.href = `/training/video/${video.id}`
-  }
-
-  const trackVideoView = async (videoId: string) => {
-    try {
-      await api.post(`/training/videos/${videoId}/track_view/`, {
-        duration_watched: 0,
-        completed: false,
-        completion_percentage: 0
-      })
-    } catch (error) {
-      console.error('Failed to track video view:', error)
-    }
+    router.push(`/training/video/${video.id}`)
   }
 
   const filteredVideos = videos.filter(video => {
@@ -223,6 +115,15 @@ export default function TrainingPage() {
         icon={<PlayCircleOutlined />}
       />
 
+      {loadError ? (
+        <EmptyState
+          type="error"
+          title="Training content could not be loaded"
+          description={loadError}
+          action={{ text: 'Try again', onClick: () => void fetchData() }}
+        />
+      ) : (
+        <>
       {/* Category Overview */}
       {categories.length > 0 && (
         <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
@@ -384,6 +285,8 @@ export default function TrainingPage() {
             </Col>
           ))}
         </Row>
+      )}
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- remove simulated training categories and videos from the training library
- load published training content from the existing authenticated API endpoints
- show a truthful, retryable error state when the service is unavailable
- route to the video player without recording a duplicate viewing event
- add browser coverage for loading, navigation, and API failure

## Verification
- `npm run type-check`
- `npm run lint`
- `npm run test:unit` (13 passed)
- `npm run test:e2e` (11 passed)
- `pre-commit run --all-files`

Continues #388; the broader module-navigation and mock-workflow audit remains open.