### PR TITLE
fix: remove fabricated vendor fallback data

### DIFF
--- a/app/schema.yml
+++ b/app/schema.yml
@@ -10373,6 +10373,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/VendorDetail'
           description: ''
+  /api/vendors/vendors/choices/:
+    get:
+      operationId: vendors_vendors_choices_retrieve
+      description: Retrieve the current vendor status, type, and risk-level choices.
+      summary: Get vendor field choices
+      tags:
+      - Vendors
+      security:
+      - cookieAuth: []
+      - SessionAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
   /api/vendors/vendors/contract_renewals/:
     get:
       operationId: vendors_vendors_contract_renewals_retrieve

--- a/app/vendors/test_api_routes.py
+++ b/app/vendors/test_api_routes.py
@@ -5,4 +5,5 @@ from vendors.views import VendorViewSet
 
 def test_vendor_api_routes_are_mounted():
     assert reverse("vendor-list") == "/api/vendors/vendors/"
+    assert reverse("vendor-choices") == "/api/vendors/vendors/choices/"
     assert resolve("/api/vendors/vendors/").func.cls is VendorViewSet

--- a/app/vendors/test_vendor_simple.py
+++ b/app/vendors/test_vendor_simple.py
@@ -251,10 +251,25 @@ def test_vendor_api_structure():
     assert "add_note" in vendor_actions
     assert "bulk_create" in vendor_actions
     assert "summary" in vendor_actions
+    assert "choices" in vendor_actions
     assert "by_category" in vendor_actions
     assert "contract_renewals" in vendor_actions
 
     print("✓ Vendor API structure tests passed")
+
+
+def test_vendor_choices_are_owned_by_the_model():
+    """The vendor choices endpoint must not depend on client-side fallback data."""
+    from vendors.views import VendorViewSet
+
+    response = VendorViewSet().choices(None)
+
+    assert {"value": "active", "label": "Active"} in response.data["status_choices"]
+    assert {
+        "value": "service_provider",
+        "label": "Service Provider",
+    } in response.data["vendor_type_choices"]
+    assert {"value": "high", "label": "High"} in response.data["risk_level_choices"]
 
 
 def test_filter_structure():

--- a/app/vendors/views.py
+++ b/app/vendors/views.py
@@ -448,6 +448,27 @@ class VendorViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
     @extend_schema(
+        summary="Get vendor field choices",
+        description="Retrieve the current vendor status, type, and risk-level choices.",
+        responses={200: OpenApiTypes.OBJECT},
+        tags=["Vendors"],
+    )
+    @action(detail=False, methods=["get"])
+    def choices(self, request):
+        """Return model-owned choices used by vendor filters and forms."""
+
+        def serialize_choices(choice_set):
+            return [{"value": value, "label": label} for value, label in choice_set]
+
+        return Response(
+            {
+                "status_choices": serialize_choices(Vendor.STATUS_CHOICES),
+                "vendor_type_choices": serialize_choices(Vendor.VENDOR_TYPE_CHOICES),
+                "risk_level_choices": serialize_choices(Vendor.RISK_LEVEL_CHOICES),
+            }
+        )
+
+    @extend_schema(
         summary="Get vendors by category",
         description="Retrieve vendors grouped by category with optional filtering.",
         parameters=[

--- a/frontend/e2e/critical-grc-flows.smoke.spec.ts
+++ b/frontend/e2e/critical-grc-flows.smoke.spec.ts
@@ -119,6 +119,48 @@ test("users can open a vendor profile from the vendor directory", async ({ page 
   await expect(page.getByText("Ada Lovelace")).toBeVisible();
 });
 
+test("vendor directory makes an unavailable service explicit instead of showing fabricated vendors", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+  await page.route("**/api/vendors/vendors/**", async (route) => {
+    if (new URL(route.request().url()).pathname !== "/api/vendors/vendors/") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "Vendor service unavailable." }),
+    });
+  });
+  await signIn(page);
+
+  await page.goto("/vendors?tenant=demo");
+
+  await expect(page.getByRole("heading", { name: "Vendors could not be loaded" })).toBeVisible();
+  await expect(page.getByText("Vendor service unavailable.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+  await expect(page.getByText("Microsoft Corporation")).toHaveCount(0);
+});
+
+test("vendor detail makes an unavailable service explicit instead of redirecting away", async ({ page }) => {
+  await mockAuthenticatedGrcApi(page);
+  await page.route("**/api/vendors/vendors/1/", async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "Vendor service unavailable." }),
+    });
+  });
+  await signIn(page);
+
+  await page.goto("/vendors/1?tenant=demo");
+
+  await expect(page.getByRole("heading", { name: "Vendor could not be loaded" })).toBeVisible();
+  await expect(page.getByText("Vendor service unavailable.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+  await expect(page).toHaveURL(/\/vendors\/1/);
+});
+
 test("vendor contracts load from tenant vendor records and open the vendor profile", async ({ page }) => {
   await mockAuthenticatedGrcApi(page);
   await signIn(page);

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -111,12 +111,25 @@ const vendor = {
   },
 };
 
-const vendorAnalytics = {
-  totalVendors: 1,
-  contractsExpiring: 0,
-  highRiskVendors: 1,
-  avgPerformance: 86,
-  performanceTrend: 4,
+const vendorSummary = {
+  total_vendors: 1,
+  active_vendors: 1,
+  inactive_vendors: 0,
+  under_review_vendors: 0,
+  critical_risk_vendors: 0,
+  high_risk_vendors: 1,
+  medium_risk_vendors: 0,
+  low_risk_vendors: 0,
+  contracts_expiring_soon: 1,
+  expired_contracts: 0,
+  auto_renewal_contracts: 0,
+  vendors_by_category: { "Cloud Services": 1 },
+  total_annual_spend: "120000.00",
+  average_performance_score: "86.00",
+  vendors_with_dpa: 1,
+  vendors_with_security_assessment: 1,
+  total_services: 0,
+  active_services: 0,
 };
 
 const executiveDashboard = {
@@ -313,8 +326,8 @@ export async function mockAuthenticatedGrcApi(page: Page) {
       return;
     }
 
-    if (path === "/api/vendors/analytics/dashboard/" && request.method() === "GET") {
-      await fulfilJson(route, vendorAnalytics);
+    if (path === "/api/vendors/vendors/summary/" && request.method() === "GET") {
+      await fulfilJson(route, vendorSummary);
       return;
     }
 
@@ -328,7 +341,7 @@ export async function mockAuthenticatedGrcApi(page: Page) {
       return;
     }
 
-    if (path === "/api/vendors/choices/" && request.method() === "GET") {
+    if (path === "/api/vendors/vendors/choices/" && request.method() === "GET") {
       await fulfilJson(route, {
         status_choices: [{ value: "active", label: "Active" }],
         vendor_type_choices: [{ value: "service_provider", label: "Service Provider" }],

--- a/frontend/e2e/navigation-integrity.smoke.spec.ts
+++ b/frontend/e2e/navigation-integrity.smoke.spec.ts
@@ -50,12 +50,17 @@ test("global search uses tenant data and opens the selected record", async ({ pa
   const search = page.getByRole("combobox", { name: "Global search" });
   await search.fill("supplier");
 
-  await expect(page.getByText("Supplier access review overdue")).toBeVisible();
+  const searchResult = page
+    .locator(".ant-select-dropdown .ant-select-item-option")
+    .filter({ hasText: "Supplier access review overdue" });
+  await expect(searchResult).toBeVisible();
   await expect.poll(() => searchRequestSent).toBe(true);
-  await page.locator(".ant-select-dropdown").getByText("Supplier access review overdue", { exact: true }).click();
+  await searchResult.click();
 
   await expect(page).toHaveURL(/\/risk\/1/);
-  await expect(page.getByText("Supplier access review overdue")).toBeVisible();
+  await expect(
+    page.getByRole("cell", { name: "Supplier access review overdue" }).getByRole("strong"),
+  ).toBeVisible();
 });
 
 test("global search makes an unavailable service explicit", async ({ page }) => {

--- a/frontend/src/app/vendors/[id]/page.tsx
+++ b/frontend/src/app/vendors/[id]/page.tsx
@@ -5,6 +5,7 @@ import { Card, Typography, Space, Button, Row, Col, Descriptions, Tag, Progress,
 import { TeamOutlined, EditOutlined, DeleteOutlined, ArrowLeftOutlined, GlobalOutlined } from '@ant-design/icons'
 import { useRouter, useParams } from 'next/navigation'
 import { Breadcrumb, EmptyState, PageHeader, StatusTag, PriorityTag, Loading } from '@/components/ui'
+import { getErrorMessage } from '@/lib/api'
 import { vendorService, type Vendor } from '@/lib/services/vendorService'
 
 const { Title, Text, Paragraph } = Typography
@@ -12,6 +13,7 @@ const { Title, Text, Paragraph } = Typography
 export default function VendorDetailPage() {
   const [loading, setLoading] = useState(true)
   const [vendor, setVendor] = useState<Vendor | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [isEditModalVisible, setIsEditModalVisible] = useState(false)
   const [editForm] = Form.useForm()
   const router = useRouter()
@@ -21,18 +23,17 @@ export default function VendorDetailPage() {
   const fetchVendor = useCallback(async () => {
     try {
       setLoading(true)
+      setLoadError(null)
       const data = await vendorService.getVendor(params.id as string)
       setVendor(data)
       editForm.setFieldsValue(data) // Pre-populate edit form
     } catch (error) {
-      message.error('Failed to load vendor details')
-      console.error('Error fetching vendor:', error)
-      // Redirect back to vendor list if vendor not found
-      setTimeout(() => router.push('/vendors'), 2000)
+      setVendor(null)
+      setLoadError(getErrorMessage(error))
     } finally {
       setLoading(false)
     }
-  }, [editForm, params.id, router])
+  }, [editForm, params.id])
 
   useEffect(() => {
     fetchVendor()
@@ -51,8 +52,7 @@ export default function VendorDetailPage() {
       message.success('Vendor updated successfully')
       setIsEditModalVisible(false)
     } catch (error) {
-      message.error('Failed to update vendor')
-      console.error('Error updating vendor:', error)
+      message.error(getErrorMessage(error))
     }
   }
 
@@ -70,8 +70,7 @@ export default function VendorDetailPage() {
           message.success('Vendor deleted successfully')
           router.push('/vendors')
         } catch (error) {
-          message.error('Failed to delete vendor')
-          console.error('Error deleting vendor:', error)
+          message.error(getErrorMessage(error))
         }
       }
     })
@@ -82,6 +81,9 @@ export default function VendorDetailPage() {
   }
 
   if (!vendor) {
+    if (loadError) {
+      return <EmptyState type="error" title="Vendor could not be loaded" description={loadError} action={{ text: "Try again", onClick: () => void fetchVendor() }} />
+    }
     return <EmptyState type="vendors" title="Vendor not found" description="The selected vendor does not exist or has been deleted." action={{ text: "Back to vendor management", onClick: () => router.push('/vendors') }} />
   }
 

--- a/frontend/src/app/vendors/page.tsx
+++ b/frontend/src/app/vendors/page.tsx
@@ -1,22 +1,15 @@
 'use client'
 
 import React, { useCallback, useState, useEffect } from 'react'
-import { Card, Typography, Space, Button, Row, Col, Table, Tag, Progress, Avatar, message, Modal, Form, Input, Select } from 'antd'
+import { Alert, Card, Typography, Space, Button, Row, Col, Table, Tag, Progress, Avatar, message, Modal, Form, Input, Select } from 'antd'
 import { TeamOutlined, PlusOutlined, WarningOutlined, CheckCircleOutlined, ClockCircleOutlined } from '@ant-design/icons'
 import { useRouter } from 'next/navigation'
-import { Breadcrumb, VendorKPICard, KPICard, StatusTag, PriorityTag, Loading, ExportButton, FilterPanel, PageHeader } from '@/components/ui'
+import { Breadcrumb, EmptyState, VendorKPICard, KPICard, StatusTag, PriorityTag, Loading, ExportButton, FilterPanel, PageHeader } from '@/components/ui'
 import type { FilterValues } from '@/components/ui/FilterPanel'
-import { vendorService, type Vendor, type VendorCategory, type VendorFilters } from '@/lib/services/vendorService'
+import { getErrorMessage } from '@/lib/api'
+import { vendorService, type Vendor, type VendorAnalytics, type VendorCategory, type VendorFilters } from '@/lib/services/vendorService'
 
 const { Text } = Typography
-
-interface VendorAnalytics {
-  totalVendors: number
-  contractsExpiring: number
-  highRiskVendors: number
-  avgPerformance: number
-  performanceTrend: number
-}
 
 interface ChoiceOption {
   value: string
@@ -33,13 +26,15 @@ type PaginationConfig = { current?: number; pageSize?: number }
 
 export default function VendorsPage() {
   const [loading, setLoading] = useState(true)
+  const [directoryError, setDirectoryError] = useState<string | null>(null)
+  const [analyticsError, setAnalyticsError] = useState<string | null>(null)
+  const [filterError, setFilterError] = useState<string | null>(null)
   const [vendorData, setVendorData] = useState<Vendor[]>([])
   const [analytics, setAnalytics] = useState<VendorAnalytics>({
     totalVendors: 0,
     contractsExpiring: 0,
     highRiskVendors: 0,
     avgPerformance: 0,
-    performanceTrend: 0
   })
   const [pagination, setPagination] = useState({ current: 1, pageSize: 10, total: 0 })
   const [filters, setFilters] = useState<FilterValues>({})
@@ -60,6 +55,7 @@ export default function VendorsPage() {
   const fetchVendors = useCallback(async (currentFilters: VendorFilters = {}, page = 1, pageSize = 10) => {
     try {
       setLoading(true)
+      setDirectoryError(null)
       const response = await vendorService.getVendors({
         ...currentFilters,
         page,
@@ -73,8 +69,9 @@ export default function VendorsPage() {
         total: response.count
       })
     } catch (error) {
-      message.error('Failed to load vendor data')
-      console.error('Error fetching vendors:', error)
+      setVendorData([])
+      setPagination({ current: page, pageSize, total: 0 })
+      setDirectoryError(getErrorMessage(error))
     } finally {
       setLoading(false)
     }
@@ -83,16 +80,18 @@ export default function VendorsPage() {
   // Fetch analytics
   const fetchAnalytics = useCallback(async () => {
     try {
+      setAnalyticsError(null)
       const data = await vendorService.getVendorAnalytics()
       setAnalytics(data)
     } catch (error) {
-      console.error('Error fetching analytics:', error)
+      setAnalyticsError(getErrorMessage(error))
     }
   }, [])
 
   // Fetch dynamic filter data
   const fetchDynamicData = useCallback(async () => {
     try {
+      setFilterError(null)
       const [categories, choices] = await Promise.all([
         vendorService.getVendorCategories(),
         vendorService.getVendorChoices()
@@ -137,8 +136,9 @@ export default function VendorsPage() {
 
       setDynamicFilters(filters)
     } catch (error) {
-      console.error('Error fetching dynamic filter data:', error)
-      // Set fallback filters if API fails
+      setVendorCategories([])
+      setVendorChoices({})
+      setFilterError(getErrorMessage(error))
       setDynamicFilters([
         {
           key: 'search',
@@ -191,8 +191,7 @@ export default function VendorsPage() {
       addVendorForm.resetFields()
       fetchVendors() // Refresh the list
     } catch (error) {
-      message.error('Failed to create vendor')
-      console.error('Error creating vendor:', error)
+      message.error(getErrorMessage(error))
     }
   }
 
@@ -355,13 +354,33 @@ export default function VendorsPage() {
             suffix="%"
             icon={<CheckCircleOutlined />}
             color="#0EB57D"
-            trend={{ value: Math.abs(analytics.performanceTrend || 0), isPositive: (analytics.performanceTrend || 0) > 0, period: "vs last quarter" }}
             description="Vendor performance score"
           />
         </Col>
       </Row>
 
+      {analyticsError ? (
+        <Alert
+          type="warning"
+          showIcon
+          message="Vendor metrics could not be loaded"
+          description={analyticsError}
+          action={<Button size="small" onClick={() => void fetchAnalytics()}>Retry</Button>}
+          style={{ marginBottom: 24 }}
+        />
+      ) : null}
+
       {/* Filters */}
+      {filterError ? (
+        <Alert
+          type="warning"
+          showIcon
+          message="Some vendor filters are unavailable"
+          description={filterError}
+          action={<Button size="small" onClick={() => void fetchDynamicData()}>Retry</Button>}
+          style={{ marginBottom: 24 }}
+        />
+      ) : null}
       {dynamicFilters.length > 0 && (
         <FilterPanel
           filters={dynamicFilters}
@@ -396,6 +415,13 @@ export default function VendorsPage() {
       >
         {loading ? (
           <Loading message="Loading vendor data..." />
+        ) : directoryError ? (
+          <EmptyState
+            type="error"
+            title="Vendors could not be loaded"
+            description={directoryError}
+            action={{ text: 'Try again', onClick: () => void fetchVendors(filters as VendorFilters, pagination.current, pagination.pageSize) }}
+          />
         ) : (
           <Table
             columns={columns}

--- a/frontend/src/lib/api/generated/schema.d.ts
+++ b/frontend/src/lib/api/generated/schema.d.ts
@@ -3880,6 +3880,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/vendors/vendors/choices/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get vendor field choices
+         * @description Retrieve the current vendor status, type, and risk-level choices.
+         */
+        get: operations["vendors_vendors_choices_retrieve"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/vendors/vendors/contract_renewals/": {
         parameters: {
             query?: never;
@@ -20151,6 +20171,27 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["VendorDetail"];
+                };
+            };
+        };
+    };
+    vendors_vendors_choices_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
         };

--- a/frontend/src/lib/services/vendorService.ts
+++ b/frontend/src/lib/services/vendorService.ts
@@ -88,11 +88,30 @@ export interface PaginatedResponse<T> {
   previous: string | null
 }
 
+export interface VendorAnalytics {
+  totalVendors: number
+  contractsExpiring: number
+  highRiskVendors: number
+  avgPerformance: number
+}
+
+interface VendorSummaryResponse {
+  total_vendors: number
+  contracts_expiring_soon: number
+  high_risk_vendors: number
+  average_performance_score: number | string | null
+}
+
+export interface VendorChoices {
+  status_choices: Array<{ value: string; label: string }>
+  vendor_type_choices: Array<{ value: string; label: string }>
+  risk_level_choices: Array<{ value: string; label: string }>
+}
+
 export const vendorService = {
   // Get all vendors with optional filtering
   async getVendors(filters: VendorFilters = {}): Promise<PaginatedResponse<Vendor>> {
-    try {
-      const params = new URLSearchParams()
+    const params = new URLSearchParams()
 
       if (filters.riskLevel) {
         params.append('risk_level', filters.riskLevel)
@@ -119,256 +138,57 @@ export const vendorService = {
         params.append('page_size', filters.pageSize.toString())
       }
 
-      const response = await api.get(`/vendors/vendors/?${params.toString()}`)
-      return response.data
-    } catch (error) {
-      console.error('Error fetching vendors:', error)
-
-      // Return mock data as fallback with Django model structure
-      return {
-        results: [
-          {
-            id: 1,
-            vendor_id: 'VEN-2024-0001',
-            name: 'Microsoft Corporation',
-            legal_name: 'Microsoft Corporation',
-            category: {
-              id: 1,
-              name: 'Cloud Services',
-              description: 'Cloud computing and software services',
-              color_code: '#0078d4',
-              risk_weight: 'low',
-              compliance_requirements: {}
-            },
-            business_description: 'Technology corporation providing cloud services and software',
-            website: 'https://www.microsoft.com',
-            tax_id: '91-1144442',
-            duns_number: '796740573',
-            address_line1: 'One Microsoft Way',
-            address_line2: '',
-            city: 'Redmond',
-            state_province: 'WA',
-            postal_code: '98052',
-            country: 'USA',
-            status: 'active',
-            vendor_type: 'service_provider',
-            risk_level: 'low',
-            risk_score: 15.5,
-            annual_spend: 120000,
-            credit_rating: 'AAA',
-            payment_terms: 'Net 30',
-            operating_regions: ['US', 'EU', 'APAC'],
-            primary_region: 'US',
-            custom_fields: {},
-            certifications: ['ISO 27001', 'SOC 2 Type II'],
-            compliance_status: { gdpr: 'compliant', sox: 'compliant' },
-            data_processing_agreement: true,
-            security_assessment_completed: true,
-            security_assessment_date: '2024-03-15',
-            assigned_to: {
-              id: 1,
-              username: 'procurement.manager',
-              first_name: 'John',
-              last_name: 'Smith',
-              email: 'john.smith@company.com'
-            },
-            relationship_start_date: '2023-06-30',
-            created_at: '2023-06-30T10:00:00Z',
-            updated_at: '2024-08-20T15:30:00Z',
-            created_by: {
-              id: 1,
-              username: 'admin',
-              first_name: 'Admin',
-              last_name: 'User'
-            }
-          },
-          {
-            id: 2,
-            vendor_id: 'VEN-2024-0002',
-            name: 'Amazon Web Services',
-            legal_name: 'Amazon Web Services, Inc.',
-            category: {
-              id: 2,
-              name: 'Infrastructure',
-              description: 'Cloud infrastructure and computing services',
-              color_code: '#ff9900',
-              risk_weight: 'low',
-              compliance_requirements: {}
-            },
-            business_description: 'Cloud computing platform and web services',
-            website: 'https://aws.amazon.com',
-            tax_id: '91-1646860',
-            duns_number: '962274814',
-            address_line1: '410 Terry Ave N',
-            address_line2: '',
-            city: 'Seattle',
-            state_province: 'WA',
-            postal_code: '98109',
-            country: 'USA',
-            status: 'active',
-            vendor_type: 'service_provider',
-            risk_level: 'low',
-            risk_score: 18.2,
-            annual_spend: 85000,
-            credit_rating: 'AAA',
-            payment_terms: 'Net 45',
-            operating_regions: ['US', 'EU', 'APAC'],
-            primary_region: 'US',
-            custom_fields: {},
-            certifications: ['ISO 27001', 'SOC 1 Type II', 'SOC 2 Type II'],
-            compliance_status: { gdpr: 'compliant', sox: 'compliant' },
-            data_processing_agreement: true,
-            security_assessment_completed: true,
-            security_assessment_date: '2024-02-20',
-            assigned_to: {
-              id: 2,
-              username: 'it.manager',
-              first_name: 'Sarah',
-              last_name: 'Johnson',
-              email: 'sarah.johnson@company.com'
-            },
-            relationship_start_date: '2023-01-15',
-            created_at: '2023-01-15T09:00:00Z',
-            updated_at: '2024-08-18T14:20:00Z',
-            created_by: {
-              id: 2,
-              username: 'it.admin',
-              first_name: 'IT',
-              last_name: 'Admin'
-            }
-          }
-        ],
-        count: 2,
-        next: null,
-        previous: null
-      }
-    }
+    const response = await api.get(`/vendors/vendors/?${params.toString()}`)
+    return response.data
   },
 
   // Get single vendor by ID
   async getVendor(id: string | number): Promise<Vendor> {
-    try {
-      const response = await api.get(`/vendors/vendors/${id}/`)
-      return response.data
-    } catch (error) {
-      console.error('Error fetching vendor:', error)
-      throw error
-    }
+    const response = await api.get(`/vendors/vendors/${id}/`)
+    return response.data
   },
 
   // Create new vendor
   async createVendor(vendorData: Partial<Vendor>): Promise<Vendor> {
-    try {
-      const response = await api.post('/vendors/vendors/', vendorData)
-      return response.data
-    } catch (error) {
-      console.error('Error creating vendor:', error)
-      throw error
-    }
+    const response = await api.post('/vendors/vendors/', vendorData)
+    return response.data
   },
 
   // Update vendor
   async updateVendor(id: string | number, vendorData: Partial<Vendor>): Promise<Vendor> {
-    try {
-      const response = await api.patch(`/vendors/vendors/${id}/`, vendorData)
-      return response.data
-    } catch (error) {
-      console.error('Error updating vendor:', error)
-      throw error
-    }
+    const response = await api.patch(`/vendors/vendors/${id}/`, vendorData)
+    return response.data
   },
 
   // Delete vendor
   async deleteVendor(id: string | number): Promise<void> {
-    try {
-      await api.delete(`/vendors/vendors/${id}/`)
-    } catch (error) {
-      console.error('Error deleting vendor:', error)
-      throw error
+    await api.delete(`/vendors/vendors/${id}/`)
+  },
+
+  async getVendorAnalytics(): Promise<VendorAnalytics> {
+    const response = await api.get<VendorSummaryResponse>('/vendors/vendors/summary/')
+    return {
+      totalVendors: response.data.total_vendors,
+      contractsExpiring: response.data.contracts_expiring_soon,
+      highRiskVendors: response.data.high_risk_vendors,
+      avgPerformance: Number(response.data.average_performance_score ?? 0),
     }
   },
 
-  // Get vendor analytics
-  async getVendorAnalytics() {
-    try {
-      const response = await api.get('/vendors/analytics/dashboard/')
-      return response.data
-    } catch (error) {
-      console.error('Error fetching vendor analytics:', error)
-
-      // Return mock analytics as fallback
-      return {
-        totalVendors: 89,
-        contractsExpiring: 8,
-        highRiskVendors: 6,
-        avgPerformance: 88.5,
-        performanceTrend: 3.2
-      }
-    }
-  },
-
-  // Get vendor categories
   async getVendorCategories(): Promise<VendorCategory[]> {
-    try {
-      const response = await api.get('/vendors/categories/')
-      return response.data.results || response.data
-    } catch (error) {
-      console.error('Error fetching vendor categories:', error)
-      return [
-        { id: 1, name: 'Cloud Services', description: 'Cloud computing and software services', color_code: '#0078d4', risk_weight: 'low', compliance_requirements: {} },
-        { id: 2, name: 'Infrastructure', description: 'Cloud infrastructure and computing services', color_code: '#ff9900', risk_weight: 'low', compliance_requirements: {} },
-        { id: 3, name: 'Software', description: 'Software vendors and applications', color_code: '#00bcf2', risk_weight: 'medium', compliance_requirements: {} }
-      ]
-    }
+    const response = await api.get('/vendors/categories/')
+    return response.data.results || response.data
   },
 
   // Get vendor contacts
   async getVendorContacts(vendorId: number): Promise<VendorContact[]> {
-    try {
-      const response = await api.get(`/vendors/contacts/?vendor=${vendorId}`)
-      return response.data.results || response.data
-    } catch (error) {
-      console.error('Error fetching vendor contacts:', error)
-      return []
-    }
+    const response = await api.get(`/vendors/contacts/?vendor=${vendorId}`)
+    return response.data.results || response.data
   },
 
-  // Get vendor choices (status, types, etc.) from Django
-  async getVendorChoices(): Promise<{
-    status_choices: Array<{value: string, label: string}>,
-    vendor_type_choices: Array<{value: string, label: string}>,
-    risk_level_choices: Array<{value: string, label: string}>
-  }> {
-    try {
-      const response = await api.get('/vendors/choices/')
-      return response.data
-    } catch (error) {
-      console.error('Error fetching vendor choices:', error)
-      return {
-        status_choices: [
-          { value: 'active', label: 'Active' },
-          { value: 'inactive', label: 'Inactive' },
-          { value: 'under_review', label: 'Under Review' },
-          { value: 'approved', label: 'Approved' },
-          { value: 'suspended', label: 'Suspended' },
-          { value: 'terminated', label: 'Terminated' }
-        ],
-        vendor_type_choices: [
-          { value: 'supplier', label: 'Supplier' },
-          { value: 'service_provider', label: 'Service Provider' },
-          { value: 'consultant', label: 'Consultant' },
-          { value: 'contractor', label: 'Contractor' },
-          { value: 'partner', label: 'Strategic Partner' },
-          { value: 'subcontractor', label: 'Subcontractor' }
-        ],
-        risk_level_choices: [
-          { value: 'low', label: 'Low' },
-          { value: 'medium', label: 'Medium' },
-          { value: 'high', label: 'High' },
-          { value: 'critical', label: 'Critical' }
-        ]
-      }
-    }
+  async getVendorChoices(): Promise<VendorChoices> {
+    const response = await api.get<VendorChoices>('/vendors/vendors/choices/')
+    return response.data
   }
 }
 


### PR DESCRIPTION
## Summary
- remove fabricated vendors, analytics, categories, choices, and contact fallbacks from the shared vendor client
- use the existing tenant-scoped vendor summary API for directory metrics
- add an authoritative, model-backed vendor choices endpoint for filters and forms
- show explicit retryable directory and detail errors instead of console logging, silent data, or redirecting away
- stabilise the global-search browser assertion by scoping it to the autocomplete option

## Verification
- `pytest app/vendors/test_vendor_simple.py app/vendors/test_api_routes.py -q --reuse-db` (14 passed)
- `npm run type-check`
- `npm run lint`
- `npm run test:unit` (13 passed)
- `npm run test:e2e` (17 passed)
- `npm run verify:api-types`
- `pre-commit run --all-files`
- `pre-commit run --hook-stage pre-push --all-files`

Closes #405.