### PR TITLE
fix: make pre-push checks reproducible

### DIFF
--- a/.github/scripts/run-frontend-checks.sh
+++ b/.github/scripts/run-frontend-checks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FRONTEND_DIR="$REPOSITORY_ROOT/frontend"
+
+if [[ ! -x "$FRONTEND_DIR/node_modules/.bin/eslint" ]]; then
+  echo "Frontend dependencies are not installed. Run: (cd frontend && npm ci)" >&2
+  exit 1
+fi
+
+cd "$FRONTEND_DIR"
+npm run lint
+npm run type-check
+npm run test:unit

--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ cython_debug/
 
 # Node.js and Next.js
 frontend/node_modules/
+.venv312/
 openapi-codegen/node_modules/
 frontend/.next/
 frontend/out/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,14 @@ repos:
         always_run: true
         stages: [pre-push]
 
+      - id: frontend-checks
+        name: frontend lint, type-check and unit tests
+        language: script
+        entry: .github/scripts/run-frontend-checks.sh
+        pass_filenames: false
+        files: ^frontend/
+        stages: [pre-push]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+PYTHON ?= python3.12
+VENV ?= .venv312
+
+.PHONY: up down logs migrate createsuper shell test bootstrap setup-hooks
+
 up:
 	docker compose up -d --build
 down:
@@ -12,5 +17,12 @@ shell:
 	docker compose exec web python manage.py shell_plus || docker compose exec web python manage.py shell
 test:
 	docker compose exec web pytest -q
+bootstrap:
+	$(PYTHON) -m venv $(VENV)
+	$(VENV)/bin/python -m pip install --upgrade pip
+	$(VENV)/bin/python -m pip install -r requirements-dev.txt
+	(cd frontend && npm ci --legacy-peer-deps)
+	$(MAKE) setup-hooks
+
 setup-hooks:
-	python -m pre_commit install --install-hooks
+	$(VENV)/bin/pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push

--- a/README.md
+++ b/README.md
@@ -3,13 +3,20 @@ A Multi-tenant Information Security GRC SaaS Application
 
 ## Developer setup
 
-Install the pinned development tooling and configure the repository hooks:
+Create the repository's Python 3.12 environment, install frontend dependencies,
+and configure the repository hooks:
 
 ```bash
-python -m pip install -r requirements-dev.txt
-make setup-hooks
+make bootstrap
 ```
 
-The hooks run Ruff formatting and linting, Bandit, and the repository's other
-pre-commit checks before commits. CI remains the authoritative check for every
-pull request.
+`make bootstrap` uses `.venv312`, installs `requirements-dev.txt` and
+`frontend/package-lock.json`, then installs both commit and push hooks. It uses
+npm's legacy peer resolver temporarily while the ESLint and Next.js peer-range
+conflict is addressed in #409. The pre-push hook validates the branch name and
+runs frontend linting, type checking and unit tests for frontend changes;
+backend type checking uses the same repository environment. CI remains the
+authoritative check for every pull request.
+
+To recreate the environment after changing dependencies, remove `.venv312` and
+`frontend/node_modules`, then run `make bootstrap` again.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@axe-core/playwright": "^4.12.1",
         "@eslint/compat": "^2.1.0",
         "@playwright/test": "^1.62.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8617,9 +8617,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "@axe-core/playwright": "^4.12.1",
     "@eslint/compat": "^2.1.0",
     "@playwright/test": "^1.62.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
     "brace-expansion": "5.0.9",
     "fast-uri": "3.1.5",
     "js-yaml": "4.3.1",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
     "sharp": "0.35.3"
   }


### PR DESCRIPTION
Closes #396.

- Adds frontend lint, type-check and unit-test checks to the pre-push hook, scoped to frontend changes and executed from the repository root safely.
- Adds make bootstrap, which creates .venv312, installs the backend and frontend development dependencies, and installs both hook stages through that environment.
- Declares the test stack's required @testing-library/dom dependency so a clean install can run unit tests.
- Ignores the repository virtual environment and documents the bootstrap path.

Validation: make bootstrap with Python 3.12; full pre-push hook; frontend lint, type-check and 13 unit tests; mypy, Ruff and Bandit.