### PR TITLE
feat: add tenant global search

### DIFF
--- a/app/core/serializers.py
+++ b/app/core/serializers.py
@@ -6,6 +6,21 @@ from rest_framework import serializers
 from .models import AuditEvent, Document, DocumentAccess, Tenant, User
 
 
+class GlobalSearchResultSerializer(serializers.Serializer):
+    """A compact, canonical result returned by the tenant global search."""
+
+    id = serializers.CharField()
+    entity_type = serializers.ChoiceField(choices=["risk", "vendor", "training"])
+    title = serializers.CharField()
+    context = serializers.CharField(allow_blank=True)
+    href = serializers.CharField()
+
+
+class GlobalSearchResponseSerializer(serializers.Serializer):
+    query = serializers.CharField()
+    results = GlobalSearchResultSerializer(many=True)
+
+
 class DocumentSerializer(serializers.ModelSerializer):
     """
     Serializer for document uploads with file validation and metadata.

--- a/app/core/test_global_search.py
+++ b/app/core/test_global_search.py
@@ -1,0 +1,119 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django_tenants.utils import schema_context, tenant_context
+from rest_framework import status
+
+from core.models import Plan, Subscription
+from risk.models import Risk, RiskCategory
+from training.models import TrainingCategory, TrainingVideo
+from vendors.models import Vendor
+
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestGlobalSearchAPI:
+    def test_returns_only_current_tenant_published_records(
+        self, api_client, test_tenant, test_user
+    ):
+        with tenant_context(test_tenant):
+            category = RiskCategory.objects.create(name="Search category")
+            risk = Risk.objects.create(
+                risk_id="RISK-NEEDLE",
+                title="Needle risk",
+                description="A searchable risk.",
+                category=category,
+                impact=3,
+                likelihood=3,
+                created_by=test_user,
+            )
+            vendor = Vendor.objects.create(name="Needle vendor", created_by=test_user)
+            training_category = TrainingCategory.objects.create(name="Search training")
+            video = TrainingVideo.objects.create(
+                title="Needle training",
+                description="A searchable training video.",
+                category=training_category,
+                video_url="https://example.test/needle",
+                created_by=test_user,
+                is_published=True,
+            )
+            TrainingVideo.objects.create(
+                title="Hidden needle training",
+                description="This must not be searchable.",
+                category=training_category,
+                video_url="https://example.test/hidden",
+                created_by=test_user,
+                is_published=False,
+            )
+
+        api_client.defaults["HTTP_HOST"] = f"{test_tenant.schema_name}.localhost"
+        api_client.force_authenticate(user=test_user)
+
+        response = api_client.get("/api/search/", {"q": "needle"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["query"] == "needle"
+        assert response.data["results"] == [
+            {
+                "id": str(risk.id),
+                "entity_type": "risk",
+                "title": "Needle risk",
+                "context": "RISK-NEEDLE",
+                "href": f"/risk/{risk.id}",
+            },
+            {
+                "id": str(vendor.id),
+                "entity_type": "vendor",
+                "title": "Needle vendor",
+                "context": vendor.vendor_id,
+                "href": f"/vendors/{vendor.id}",
+            },
+            {
+                "id": str(video.id),
+                "entity_type": "training",
+                "title": "Needle training",
+                "context": "Search training",
+                "href": f"/training/video/{video.id}",
+            },
+        ]
+
+    def test_respects_subscription_module_entitlements(self, api_client, test_tenant, test_user):
+        with schema_context("public"):
+            plan = Plan.objects.create(
+                name="Risk only",
+                slug="risk-only",
+                price_monthly=10,
+                included_modules=["risk"],
+            )
+            Subscription.objects.create(tenant=test_tenant, plan=plan, status="active")
+
+        with tenant_context(test_tenant):
+            category = RiskCategory.objects.create(name="Entitlement category")
+            Risk.objects.create(
+                risk_id="RISK-ACCESS",
+                title="Access needle risk",
+                description="A searchable risk.",
+                category=category,
+                impact=2,
+                likelihood=2,
+                created_by=test_user,
+            )
+            Vendor.objects.create(name="Access needle vendor", created_by=test_user)
+
+        api_client.defaults["HTTP_HOST"] = f"{test_tenant.schema_name}.localhost"
+        api_client.force_authenticate(user=test_user)
+
+        response = api_client.get("/api/search/", {"q": "needle"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [result["entity_type"] for result in response.data["results"]] == ["risk"]
+
+    @pytest.mark.parametrize("query", ["", "n", "x" * 101])
+    def test_rejects_invalid_query_lengths(self, api_client, test_tenant, test_user, query):
+        api_client.defaults["HTTP_HOST"] = f"{test_tenant.schema_name}.localhost"
+        api_client.force_authenticate(user=test_user)
+
+        response = api_client.get("/api/search/", {"q": query})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/app/core/urls.py
+++ b/app/core/urls.py
@@ -11,6 +11,7 @@ from .views import (
     TenantEmailVerificationConfirmView,
     TenantEmailVerificationRequestView,
     TenantTaxProfileView,
+    GlobalSearchView,
 )
 from .health import (
     HealthCheckView,
@@ -30,6 +31,7 @@ router.register("audit-events", AuditEventViewSet, basename="audit-events")
 urlpatterns = [
     # API endpoints
     path("api/", include(router.urls)),
+    path("api/search/", GlobalSearchView.as_view(), name="global-search"),
     path(
         "api/tenant-email-settings/",
         TenantEmailSettingsView.as_view(),

--- a/app/core/views.py
+++ b/app/core/views.py
@@ -4,6 +4,7 @@ Views for document management and storage testing.
 
 from django.conf import settings
 from django.db import transaction
+from django.db.models import Q
 from rest_framework import filters, viewsets, status, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -33,7 +34,12 @@ from .serializers import (
     SenderVerificationConfirmSerializer,
     SenderVerificationResponseSerializer,
     TenantTaxProfileSerializer,
+    GlobalSearchResultSerializer,
+    GlobalSearchResponseSerializer,
 )
+from risk.models import Risk
+from training.models import TrainingVideo
+from vendors.models import Vendor
 from billing.decorators import check_document_limits
 from billing.services import PlanEnforcementService
 from drf_spectacular.utils import (
@@ -45,6 +51,122 @@ from drf_spectacular.utils import (
 )
 from drf_spectacular.types import OpenApiTypes
 from rest_framework.views import APIView
+
+
+class GlobalSearchView(APIView):
+    """Search records in the current tenant that have a canonical product route."""
+
+    permission_classes = [permissions.IsAuthenticated]
+    minimum_query_length = 2
+    maximum_query_length = 100
+    maximum_results = 12
+    results_per_entity = 4
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="q",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="Search text; at least two characters.",
+            ),
+        ],
+        responses=GlobalSearchResponseSerializer,
+        tags=["Search"],
+    )
+    def get(self, request):
+        query = request.query_params.get("q", "").strip()
+        if len(query) < self.minimum_query_length:
+            return Response(
+                {"detail": "Enter at least two characters to search."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if len(query) > self.maximum_query_length:
+            return Response(
+                {"detail": "Search text must be 100 characters or fewer."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        enabled_modules = self._enabled_modules(request)
+        results = [
+            *(self._risk_results(query) if "risk" in enabled_modules else []),
+            *(self._vendor_results(query) if "vendors" in enabled_modules else []),
+            *(self._training_results(query) if "training" in enabled_modules else []),
+        ][: self.maximum_results]
+        serializer = GlobalSearchResultSerializer(results, many=True)
+        return Response({"query": query, "results": serializer.data})
+
+    @staticmethod
+    def _enabled_modules(request):
+        subscription = PlanEnforcementService.get_tenant_subscription(request.tenant)
+        # Match the plan middleware: legacy tenants without subscription setup
+        # retain access to their tenant data.
+        if subscription is None:
+            return {"risk", "vendors", "training"}
+        return set(subscription.get_enabled_modules())
+
+    def _risk_results(self, query):
+        risks = (
+            Risk.objects.filter(
+                Q(risk_id__icontains=query)
+                | Q(title__icontains=query)
+                | Q(description__icontains=query)
+            )
+            .only("id", "risk_id", "title")
+            .order_by("title")[: self.results_per_entity]
+        )
+        return [
+            {
+                "id": str(risk.id),
+                "entity_type": "risk",
+                "title": risk.title,
+                "context": risk.risk_id,
+                "href": f"/risk/{risk.id}",
+            }
+            for risk in risks
+        ]
+
+    def _vendor_results(self, query):
+        vendors = (
+            Vendor.objects.filter(
+                Q(vendor_id__icontains=query)
+                | Q(name__icontains=query)
+                | Q(legal_name__icontains=query)
+                | Q(business_description__icontains=query)
+            )
+            .only("id", "vendor_id", "name")
+            .order_by("name")[: self.results_per_entity]
+        )
+        return [
+            {
+                "id": str(vendor.id),
+                "entity_type": "vendor",
+                "title": vendor.name,
+                "context": vendor.vendor_id,
+                "href": f"/vendors/{vendor.id}",
+            }
+            for vendor in vendors
+        ]
+
+    def _training_results(self, query):
+        videos = (
+            TrainingVideo.objects.filter(is_published=True)
+            .filter(Q(title__icontains=query) | Q(description__icontains=query))
+            .select_related("category")
+            .only("id", "title", "category__name")
+            .order_by("title")[: self.results_per_entity]
+        )
+        return [
+            {
+                "id": str(video.id),
+                "entity_type": "training",
+                "title": video.title,
+                "context": video.category.name,
+                "href": f"/training/video/{video.id}",
+            }
+            for video in videos
+        ]
 
 
 class TenantEmailSettingsView(APIView):

--- a/app/schema.yml
+++ b/app/schema.yml
@@ -13827,6 +13827,30 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuditEvent'
           description: ''
+  /api/search/:
+    get:
+      operationId: search_retrieve
+      description: Search records in the current tenant that have a canonical product
+        route.
+      parameters:
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: Search text; at least two characters.
+        required: true
+      tags:
+      - Search
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalSearchResponse'
+          description: ''
   /api/tenant-email-settings/:
     get:
       operationId: tenant_email_settings_retrieve
@@ -17233,6 +17257,16 @@ components:
       required:
       - method
       - password
+    EntityTypeEnum:
+      enum:
+      - risk
+      - vendor
+      - training
+      type: string
+      description: |-
+        * `risk` - risk
+        * `vendor` - vendor
+        * `training` - training
     EventTypeEnum:
       enum:
       - deadline
@@ -17604,6 +17638,38 @@ components:
         * `daily` - Daily
         * `weekly` - Weekly
         * `monthly` - Monthly
+    GlobalSearchResponse:
+      type: object
+      properties:
+        query:
+          type: string
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/GlobalSearchResult'
+      required:
+      - query
+      - results
+    GlobalSearchResult:
+      type: object
+      description: A compact, canonical result returned by the tenant global search.
+      properties:
+        id:
+          type: string
+        entity_type:
+          $ref: '#/components/schemas/EntityTypeEnum'
+        title:
+          type: string
+        context:
+          type: string
+        href:
+          type: string
+      required:
+      - context
+      - entity_type
+      - href
+      - id
+      - title
     GovernanceArtefact:
       type: object
       properties:

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -224,6 +224,22 @@ export async function mockAuthenticatedGrcApi(page: Page) {
       return;
     }
 
+    if (path === "/api/search/" && request.method() === "GET") {
+      await fulfilJson(route, {
+        query: url.searchParams.get("q") || "",
+        results: [
+          {
+            id: String(risk.id),
+            entity_type: "risk",
+            title: risk.title,
+            context: risk.risk_id,
+            href: `/risk/${risk.id}`,
+          },
+        ],
+      });
+      return;
+    }
+
     if (path === "/api/billing/current_subscription/" && request.method() === "GET") {
       await fulfilJson(route, {
         enabled_module_keys: [

--- a/frontend/e2e/navigation-integrity.smoke.spec.ts
+++ b/frontend/e2e/navigation-integrity.smoke.spec.ts
@@ -1,6 +1,14 @@
 import { expect, test } from "@playwright/test";
 import { mockAuthenticatedGrcApi } from "./helpers/api";
 
+async function signIn(page: import("@playwright/test").Page) {
+  await page.goto("/login?tenant=demo");
+  await page.getByLabel("Email").fill("user@example.com");
+  await page.getByLabel("Password").fill("E2ePassw0rd!");
+  await page.getByRole("button", { name: "Login" }).click();
+  await expect(page).toHaveURL(/\/$/);
+}
+
 test("assessment setup and account menu expose only working actions", async ({ page }) => {
   await mockAuthenticatedGrcApi(page);
 
@@ -25,4 +33,43 @@ test("assessment setup and account menu expose only working actions", async ({ p
   await page.getByText("TU", { exact: true }).click();
   await page.getByRole("menuitem", { name: "Sign Out" }).click();
   await expect(page).toHaveURL(/\/login$/);
+});
+
+test("global search uses tenant data and opens the selected record", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+  await signIn(page);
+
+  let searchRequestSent = false;
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/api/search/" && url.searchParams.get("q") === "supplier") {
+      searchRequestSent = true;
+    }
+  });
+
+  const search = page.getByRole("combobox", { name: "Global search" });
+  await search.fill("supplier");
+
+  await expect(page.getByText("Supplier access review overdue")).toBeVisible();
+  await expect.poll(() => searchRequestSent).toBe(true);
+  await page.locator(".ant-select-dropdown").getByText("Supplier access review overdue", { exact: true }).click();
+
+  await expect(page).toHaveURL(/\/risk\/1/);
+  await expect(page.getByText("Supplier access review overdue")).toBeVisible();
+});
+
+test("global search makes an unavailable service explicit", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+  await page.route("**/api/search/**", async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "Search service unavailable." }),
+    });
+  });
+  await signIn(page);
+
+  await page.getByRole("combobox", { name: "Global search" }).fill("supplier");
+
+  await expect(page.getByText("Search is unavailable: Search service unavailable.")).toBeVisible();
 });

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -189,7 +189,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             : '0 2px 8px rgba(0,0,0,0.06)'
         }}>
           <SearchBar
-            placeholder="Search controls, vendors, risks, policies..."
+            placeholder="Search risks, vendors and training..."
             style={{ maxWidth: 440 }}
             size="large"
           />

--- a/frontend/src/components/ui/SearchBar.tsx
+++ b/frontend/src/components/ui/SearchBar.tsx
@@ -1,17 +1,38 @@
 'use client'
 
-import React, { useState } from 'react'
-import { Input, AutoComplete, Space, Tag, Typography } from 'antd'
-import { SearchOutlined, FileTextOutlined, TeamOutlined, SafetyOutlined, CheckSquareOutlined, VideoCameraOutlined } from '@ant-design/icons'
+import React, { useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { AutoComplete, Input, Space, Tag, Typography } from 'antd'
+import {
+  SafetyOutlined,
+  SearchOutlined,
+  TeamOutlined,
+  VideoCameraOutlined,
+} from '@ant-design/icons'
+import { api, getErrorMessage } from '@/lib/api'
 import { useTheme } from '@/theme'
 
 const { Text } = Typography
 
+type SearchEntityType = 'risk' | 'vendor' | 'training'
+
+interface SearchResult {
+  id: string
+  entity_type: SearchEntityType
+  title: string
+  context: string
+  href: string
+}
+
+interface SearchResponse {
+  query: string
+  results: SearchResult[]
+}
+
 interface SearchOption {
   value: string
   label: React.ReactNode
-  category: string
-  href: string
+  result: SearchResult
 }
 
 interface SearchBarProps {
@@ -21,149 +42,125 @@ interface SearchBarProps {
   size?: 'small' | 'middle' | 'large'
 }
 
+const labels: Record<SearchEntityType, string> = {
+  risk: 'Risk',
+  vendor: 'Vendor',
+  training: 'Training',
+}
+
+const icons: Record<SearchEntityType, React.ReactNode> = {
+  risk: <SafetyOutlined />,
+  vendor: <TeamOutlined />,
+  training: <VideoCameraOutlined />,
+}
+
+const colours: Record<SearchEntityType, string> = {
+  risk: '#E5484D',
+  vendor: '#2F6FED',
+  training: '#0F766E',
+}
+
 export const SearchBar: React.FC<SearchBarProps> = ({
-  placeholder = "Search controls, vendors, risks, policies...",
+  placeholder = 'Search risks, vendors and training...',
   onSelect,
   style,
-  size = 'large'
+  size = 'large',
 }) => {
+  const router = useRouter()
   const { mode } = useTheme()
   const isDark = mode === 'dark'
   const [searchValue, setSearchValue] = useState('')
-  const [options, setOptions] = useState<SearchOption[]>([])
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
-  // Mock search data - replace with real API calls
-  const mockSearchData: SearchOption[] = [
-    // Policies
-    { value: 'Information Security Policy', label: 'Information Security Policy', category: 'Policies', href: '/policies' },
-    { value: 'Data Privacy Policy', label: 'Data Privacy Policy', category: 'Policies', href: '/policies' },
-    { value: 'Access Control Policy', label: 'Access Control Policy', category: 'Policies', href: '/policies' },
-
-    // Vendors
-    { value: 'Microsoft Corporation', label: 'Microsoft Corporation', category: 'Vendors', href: '/vendors' },
-    { value: 'Amazon Web Services', label: 'Amazon Web Services', category: 'Vendors', href: '/vendors' },
-    { value: 'Salesforce Inc', label: 'Salesforce Inc', category: 'Vendors', href: '/vendors' },
-
-    // Risks
-    { value: 'Data Breach Risk', label: 'Data Breach Risk', category: 'Risks', href: '/risk' },
-    { value: 'Third Party Risk', label: 'Third Party Risk', category: 'Risks', href: '/risk' },
-    { value: 'Compliance Risk', label: 'Compliance Risk', category: 'Risks', href: '/risk' },
-
-    // Controls/Assessments
-    { value: 'Access Management', label: 'Access Management', category: 'Controls', href: '/assessments' },
-    { value: 'Incident Response', label: 'Incident Response', category: 'Controls', href: '/assessments' },
-    { value: 'Data Classification', label: 'Data Classification', category: 'Controls', href: '/assessments' },
-
-    // Training
-    { value: 'Phishing Awareness', label: 'Phishing Awareness', category: 'Training', href: '/training' },
-    { value: 'Security Fundamentals', label: 'Security Fundamentals', category: 'Training', href: '/training' },
-  ]
-
-  const getCategoryIcon = (category: string) => {
-    switch (category) {
-      case 'Policies': return <FileTextOutlined />
-      case 'Vendors': return <TeamOutlined />
-      case 'Risks': return <SafetyOutlined />
-      case 'Controls': return <CheckSquareOutlined />
-      case 'Training': return <VideoCameraOutlined />
-      default: return <SearchOutlined />
-    }
-  }
-
-  const getCategoryColor = (category: string) => {
-    switch (category) {
-      case 'Policies': return '#FFB020'
-      case 'Vendors': return '#3B82F6'
-      case 'Risks': return '#E5484D'
-      case 'Controls': return '#0EB57D'
-      case 'Training': return '#722ED1'
-      default: return '#2F6FED'
-    }
-  }
-
-  const handleSearch = (value: string) => {
-    setSearchValue(value)
-
-    if (!value.trim()) {
-      setOptions([])
+  useEffect(() => {
+    const query = searchValue.trim()
+    if (query.length < 2) {
+      setResults([])
+      setError(null)
+      setLoading(false)
       return
     }
 
-    // Filter options based on search value
-    const filteredOptions = mockSearchData
-      .filter(item =>
-        item.value.toLowerCase().includes(value.toLowerCase())
-      )
-      .slice(0, 10) // Limit to 10 results
-      .map(item => ({
-        ...item,
-        label: (
-          <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '4px 0'
-          }}>
-            <Space>
-              {getCategoryIcon(item.category)}
-              <Text style={{ color: isDark ? '#F8FAFC' : '#0F172A' }}>
-                {item.value}
-              </Text>
-            </Space>
-            <Tag
-              color={getCategoryColor(item.category)}
-              style={{
-                fontSize: '11px',
-                margin: 0,
-                borderRadius: 4
-              }}
-            >
-              {item.category}
-            </Tag>
-          </div>
-        )
-      }))
+    const controller = new AbortController()
+    const timeout = window.setTimeout(async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const response = await api.get<SearchResponse>('/search/', {
+          params: { q: query },
+          signal: controller.signal,
+        })
+        setResults(response.data.results)
+      } catch (requestError: unknown) {
+        if (!controller.signal.aborted) {
+          setResults([])
+          setError(getErrorMessage(requestError))
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    }, 250)
 
-    setOptions(filteredOptions)
-  }
+    return () => {
+      controller.abort()
+      window.clearTimeout(timeout)
+    }
+  }, [searchValue])
+
+  const options = useMemo<SearchOption[]>(() => results.map((result) => ({
+    value: `${result.entity_type}:${result.id}`,
+    result,
+    label: (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, padding: '4px 0' }}>
+        <Space size={8}>
+          {icons[result.entity_type]}
+          <span>
+            <Text style={{ color: isDark ? '#F8FAFC' : '#0F172A' }}>{result.title}</Text>
+            {result.context && (
+              <Text type="secondary" style={{ display: 'block', fontSize: 12 }}>{result.context}</Text>
+            )}
+          </span>
+        </Space>
+        <Tag color={colours[result.entity_type]} style={{ margin: 0 }}>{labels[result.entity_type]}</Tag>
+      </div>
+    ),
+  })), [isDark, results])
 
   const handleSelect = (value: string) => {
-    const selectedOption = mockSearchData.find(item => item.value === value)
-    if (selectedOption) {
-      // Navigate to the selected item's page
-      window.location.href = selectedOption.href
-      if (onSelect) {
-        onSelect(value, selectedOption)
-      }
-    }
+    const option = options.find((candidate) => candidate.value === value)
+    if (!option) return
+
+    router.push(option.result.href)
+    onSelect?.(value, option)
     setSearchValue('')
-    setOptions([])
+    setResults([])
   }
+
+  const query = searchValue.trim()
+  const notFoundContent = query.length < 2
+    ? 'Enter at least two characters'
+    : loading
+      ? 'Searching your organisation...'
+      : error
+        ? `Search is unavailable: ${error}`
+        : 'No matching records'
 
   return (
     <AutoComplete
       value={searchValue}
       options={options}
-      onSearch={handleSearch}
+      onSearch={setSearchValue}
       onSelect={handleSelect}
-      style={{
-        width: '100%',
-        maxWidth: 440,
-        ...style
-      }}
+      notFoundContent={notFoundContent}
+      style={{ width: '100%', maxWidth: 440, ...style }}
     >
-      <Input.Search
+      <Input
         placeholder={placeholder}
         size={size}
-        style={{
-          borderRadius: 8,
-        }}
-        suffix={
-          <SearchOutlined style={{
-            color: isDark ? '#64748B' : '#94A3B8',
-            fontSize: 16
-          }} />
-        }
+        aria-label="Global search"
+        suffix={<SearchOutlined style={{ color: isDark ? '#64748B' : '#94A3B8', fontSize: 16 }} />}
       />
     </AutoComplete>
   )

--- a/frontend/src/lib/api/generated/schema.d.ts
+++ b/frontend/src/lib/api/generated/schema.d.ts
@@ -5181,6 +5181,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/search/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Search records in the current tenant that have a canonical product route. */
+        get: operations["search_retrieve"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/tenant-email-settings/": {
         parameters: {
             query?: never;
@@ -6905,6 +6922,13 @@ export interface components {
             push_service?: components["schemas"]["PushServiceEnum"];
         };
         /**
+         * @description * `risk` - risk
+         *     * `vendor` - vendor
+         *     * `training` - training
+         * @enum {string}
+         */
+        EntityTypeEnum: "risk" | "vendor" | "training";
+        /**
          * @description * `deadline` - Deadline
          *     * `review` - Review
          *     * `meeting` - Meeting
@@ -7087,6 +7111,18 @@ export interface components {
          * @enum {string}
          */
         FrequencyEnum: "manual" | "daily" | "weekly" | "monthly";
+        GlobalSearchResponse: {
+            query: string;
+            results: components["schemas"]["GlobalSearchResult"][];
+        };
+        /** @description A compact, canonical result returned by the tenant global search. */
+        GlobalSearchResult: {
+            id: string;
+            entity_type: components["schemas"]["EntityTypeEnum"];
+            title: string;
+            context: string;
+            href: string;
+        };
         GovernanceArtefact: {
             readonly id: number;
             readonly artefact_id: string;
@@ -22794,6 +22830,28 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AuditEvent"];
+                };
+            };
+        };
+    };
+    search_retrieve: {
+        parameters: {
+            query: {
+                /** @description Search text; at least two characters. */
+                q: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GlobalSearchResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary
- replace hard-coded global-search results with a debounced, cancellable tenant API request
- add `GET /api/search/?q=` for authorised risk, vendor and published training records with canonical product routes
- enforce active subscription module grants so disabled-module records are not discoverable
- provide loading, empty, and service-unavailable feedback and preserve client-side navigation
- regenerate the OpenAPI schema and TypeScript declarations

## Scope note
Policies are intentionally excluded because the product has no policy repository/detail route. That dependency is tracked in #402.

## Verification
- `ruff check` and `ruff format --check` on the changed backend files
- targeted Django search tests with `pytest app/core/test_global_search.py -q --reuse-db`
- exact OpenAPI schema-freshness script: 0 warnings, 0 errors
- `npm run verify:api-types`
- `npm run type-check`, `npm run lint`, `npm run test:unit` (13 passed)
- `npm run test:e2e` (13 passed)
- `pre-commit run --all-files`

Closes #389.